### PR TITLE
Require explicit copyright notices in backfill

### DIFF
--- a/scripts/backfill_legal_metadata.py
+++ b/scripts/backfill_legal_metadata.py
@@ -68,7 +68,11 @@ def skill_branch(metadata: dict[str, Any]) -> str:
 def extract_copyright_notice(license_text: str) -> str:
     for line in license_text.splitlines():
         text = line.strip()
-        if re.match(r"^(copyright|\(c\)|©)\b", text, flags=re.IGNORECASE):
+        if re.match(
+            r"^(copyright\s+(?:\(c\)|©|\d{4})|\(c\)\s+\d{4}|©\s*\d{4})(?=\s|$)",
+            text,
+            flags=re.IGNORECASE,
+        ):
             return text
     return ""
 


### PR DESCRIPTION
## Summary
- tighten legal metadata backfill copyright extraction
- avoid storing Apache definition prose as copyright metadata
- keep fallback upstream ownership text when no explicit copyright notice exists

## Verification
- python -m ruff check scripts/backfill_legal_metadata.py tests/test_backfill_legal_metadata.py
- python -m pytest tests/test_backfill_legal_metadata.py