### PR TITLE
Make legal metadata backfill resilient

### DIFF
--- a/scripts/backfill_legal_metadata.py
+++ b/scripts/backfill_legal_metadata.py
@@ -89,12 +89,26 @@ def github_request(url: str, token: str, timeout: int) -> dict[str, Any]:
 
 def fetch_repo_license(repo: str, token: str, timeout: int) -> dict[str, str]:
     url = f"https://api.github.com/repos/{repo}/license"
-    try:
-        payload = github_request(url, token=token, timeout=timeout)
-    except urllib.error.HTTPError as exc:
-        if exc.code in {403, 404, 451}:
-            return {"license": "NOASSERTION", "copyright": "", "error": f"http_{exc.code}"}
-        raise
+    for attempt in range(3):
+        try:
+            payload = github_request(url, token=token, timeout=timeout)
+            break
+        except urllib.error.HTTPError as exc:
+            if exc.code in {403, 404, 451}:
+                return {"license": "NOASSERTION", "copyright": "", "error": f"http_{exc.code}"}
+            raise
+        except (TimeoutError, urllib.error.URLError, OSError) as exc:
+            if attempt < 2:
+                time.sleep(1 + attempt)
+                continue
+            reason = getattr(exc, "reason", exc)
+            return {
+                "license": "NOASSERTION",
+                "copyright": "",
+                "error": f"fetch_error:{reason}",
+            }
+    else:  # pragma: no cover - loop always returns or breaks
+        return {"license": "NOASSERTION", "copyright": "", "error": "fetch_failed"}
 
     license_payload = payload.get("license") or {}
     spdx = normalize_license(str(license_payload.get("spdx_id") or "NOASSERTION"))
@@ -230,6 +244,7 @@ def main() -> int:
             continue
         repos_seen.add(repo)
 
+        had_cache = repo in cache
         repo_license = load_or_fetch_license(
             repo,
             cache,
@@ -238,6 +253,8 @@ def main() -> int:
             timeout=args.timeout,
             sleep_seconds=args.sleep,
         )
+        if not had_cache:
+            write_json(cache_path, cache)
         updated = backfill_metadata(metadata, repo_license)
         if updated == metadata:
             stats["unchanged"] += 1

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -3,12 +3,11 @@
 Shared utilities for skill registry scripts.
 """
 
-import re
 import hashlib
 import json
 import logging
+import re
 from pathlib import Path
-from typing import Optional
 from urllib.parse import urlparse
 
 import yaml
@@ -25,6 +24,7 @@ PERMISSIVE_LICENSES = {
     "CC0-1.0",
     "ISC",
     "MIT",
+    "MIT-0",
     "Unlicense",
 }
 
@@ -34,6 +34,7 @@ RESTRICTED_LICENSE_PATTERNS = (
     "GPL",
     "LGPL",
     "MPL",
+    "EUPL",
     "CC-BY-NC",
     "CC-BY-ND",
     "NONCOMMERCIAL",
@@ -159,11 +160,11 @@ def build_legal_metadata(
 
     if not permission_note:
         if distribution == "compatible":
-            permission_note = "Use according to upstream license terms and attribution requirements."
-        else:
             permission_note = (
-                "Restricted or unknown license. Do not treat as MIT; verify upstream permission before reuse."
+                "Use according to upstream license terms and attribution requirements."
             )
+        else:
+            permission_note = "Restricted or unknown license. Do not treat as MIT; verify upstream permission before reuse."
 
     if not copyright_text:
         if source_url:
@@ -207,9 +208,9 @@ def normalize_name(name: str) -> str:
     if not name:
         return "unknown"
     # Convert to lowercase, replace non-alphanumeric with hyphens
-    name = re.sub(r'[^a-z0-9]+', '-', name.lower())
+    name = re.sub(r"[^a-z0-9]+", "-", name.lower())
     # Strip leading/trailing hyphens, collapse consecutive hyphens
-    name = re.sub(r'-+', '-', name).strip('-')
+    name = re.sub(r"-+", "-", name).strip("-")
     # Max 64 chars
     return name[:64] if name else "unknown"
 
@@ -221,8 +222,8 @@ def normalize_category(category: str) -> str:
     """
     if not category:
         return "other"
-    name = re.sub(r'[^a-z0-9]+', '-', category.lower())
-    name = re.sub(r'-+', '-', name).strip('-')
+    name = re.sub(r"[^a-z0-9]+", "-", category.lower())
+    name = re.sub(r"-+", "-", name).strip("-")
     return name[:32] if name else "other"
 
 
@@ -252,7 +253,7 @@ def normalize_repo(repo: str) -> str:
     """Normalize GitHub repo to owner/repo format."""
     repo = (repo or "").strip()
     if repo.startswith("https://github.com/"):
-        repo = repo[len("https://github.com/"):]
+        repo = repo[len("https://github.com/") :]
     return repo.strip("/")
 
 
@@ -359,13 +360,77 @@ def ensure_unique_dir(parent: Path, base_name: str, key: str = "", repo: str = "
 
 # Category keywords used across multiple scripts for auto-detection.
 CATEGORY_KEYWORDS = {
-    "development": ["dev", "code", "programming", "api", "sdk", "framework", "build", "software", "compile", "debug", "refactor"],
-    "testing": ["test", "qa", "quality", "tdd", "jest", "pytest", "unittest", "integration", "e2e", "playwright", "cypress"],
+    "development": [
+        "dev",
+        "code",
+        "programming",
+        "api",
+        "sdk",
+        "framework",
+        "build",
+        "software",
+        "compile",
+        "debug",
+        "refactor",
+    ],
+    "testing": [
+        "test",
+        "qa",
+        "quality",
+        "tdd",
+        "jest",
+        "pytest",
+        "unittest",
+        "integration",
+        "e2e",
+        "playwright",
+        "cypress",
+    ],
     "devops": ["devops", "ci", "cd", "docker", "kubernetes", "deploy", "infra", "infrastructure"],
-    "security": ["security", "auth", "crypto", "vulnerability", "audit", "owasp", "pentest", "fuzzing"],
-    "documents": ["doc", "pdf", "word", "excel", "pptx", "xlsx", "docx", "markdown", "documentation"],
-    "data": ["data", "analytics", "sql", "database", "etl", "pipeline", "ml", "ai", "machine-learning", "visualization"],
-    "design": ["design", "ui", "ux", "css", "frontend", "component", "tailwind", "figma", "animation"],
+    "security": [
+        "security",
+        "auth",
+        "crypto",
+        "vulnerability",
+        "audit",
+        "owasp",
+        "pentest",
+        "fuzzing",
+    ],
+    "documents": [
+        "doc",
+        "pdf",
+        "word",
+        "excel",
+        "pptx",
+        "xlsx",
+        "docx",
+        "markdown",
+        "documentation",
+    ],
+    "data": [
+        "data",
+        "analytics",
+        "sql",
+        "database",
+        "etl",
+        "pipeline",
+        "ml",
+        "ai",
+        "machine-learning",
+        "visualization",
+    ],
+    "design": [
+        "design",
+        "ui",
+        "ux",
+        "css",
+        "frontend",
+        "component",
+        "tailwind",
+        "figma",
+        "animation",
+    ],
     "productivity": ["productivity", "automation", "workflow", "task", "planning", "memory"],
     "product": ["product", "prd", "roadmap", "feature", "backlog", "user-research", "metrics"],
     "marketing": ["marketing", "seo", "content", "social", "campaign", "brand"],
@@ -405,8 +470,8 @@ def extract_description(content: str, max_length: int = 200) -> str:
         if line.startswith("#"):
             continue
         if line and not line.startswith("```") and len(line) > 20:
-            line = re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', line)
-            line = re.sub(r'[*_`]', '', line)
+            line = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", line)
+            line = re.sub(r"[*_`]", "", line)
             return line[:max_length]
     return ""
 

--- a/tests/test_backfill_legal_metadata.py
+++ b/tests/test_backfill_legal_metadata.py
@@ -1,6 +1,7 @@
 import importlib.util
 import json
 import sys
+import urllib.error
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -72,6 +73,43 @@ def test_extract_copyright_notice_ignores_apache_definition_lines():
     """
 
     assert module.extract_copyright_notice(license_text) == "Copyright (c) 2026 Real Owner"
+
+
+def test_fetch_repo_license_degrades_after_url_errors(monkeypatch):
+    module = load_module()
+
+    def fail_request(*args, **kwargs):
+        raise urllib.error.URLError("tls eof")
+
+    monkeypatch.setattr(module, "github_request", fail_request)
+    monkeypatch.setattr(module.time, "sleep", lambda _seconds: None)
+
+    result = module.fetch_repo_license("owner/repo", token="", timeout=1)
+
+    assert result["license"] == "NOASSERTION"
+    assert result["error"] == "fetch_error:tls eof"
+
+
+def test_fetch_repo_license_degrades_after_timeout(monkeypatch):
+    module = load_module()
+
+    def fail_request(*args, **kwargs):
+        raise TimeoutError("read timed out")
+
+    monkeypatch.setattr(module, "github_request", fail_request)
+    monkeypatch.setattr(module.time, "sleep", lambda _seconds: None)
+
+    result = module.fetch_repo_license("owner/repo", token="", timeout=1)
+
+    assert result["license"] == "NOASSERTION"
+    assert result["error"] == "fetch_error:read timed out"
+
+
+def test_license_classification_covers_backfill_spdx_values():
+    module = load_module()
+
+    assert module.build_legal_metadata(license_name="MIT-0")["distribution"] == "compatible"
+    assert module.build_legal_metadata(license_name="EUPL-1.2")["distribution"] == "restricted"
 
 
 def test_main_dry_run_does_not_modify_metadata(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- retry and safely degrade transient GitHub license fetch errors
- write repo license cache entries incrementally during backfill
- classify MIT-0 as compatible and EUPL as restricted
- add regression coverage for timeout/URL failures and SPDX classification

## Verification
- python -m ruff check scripts/utils.py scripts/backfill_legal_metadata.py tests/test_backfill_legal_metadata.py
- python -m pytest tests/test_backfill_legal_metadata.py
- metadata compliance scan over 56,142 changed data metadata files: 0 errors, 0 warnings