### PR TITLE
Handle incomplete GitHub license reads

### DIFF
--- a/scripts/backfill_legal_metadata.py
+++ b/scripts/backfill_legal_metadata.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import http.client
 import json
 import os
 import re
@@ -101,7 +102,7 @@ def fetch_repo_license(repo: str, token: str, timeout: int) -> dict[str, str]:
             if exc.code in {403, 404, 451}:
                 return {"license": "NOASSERTION", "copyright": "", "error": f"http_{exc.code}"}
             raise
-        except (TimeoutError, urllib.error.URLError, OSError) as exc:
+        except (TimeoutError, http.client.IncompleteRead, urllib.error.URLError, OSError) as exc:
             if attempt < 2:
                 time.sleep(1 + attempt)
                 continue

--- a/tests/test_backfill_legal_metadata.py
+++ b/tests/test_backfill_legal_metadata.py
@@ -1,3 +1,4 @@
+import http.client
 import importlib.util
 import json
 import sys
@@ -103,6 +104,21 @@ def test_fetch_repo_license_degrades_after_timeout(monkeypatch):
 
     assert result["license"] == "NOASSERTION"
     assert result["error"] == "fetch_error:read timed out"
+
+
+def test_fetch_repo_license_degrades_after_incomplete_read(monkeypatch):
+    module = load_module()
+
+    def fail_request(*args, **kwargs):
+        raise http.client.IncompleteRead(b"{}", 10)
+
+    monkeypatch.setattr(module, "github_request", fail_request)
+    monkeypatch.setattr(module.time, "sleep", lambda _seconds: None)
+
+    result = module.fetch_repo_license("owner/repo", token="", timeout=1)
+
+    assert result["license"] == "NOASSERTION"
+    assert result["error"].startswith("fetch_error:IncompleteRead")
 
 
 def test_license_classification_covers_backfill_spdx_values():


### PR DESCRIPTION
## Summary
- treat http.client.IncompleteRead as a transient license fetch failure
- degrade affected repos to NOASSERTION/restricted instead of aborting the batch
- add regression coverage for truncated GitHub API reads

## Verification
- python -m ruff check scripts/backfill_legal_metadata.py tests/test_backfill_legal_metadata.py
- python -m pytest tests/test_backfill_legal_metadata.py