### PR TITLE
Classify Zlib and BlueOak as permissive

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -19,6 +19,7 @@ _DIR_CACHE = {}
 PERMISSIVE_LICENSES = {
     "0BSD",
     "Apache-2.0",
+    "BlueOak-1.0.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
     "CC0-1.0",
@@ -27,6 +28,7 @@ PERMISSIVE_LICENSES = {
     "MIT-0",
     "Unlicense",
     "WTFPL",
+    "Zlib",
 }
 
 # License families that should not be merged into MIT-compatible distribution by default.

--- a/tests/test_backfill_legal_metadata.py
+++ b/tests/test_backfill_legal_metadata.py
@@ -108,8 +108,10 @@ def test_fetch_repo_license_degrades_after_timeout(monkeypatch):
 def test_license_classification_covers_backfill_spdx_values():
     module = load_module()
 
+    assert module.build_legal_metadata(license_name="BlueOak-1.0.0")["distribution"] == "compatible"
     assert module.build_legal_metadata(license_name="MIT-0")["distribution"] == "compatible"
     assert module.build_legal_metadata(license_name="WTFPL")["distribution"] == "compatible"
+    assert module.build_legal_metadata(license_name="Zlib")["distribution"] == "compatible"
     assert module.build_legal_metadata(license_name="EUPL-1.2")["distribution"] == "restricted"
 
 


### PR DESCRIPTION
## Summary
- classify Zlib and BlueOak-1.0.0 as compatible/permissive
- preserve GitHub API-reported concrete license IDs during legal metadata backfill
- add regression coverage for both values

## Verification
- python -m ruff check scripts/utils.py tests/test_backfill_legal_metadata.py
- python -m pytest tests/test_backfill_legal_metadata.py
- metadata compliance scan over 11,163 changed data metadata files: 0 errors, 0 warnings