### PR TITLE
Tighten license copyright extraction

### DIFF
--- a/scripts/backfill_legal_metadata.py
+++ b/scripts/backfill_legal_metadata.py
@@ -68,7 +68,7 @@ def skill_branch(metadata: dict[str, Any]) -> str:
 def extract_copyright_notice(license_text: str) -> str:
     for line in license_text.splitlines():
         text = line.strip()
-        if re.search(r"\bcopyright\b", text, flags=re.IGNORECASE):
+        if re.match(r"^(copyright|\(c\)|©)\b", text, flags=re.IGNORECASE):
             return text
     return ""
 

--- a/tests/test_backfill_legal_metadata.py
+++ b/tests/test_backfill_legal_metadata.py
@@ -62,6 +62,18 @@ def test_backfill_metadata_uses_repo_license_cache():
     assert updated["license_class"] == "compatible"
 
 
+def test_extract_copyright_notice_ignores_apache_definition_lines():
+    module = load_module()
+    license_text = """
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      Copyright (c) 2026 Real Owner
+    """
+
+    assert module.extract_copyright_notice(license_text) == "Copyright (c) 2026 Real Owner"
+
+
 def test_main_dry_run_does_not_modify_metadata(tmp_path, monkeypatch):
     module = load_module()
     metadata_path = tmp_path / "skills" / "development" / "demo" / "metadata.json"


### PR DESCRIPTION
## Summary
- avoid extracting generic Apache definition text as copyright metadata
- only use explicit notice-style copyright lines from license text
- add regression coverage for Apache-style wording

## Verification
- python -m ruff check scripts/backfill_legal_metadata.py tests/test_backfill_legal_metadata.py
- python -m pytest tests/test_backfill_legal_metadata.py