### PR TITLE
Classify WTFPL as permissive

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -26,6 +26,7 @@ PERMISSIVE_LICENSES = {
     "MIT",
     "MIT-0",
     "Unlicense",
+    "WTFPL",
 }
 
 # License families that should not be merged into MIT-compatible distribution by default.

--- a/tests/test_backfill_legal_metadata.py
+++ b/tests/test_backfill_legal_metadata.py
@@ -109,6 +109,7 @@ def test_license_classification_covers_backfill_spdx_values():
     module = load_module()
 
     assert module.build_legal_metadata(license_name="MIT-0")["distribution"] == "compatible"
+    assert module.build_legal_metadata(license_name="WTFPL")["distribution"] == "compatible"
     assert module.build_legal_metadata(license_name="EUPL-1.2")["distribution"] == "restricted"
 
 


### PR DESCRIPTION
## Summary
- classify WTFPL as compatible/permissive in license metadata helpers
- preserve GitHub API-reported WTFPL instead of downgrading it to NOASSERTION
- add regression coverage for WTFPL classification

## Verification
- python -m ruff check scripts/utils.py tests/test_backfill_legal_metadata.py
- python -m pytest tests/test_backfill_legal_metadata.py
- metadata compliance scan over 19,410 changed data metadata files: 0 errors, 0 warnings