### PR TITLE
Publish generated third-party notices

### DIFF
--- a/scripts/check_metadata_compliance.py
+++ b/scripts/check_metadata_compliance.py
@@ -16,10 +16,19 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 import jsonschema
-
 from utils import classify_license, is_valid_https_url, normalize_license, normalize_repo
 
 PLACEHOLDER_AUTHOR_VALUES = {"", "n/a", "na", "none", "null", "tbd", "unknown"}
+
+LICENSE_NOTICE_TEXTS = {
+    "MIT": [
+        'Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:',
+        "",
+        "The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.",
+        "",
+        'THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.',
+    ],
+}
 
 
 def load_schema(schema_path: Path) -> dict:
@@ -132,6 +141,10 @@ def validate_single_metadata(
     if len(permission_note) < 10:
         errors.append("permission_note must be descriptive (>= 10 characters)")
 
+    copyright_notice = str(raw.get("copyright", "")).strip()
+    if len(copyright_notice) < 5:
+        errors.append("copyright must be descriptive")
+
     declared_distribution = str(raw.get("distribution", "")).strip()
     normalized = normalize_license(raw.get("license", ""))
     detected_class = classify_license(normalized)
@@ -142,9 +155,7 @@ def validate_single_metadata(
         )
 
     if detected_class == "restricted" and declared_distribution != "restricted":
-        errors.append(
-            f'distribution must be "restricted" for license "{normalized}"'
-        )
+        errors.append(f'distribution must be "restricted" for license "{normalized}"')
 
     if detected_class == "compatible" and declared_distribution != "compatible":
         warnings.append(
@@ -156,9 +167,13 @@ def validate_single_metadata(
 
     entry = {
         "name": raw.get("name", ""),
+        "local_path": (
+            f"skills/{str(raw.get('category', '')).strip()}/{str(raw.get('dir_name', '')).strip()}"
+        ),
         "repo": repo,
         "author": author,
         "license": normalized,
+        "copyright": copyright_notice,
         "distribution": declared_distribution,
         "source_url": source_url,
         "permission_note": permission_note,
@@ -201,27 +216,46 @@ def write_notices(path: Path, rows: List[Dict], scanned_count: int) -> None:
             [
                 "## Entries",
                 "",
-                "| Skill | Repo | Author | License | Distribution | Source |",
-                "| --- | --- | --- | --- | --- | --- |",
+                "| Skill | Local path | Repo | Author | License | Copyright | Distribution | Source | Permission note |",
+                "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
             ]
         )
         for row in sorted(rows, key=lambda item: (item.get("repo", ""), item.get("name", ""))):
             name = str(row.get("name", "")).replace("|", "\\|")
+            local_path = str(row.get("local_path", "")).replace("|", "\\|")
             repo = str(row.get("repo", "")).replace("|", "\\|")
             author = str(row.get("author", "")).replace("|", "\\|")
             license_name = str(row.get("license", "")).replace("|", "\\|")
+            copyright_notice = str(row.get("copyright", "")).replace("|", "\\|")
             distribution = str(row.get("distribution", "")).replace("|", "\\|")
             source_url = str(row.get("source_url", ""))
+            permission_note = str(row.get("permission_note", "")).replace("|", "\\|")
             lines.append(
-                f"| {name} | {repo} | {author} | {license_name} | {distribution} | {source_url} |"
+                f"| {name} | {local_path} | {repo} | {author} | {license_name} | {copyright_notice} | {distribution} | {source_url} | {permission_note} |"
             )
         lines.append("")
+
+        license_names = sorted(
+            {
+                str(row.get("license", "")).strip()
+                for row in rows
+                if str(row.get("license", "")).strip() in LICENSE_NOTICE_TEXTS
+            }
+        )
+        if license_names:
+            lines.extend(["## License Texts", ""])
+            for license_name in license_names:
+                lines.extend([f"### {license_name}", ""])
+                lines.extend(LICENSE_NOTICE_TEXTS[license_name])
+                lines.append("")
 
     path.write_text("\n".join(lines), encoding="utf-8")
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Validate skill metadata attribution/license compliance")
+    parser = argparse.ArgumentParser(
+        description="Validate skill metadata attribution/license compliance"
+    )
     parser.add_argument("--skills-dir", default="skills", help="Skills directory root")
     parser.add_argument(
         "--metadata-schema",
@@ -244,7 +278,9 @@ def main() -> int:
         action="store_true",
         help="Always exit 0 after generating report artifacts",
     )
-    parser.add_argument("--fail-on-warnings", action="store_true", help="Treat warnings as failures")
+    parser.add_argument(
+        "--fail-on-warnings", action="store_true", help="Treat warnings as failures"
+    )
     args = parser.parse_args()
 
     repo_root = Path.cwd().resolve()

--- a/scripts/sync_main_repo.sh
+++ b/scripts/sync_main_repo.sh
@@ -64,4 +64,11 @@ if [[ "$rebuild" -eq 1 ]]; then
   python "$main_dir/scripts/build_search_index.py" --skills-dir "$main_dir/skills" --output "$main_dir/docs"
 fi
 
+echo "Generating third-party notices..."
+python "$main_dir/scripts/check_metadata_compliance.py" \
+  --skills-dir "$main_dir/skills" \
+  --metadata-schema "$main_dir/schema/metadata.schema.json" \
+  --notices "$main_dir/THIRD_PARTY_NOTICES.md" \
+  --report-only
+
 echo "Done."

--- a/tests/test_metadata_compliance.py
+++ b/tests/test_metadata_compliance.py
@@ -1,0 +1,70 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import check_metadata_compliance  # noqa: E402
+
+
+def test_validate_metadata_preserves_copyright_for_notices(tmp_path):
+    schema = json.loads((ROOT / "schema" / "metadata.schema.json").read_text(encoding="utf-8"))
+    metadata_path = tmp_path / "metadata.json"
+    metadata_path.write_text(
+        json.dumps(
+            {
+                "name": "aksel-spacing",
+                "repo": "navikt/copilot",
+                "category": "design",
+                "dir_name": "aksel-spacing",
+                "author": "Nav",
+                "source_url": "https://github.com/navikt/copilot/blob/main/.github/skills/aksel-spacing/SKILL.md",
+                "license": "MIT",
+                "copyright": "Copyright (c) 2025 Nav",
+                "permission_note": "MIT terms require preserving copyright and permission notices.",
+                "distribution": "compatible",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    errors, warnings, row = check_metadata_compliance.validate_single_metadata(
+        metadata_path, schema
+    )
+
+    assert errors == []
+    assert warnings == []
+    assert row["copyright"] == "Copyright (c) 2025 Nav"
+    assert row["local_path"] == "skills/design/aksel-spacing"
+
+
+def test_write_notices_includes_attribution_and_mit_text(tmp_path):
+    notices_path = tmp_path / "THIRD_PARTY_NOTICES.md"
+
+    check_metadata_compliance.write_notices(
+        notices_path,
+        [
+            {
+                "name": "aksel-spacing",
+                "local_path": "skills/design/aksel-spacing",
+                "repo": "navikt/copilot",
+                "author": "Nav",
+                "license": "MIT",
+                "copyright": "Copyright (c) 2025 Nav",
+                "distribution": "compatible",
+                "source_url": "https://github.com/navikt/copilot/blob/main/.github/skills/aksel-spacing/SKILL.md",
+                "permission_note": "MIT terms require preserving copyright and permission notices.",
+            }
+        ],
+        scanned_count=1,
+    )
+
+    notices = notices_path.read_text(encoding="utf-8")
+
+    assert "Copyright (c) 2025 Nav" in notices
+    assert "skills/design/aksel-spacing" in notices
+    assert "MIT terms require preserving copyright and permission notices." in notices
+    assert "The above copyright notice and this permission notice shall be included" in notices


### PR DESCRIPTION
## Summary
- include copyright, local path, permission notes, and MIT text in generated third-party notices
- regenerate THIRD_PARTY_NOTICES.md during main publish sync
- add regression coverage for Nav/MIT attribution output

## Data dependency
- claude-skill-registry-data main now includes navikt/copilot metadata attribution in commit 022f6dc19c1a75a3082960b20d8fb77a10f3018f

## Verification
- python -m ruff check scripts/check_metadata_compliance.py tests/test_metadata_compliance.py
- python -m pytest tests/test_metadata_compliance.py tests/test_plugin_contract.py
- bash -n scripts/sync_main_repo.sh
- targeted metadata compliance scan for the 12 navikt/copilot entries: 0 errors, 0 warnings

Fixes majiayu000/claude-skill-registry#22