### PR TITLE
Upgrade Pages actions to Node 24 majors

### DIFF
--- a/.github/workflows/build-index.yml
+++ b/.github/workflows/build-index.yml
@@ -52,7 +52,7 @@ jobs:
           fetch-depth: 1
 
       - name: Download latest security report
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const {owner, repo} = context.repo;
@@ -107,10 +107,10 @@ jobs:
           du -sh docs/*.json docs/*.gz 2>/dev/null || true
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: 'docs'
 
@@ -126,4 +126,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- upgrade build-index Pages-related actions to Node 24-compatible majors
- replace actions/github-script@v7 with @v9
- replace actions/configure-pages@v4 with @v6
- replace actions/upload-pages-artifact@v3 with @v5
- replace actions/deploy-pages@v4 with @v5

## Verification
- PyYAML parse of .github/workflows/*.yml