### PR TITLE
[codex] support directory archives and SkillHub Plus indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ sk install anthropics/skills/skills/docx
 # Lightweight search index (gzip-compressed)
 curl https://majiayu000.github.io/claude-skill-registry-core/search-index.json
 
+# Deduplicated catalog index with quality/security/install signals
+curl https://majiayu000.github.io/claude-skill-registry-core/search-index-lite.json
+curl https://majiayu000.github.io/claude-skill-registry-core/quality-index.json
+curl https://majiayu000.github.io/claude-skill-registry-core/security-index.json
+curl https://majiayu000.github.io/claude-skill-registry-core/ranking-index.json
+
 # Lightweight registry summary (counts only)
 curl https://raw.githubusercontent.com/majiayu000/claude-skill-registry-core/main/registry_summary.json
 

--- a/scripts/build_search_index.py
+++ b/scripts/build_search_index.py
@@ -13,7 +13,9 @@ Output files:
 """
 
 import argparse
+import base64
 import gzip
+import hashlib
 import json
 import logging
 from datetime import datetime, timezone
@@ -44,6 +46,10 @@ CATEGORY_CODES = {
 # Known category directories (for scanning)
 KNOWN_CATEGORIES = set(CATEGORY_CODES.keys()) | {"data", "other"}
 
+# First-paint catalog index. Full search still uses search-index.json until
+# server-side search or sharded search details are introduced.
+LITE_INDEX_LIMIT = 5000
+
 
 def utc_now_isoformat() -> str:
     """Return a stable UTC timestamp with trailing Z."""
@@ -67,6 +73,104 @@ def get_category_code(category: str) -> str:
     if not category:
         return "oth"
     return CATEGORY_CODES.get(category.lower(), "oth")
+
+
+def get_stable_id(install: str, branch: str) -> str:
+    """Build a stable URL-safe skill id from install path and branch."""
+    key = f"{install}|{branch or 'main'}".encode("utf-8")
+    digest = hashlib.sha256(key).digest()
+    return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=").lower()
+
+
+def infer_install_status(repo: str, path: str, install: str) -> str:
+    """Classify whether the install path is clearly usable from registry metadata."""
+    if not install:
+        return "broken"
+    if install.startswith("local/"):
+        return "unknown"
+    if repo and path:
+        return "known_good"
+    if repo:
+        return "unknown"
+    return "risky"
+
+
+def infer_security_status(skill: Dict[str, Any]) -> str:
+    """Return per-skill security status when available; otherwise unknown."""
+    status = skill.get("security_status") or skill.get("security")
+    if isinstance(status, str):
+        normalized = status.lower()
+        if normalized in {"passed", "failed", "unknown"}:
+            return normalized
+    return "unknown"
+
+
+def infer_compatible_agents(skill: Dict[str, Any]) -> List[str]:
+    """Infer a conservative compatible-agent hint from metadata and path."""
+    haystack = " ".join(
+        str(part)
+        for part in [
+            skill.get("name", ""),
+            skill.get("description", ""),
+            skill.get("repo", ""),
+            skill.get("path", ""),
+            " ".join(skill.get("tags", []) or []),
+        ]
+        if part
+    ).lower()
+    agents = []
+    if ".claude/" in haystack or "/skills/" in haystack or "claude" in haystack:
+        agents.append("Claude Code")
+    if "codex" in haystack:
+        agents.append("Codex CLI")
+    if "gemini" in haystack:
+        agents.append("Gemini CLI")
+    if "cursor" in haystack:
+        agents.append("Cursor")
+    return agents[:5]
+
+
+def score_skill_quality(skill: Dict[str, Any], install_status: str, security_status: str) -> Dict[str, Any]:
+    """Compute a transparent first-pass quality score from existing metadata."""
+    description = str(skill.get("description", "") or "")
+    repo = str(skill.get("repo", "") or "")
+    path = str(skill.get("path", "") or "")
+    tags = skill.get("tags", []) or []
+    stars = int(skill.get("stars", 0) or 0)
+
+    components = {
+        "description": 20 if len(description) >= 80 else 12 if len(description) >= 30 else 4,
+        "repo": 15 if repo and "/" in repo else 0,
+        "path": 15 if path else 0,
+        "tags": 10 if len(tags) >= 3 else 6 if tags else 0,
+        "install": 20 if install_status == "known_good" else 8 if install_status == "unknown" else 0,
+        "security": 10 if security_status == "passed" else 4 if security_status == "unknown" else 0,
+        "popularity": 10 if stars >= 1000 else 6 if stars >= 100 else 3 if stars > 0 else 0,
+    }
+    score = sum(components.values())
+    if install_status in {"broken", "risky"}:
+        score = min(score, 45)
+    if security_status == "failed":
+        score = min(score, 50)
+
+    if security_status == "failed" or install_status == "broken":
+        grade = "blocked"
+    elif score >= 85:
+        grade = "S"
+    elif score >= 70:
+        grade = "A"
+    elif score >= 55:
+        grade = "B"
+    elif score >= 40:
+        grade = "C"
+    else:
+        grade = "unknown"
+
+    return {
+        "quality_score": score,
+        "quality_grade": grade,
+        "score_inputs": components,
+    }
 
 
 def scan_skills_v2(skills_dir: Path) -> List[Dict]:
@@ -215,6 +319,10 @@ def build_search_index(
 
     # Featured skills
     featured_skills = []
+    lite_skills_by_key: Dict[str, Dict[str, Any]] = {}
+    quality_records_by_id: Dict[str, Dict[str, Any]] = {}
+    security_records_by_id: Dict[str, Dict[str, Any]] = {}
+    ranking_records_by_id: Dict[str, Dict[str, Any]] = {}
 
     for skill in skills:
         name = skill.get('name', '')
@@ -225,6 +333,23 @@ def build_search_index(
         repo = skill.get('repo', '')
         install = skill.get('install', repo)
         branch = skill.get('branch', 'main')
+        path = skill.get('path', '')
+        skill_id = get_stable_id(install, branch)
+        owner = repo.split("/", 1)[0] if "/" in repo else ""
+        install_status = infer_install_status(repo, path, install)
+        security_status = infer_security_status(skill)
+        compatible_agents = infer_compatible_agents(skill)
+        quality = score_skill_quality(skill, install_status, security_status)
+        quality_score = quality["quality_score"]
+        quality_grade = quality["quality_grade"]
+        trust_score = min(
+            100,
+            (30 if repo and "/" in repo else 0)
+            + (25 if path else 0)
+            + (20 if install_status == "known_good" else 8 if install_status == "unknown" else 0)
+            + (15 if security_status != "failed" else 0)
+            + (10 if stars > 0 else 0),
+        )
 
         # Minimal record
         mini_record = {
@@ -243,13 +368,21 @@ def build_search_index(
             "name": name,
             "description": truncate_text(description, 200),
             "repo": repo,
-            "path": skill.get('path', ''),
+            "path": path,
             "branch": branch,
             "category": category,
             "tags": tags[:10] if tags else [],
             "stars": stars,
             "install": install,
-            "source": skill.get('source', '')
+            "source": skill.get('source', ''),
+            "id": skill_id,
+            "owner": owner,
+            "quality_grade": quality_grade,
+            "quality_score": quality_score,
+            "security_status": security_status,
+            "install_status": install_status,
+            "trust_score": trust_score,
+            "compatible_agents": compatible_agents,
         }
 
         # Add to category
@@ -261,10 +394,87 @@ def build_search_index(
         if stars > 0:
             featured_skills.append(full_record)
 
+        lite_record = {
+            "id": skill_id,
+            "name": name,
+            "description": truncate_text(description, 180),
+            "category": category,
+            "tags": tags[:8] if tags else [],
+            "repo": repo,
+            "owner": owner,
+            "path": path,
+            "install": install,
+            "branch": branch,
+            "stars": stars,
+            "source": skill.get("source", ""),
+            "quality_grade": quality_grade,
+            "security_status": security_status,
+            "install_status": install_status,
+            "quality_score": quality_score,
+            "trust_score": trust_score,
+            "compatible_agents": compatible_agents,
+        }
+        dedupe_key = f"{install}|{branch}"
+        existing = lite_skills_by_key.get(dedupe_key)
+        if not existing or (
+            stars,
+            quality_score,
+            len(description),
+        ) > (
+            int(existing.get("stars", 0) or 0),
+            int(existing.get("quality_score", 0) or 0),
+            len(str(existing.get("description", ""))),
+        ):
+            lite_skills_by_key[dedupe_key] = lite_record
+            quality_records_by_id[skill_id] = {
+                "id": skill_id,
+                "install": install,
+                "branch": branch,
+                "quality_grade": quality_grade,
+                "quality_score": quality_score,
+                "score_inputs": quality["score_inputs"],
+            }
+            security_records_by_id[skill_id] = {
+                "id": skill_id,
+                "install": install,
+                "branch": branch,
+                "security_status": security_status,
+                "install_status": install_status,
+            }
+            ranking_records_by_id[skill_id] = {
+                "id": skill_id,
+                "install": install,
+                "branch": branch,
+                "stars": stars,
+                "quality_score": quality_score,
+                "trust_score": trust_score,
+                "recommended_score": round(
+                    quality_score * 0.45
+                    + trust_score * 0.30
+                    + min(100, stars ** 0.5) * 0.25,
+                    2,
+                ),
+            }
+
     # Sort by stars
     search_index["s"].sort(key=lambda x: x.get("r", 0), reverse=True)
     featured_skills.sort(key=lambda x: x.get("stars", 0), reverse=True)
     featured_skills = featured_skills[:100]
+    all_lite_skills = sorted(
+        lite_skills_by_key.values(),
+        key=lambda x: (
+            x.get("quality_score", 0),
+            x.get("trust_score", 0),
+            x.get("stars", 0),
+        ),
+        reverse=True,
+    )
+    lite_skills = all_lite_skills[:LITE_INDEX_LIMIT]
+    ranking_records = sorted(
+        ranking_records_by_id.values(),
+        key=lambda x: x.get("recommended_score", 0),
+        reverse=True,
+    )
 
     # Create output directories
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -283,6 +493,71 @@ def build_search_index(
 
     logger.info(f"  search-index.json: {search_index_path.stat().st_size / 1024 / 1024:.2f} MB")
     logger.info(f"  search-index.json.gz: {search_index_gz_path.stat().st_size / 1024 / 1024:.2f} MB")
+
+    # Write SkillHub Plus lite and scoring indexes.
+    lite_index = {
+        "version": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+        "updated_at": utc_now_isoformat(),
+        "total_count": len(all_lite_skills),
+        "included_count": len(lite_skills),
+        "limit": LITE_INDEX_LIMIT,
+        "raw_count": len(skills),
+        "dedupe_key": "install|branch",
+        "skills": lite_skills,
+    }
+    search_index_lite_path = output_dir / "search-index-lite.json"
+    with open(search_index_lite_path, "w", encoding="utf-8") as f:
+        json.dump(lite_index, f, ensure_ascii=False, separators=(",", ":"))
+
+    search_index_lite_gz_path = output_dir / "search-index-lite.json.gz"
+    with gzip.open(search_index_lite_gz_path, "wt", encoding="utf-8") as f:
+        json.dump(lite_index, f, ensure_ascii=False, separators=(",", ":"))
+
+    quality_index_path = output_dir / "quality-index.json"
+    with open(quality_index_path, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "updated_at": utc_now_isoformat(),
+                "count": len(quality_records_by_id),
+                "records": list(quality_records_by_id.values()),
+            },
+            f,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+
+    security_index_path = output_dir / "security-index.json"
+    with open(security_index_path, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "updated_at": utc_now_isoformat(),
+                "count": len(security_records_by_id),
+                "records": list(security_records_by_id.values()),
+            },
+            f,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+
+    ranking_index_path = output_dir / "ranking-index.json"
+    with open(ranking_index_path, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "updated_at": utc_now_isoformat(),
+                "count": len(ranking_records),
+                "records": ranking_records,
+            },
+            f,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+
+    logger.info(
+        f"  search-index-lite.json: {search_index_lite_path.stat().st_size / 1024 / 1024:.2f} MB"
+    )
+    logger.info(f"  quality-index.json: {quality_index_path.stat().st_size / 1024 / 1024:.2f} MB")
+    logger.info(f"  security-index.json: {security_index_path.stat().st_size / 1024 / 1024:.2f} MB")
+    logger.info(f"  ranking-index.json: {ranking_index_path.stat().st_size / 1024 / 1024:.2f} MB")
 
     # Write category indexes
     category_index = {
@@ -350,6 +625,13 @@ def build_search_index(
         "featured_count": len(featured_skills),
         "index_size_bytes": search_index_path.stat().st_size,
         "index_size_gzip_bytes": search_index_gz_path.stat().st_size,
+        "lite_index_count": len(all_lite_skills),
+        "lite_index_included_count": len(lite_skills),
+        "lite_index_size_bytes": search_index_lite_path.stat().st_size,
+        "lite_index_gzip_size_bytes": search_index_lite_gz_path.stat().st_size,
+        "quality_index_size_bytes": quality_index_path.stat().st_size,
+        "security_index_size_bytes": security_index_path.stat().st_size,
+        "ranking_index_size_bytes": ranking_index_path.stat().st_size,
     }
     # Attach latest security scan summary if available
     security_report_path = output_dir / "security-report.json"
@@ -379,6 +661,7 @@ def build_search_index(
         logger.info(f"  Archive metadata.json count (raw): {archive_metadata_count_raw}")
     if registry_skill_count_dedup is not None:
         logger.info(f"  Registry deduplicated count: {registry_skill_count_dedup}")
+    logger.info(f"  Lite index count: {len(lite_skills)} / {len(all_lite_skills)}")
     logger.info(f"  Categories: {len(categories)}")
 
     return stats

--- a/scripts/security_scanner.py
+++ b/scripts/security_scanner.py
@@ -4,14 +4,13 @@ Security Scanner for SKILL.md files
 Implements automated security checks for skill registry
 """
 
-import os
-import re
 import json
-import yaml
-import hashlib
+import re
 from pathlib import Path
 from typing import Dict, List, Tuple
+
 import jsonschema
+import yaml
 
 # Load schema
 SCHEMA_PATH = Path(__file__).parent.parent / "schema" / "skill.schema.json"
@@ -107,6 +106,41 @@ SENSITIVE_PATHS = [
     '/proc/', '/sys/', '$HOME/.env', '.env',
 ]
 
+BUNDLED_SCAN_DIRS = ('references', 'scripts', 'assets', 'templates', 'examples')
+BUNDLED_SCAN_ROOT_FILES = (
+    'package.json',
+    'package-lock.json',
+    'pnpm-lock.yaml',
+    'yarn.lock',
+    'requirements.txt',
+    'pyproject.toml',
+    'uv.lock',
+    'README.md',
+)
+BUNDLED_SCAN_EXTENSIONS = {
+    '.bash',
+    '.css',
+    '.csv',
+    '.html',
+    '.js',
+    '.json',
+    '.jsx',
+    '.j2',
+    '.md',
+    '.mjs',
+    '.ps1',
+    '.py',
+    '.sh',
+    '.svg',
+    '.toml',
+    '.tpl',
+    '.ts',
+    '.tsx',
+    '.txt',
+    '.yaml',
+    '.yml',
+}
+
 INJECTION_PATTERNS = [
     re.compile(r'ignore\s+(all\s+)?(previous|prior|above)\s+(instructions|prompts)', re.IGNORECASE),
     re.compile(r'disregard\s+(everything|all)', re.IGNORECASE),
@@ -186,7 +220,7 @@ class SecurityScanner:
         # 4. Check for sensitive paths
         self._scan_sensitive_paths(content)
 
-        # 5. Check bundled scripts
+        # 5. Check bundled scripts and reference implementations
         self._scan_bundled_files(skill_path.parent)
 
         # 6. Prompt injection detection
@@ -289,32 +323,43 @@ class SecurityScanner:
                 })
 
     def _scan_bundled_files(self, skill_dir: Path):
-        """Scan bundled scripts and resources"""
-        scripts_dir = skill_dir / 'scripts'
-        if not scripts_dir.exists():
-            return
+        """Scan bundled executable/reference files."""
+        for filename in BUNDLED_SCAN_ROOT_FILES:
+            bundled_file = skill_dir / filename
+            if bundled_file.is_file():
+                self._scan_bundled_text_file(bundled_file)
 
-        for script_file in scripts_dir.rglob('*'):
-            if not script_file.is_file():
+        for dirname in BUNDLED_SCAN_DIRS:
+            bundled_dir = skill_dir / dirname
+            if not bundled_dir.exists():
                 continue
 
-            # Check file size
-            size = script_file.stat().st_size
-            if size > 10_000_000:  # 10MB
-                self.issues.append({
-                    'severity': 'error',
-                    'type': 'file_too_large',
-                    'file': str(script_file),
-                    'message': f'Bundled file too large: {size} bytes'
-                })
+            for script_file in bundled_dir.rglob('*'):
+                if not script_file.is_file():
+                    continue
 
-            # Scan script content
-            if script_file.suffix in ['.py', '.sh', '.js']:
-                try:
-                    content = script_file.read_text(encoding='utf-8')
-                    self._scan_dangerous_patterns(content, script_file)
-                except (OSError, UnicodeDecodeError):
-                    pass
+                if script_file.suffix.lower() in BUNDLED_SCAN_EXTENSIONS:
+                    self._scan_bundled_text_file(script_file)
+
+    def _scan_bundled_text_file(self, bundled_file: Path):
+        """Scan an archived support file when it is text-like executable input."""
+        size = bundled_file.stat().st_size
+        if size > 10_000_000:  # 10MB
+            self.issues.append({
+                'severity': 'error',
+                'type': 'file_too_large',
+                'file': str(bundled_file),
+                'message': f'Bundled file too large: {size} bytes'
+            })
+            return
+
+        try:
+            content = bundled_file.read_text(encoding='utf-8')
+            self._scan_dangerous_patterns(content, bundled_file)
+            self._detect_credentials(content, bundled_file)
+            self._detect_obfuscation_exec(content, bundled_file)
+        except (OSError, UnicodeDecodeError):
+            pass
 
     def _detect_credentials(self, content: str, file_path: Path):
         """Detect hardcoded credentials and secret key formats"""

--- a/scripts/security_scanner.py
+++ b/scripts/security_scanner.py
@@ -338,11 +338,13 @@ class SecurityScanner:
                 if not script_file.is_file():
                     continue
 
+                if not self._check_bundled_file_size(script_file):
+                    continue
                 if script_file.suffix.lower() in BUNDLED_SCAN_EXTENSIONS:
                     self._scan_bundled_text_file(script_file)
 
-    def _scan_bundled_text_file(self, bundled_file: Path):
-        """Scan an archived support file when it is text-like executable input."""
+    def _check_bundled_file_size(self, bundled_file: Path) -> bool:
+        """Return False and record an issue when an archived support file is too large."""
         size = bundled_file.stat().st_size
         if size > 10_000_000:  # 10MB
             self.issues.append({
@@ -351,6 +353,12 @@ class SecurityScanner:
                 'file': str(bundled_file),
                 'message': f'Bundled file too large: {size} bytes'
             })
+            return False
+        return True
+
+    def _scan_bundled_text_file(self, bundled_file: Path):
+        """Scan an archived support file when it is text-like executable input."""
+        if not self._check_bundled_file_size(bundled_file):
             return
 
         try:

--- a/scripts/sync_and_download.py
+++ b/scripts/sync_and_download.py
@@ -98,6 +98,11 @@ BUNDLED_ROOT_FILE_ALLOWLIST = {
     "LICENSE",
     "LICENSE.md",
 }
+BUNDLED_REQUIRED_ROOT_FILE_HINTS = BUNDLED_ROOT_FILE_ALLOWLIST - {
+    "README.md",
+    "LICENSE",
+    "LICENSE.md",
+}
 BUNDLED_FILE_EXTENSIONS = {
     ".bash",
     ".css",
@@ -238,6 +243,15 @@ def is_safe_bundled_file(relative_path: str, size: int) -> bool:
 def is_submodule_contents_entry(entry: dict) -> bool:
     """Return True for GitHub Contents API submodules exposed as file entries."""
     return entry.get("type") == "submodule" or "submodule_git_url" in entry
+
+
+def requires_complete_bundled_archive(skill_content: str) -> bool:
+    """Return True when SKILL.md explicitly depends on bundled support files."""
+    normalized = (skill_content or "").lower().replace("\\", "/")
+    for dirname in BUNDLED_DIR_ALLOWLIST:
+        if f"{dirname}/" in normalized:
+            return True
+    return any(filename.lower() in normalized for filename in BUNDLED_REQUIRED_ROOT_FILE_HINTS)
 
 
 def build_manifest_key(repo: str, path: str, name: str, category: str) -> str:
@@ -932,12 +946,15 @@ async def download_skills(
         branch: str,
         resolved_skill_path: str,
         skill_dir: Path,
+        require_complete_archive: bool,
     ) -> tuple[list[str], list[str], str]:
         archived: list[str] = []
         failed: list[str] = []
         try:
             entries = await collect_bundled_file_entries(session, repo, branch, resolved_skill_path)
         except BundledListingError as exc:
+            if not require_complete_archive:
+                return archived, failed, ""
             return archived, [str(exc)], "bundled_listing_failed"
         if not entries:
             return archived, failed, ""
@@ -971,6 +988,17 @@ async def download_skills(
             target_path.parent.mkdir(parents=True, exist_ok=True)
             target_path.write_bytes(content)
             archived.append(rel_path)
+
+        if failed and not require_complete_archive:
+            skill_root = skill_dir.resolve()
+            for rel_path in archived:
+                target_path = (skill_dir / rel_path).resolve()
+                try:
+                    target_path.relative_to(skill_root)
+                except ValueError:
+                    continue
+                target_path.unlink(missing_ok=True)
+            return [], [], ""
 
         failure_reason = "bundled_download_failed" if failed else ""
         return archived, failed, failure_reason
@@ -1012,6 +1040,7 @@ async def download_skills(
                             if resp.status == 200:
                                 content = await resp.text()
                                 if content and len(content) > 50 and ("---" in content[:50] or "#" in content[:100]):
+                                    require_complete_archive = requires_complete_bundled_archive(content)
                                     # Valid content - save under category with normalized name
                                     category_dir = output_dir / category
                                     category_dir.mkdir(parents=True, exist_ok=True)
@@ -1030,6 +1059,7 @@ async def download_skills(
                                         branch,
                                         relative_path,
                                         skill_dir,
+                                        require_complete_archive,
                                     )
                                     if bundled_failures:
                                         failure_reason = (

--- a/scripts/sync_and_download.py
+++ b/scripts/sync_and_download.py
@@ -235,6 +235,11 @@ def is_safe_bundled_file(relative_path: str, size: int) -> bool:
     return PurePosixPath(filename).suffix.lower() in BUNDLED_FILE_EXTENSIONS
 
 
+def is_submodule_contents_entry(entry: dict) -> bool:
+    """Return True for GitHub Contents API submodules exposed as file entries."""
+    return entry.get("type") == "submodule" or "submodule_git_url" in entry
+
+
 def build_manifest_key(repo: str, path: str, name: str, category: str) -> str:
     """Build a stable key for acquisition manifest lookups."""
     return build_skill_key(repo, path, name=name, category=sanitize_category(category))
@@ -880,6 +885,9 @@ async def download_skills(
 
             for entry in await fetch_contents_listing(session, repo, branch, current_dir):
                 entry_type = entry.get("type")
+                if is_submodule_contents_entry(entry):
+                    continue
+
                 repo_path = str(entry.get("path") or "").strip("/")
                 rel_path = bundled_relative_path(source_dir, repo_path)
                 if not rel_path:

--- a/scripts/sync_and_download.py
+++ b/scripts/sync_and_download.py
@@ -28,10 +28,12 @@ import hashlib
 import json
 import logging
 import os
+import shutil
 import sys
 import time
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+from urllib.parse import quote
 
 # Add parent to path for imports
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -75,6 +77,66 @@ logger = logging.getLogger(__name__)
 ACQUISITION_MANIFEST_VERSION = 1
 DEFAULT_MANIFEST_PATH = ROOT_DIR / "sources" / "acquisition_manifest.json"
 DEFAULT_LEARNING_PRIORS_PATH = ROOT_DIR / "sources" / "learning" / "discovery_priors.json"
+GITHUB_API_BASE = "https://api.github.com"
+
+BUNDLED_DIR_ALLOWLIST = {
+    "references",
+    "scripts",
+    "assets",
+    "templates",
+    "examples",
+}
+BUNDLED_ROOT_FILE_ALLOWLIST = {
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "requirements.txt",
+    "pyproject.toml",
+    "uv.lock",
+    "README.md",
+    "LICENSE",
+    "LICENSE.md",
+}
+BUNDLED_FILE_EXTENSIONS = {
+    ".bash",
+    ".css",
+    ".csv",
+    ".gif",
+    ".html",
+    ".jpeg",
+    ".jpg",
+    ".js",
+    ".json",
+    ".jsx",
+    ".j2",
+    ".md",
+    ".mjs",
+    ".png",
+    ".ps1",
+    ".py",
+    ".sh",
+    ".svg",
+    ".toml",
+    ".tpl",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+BUNDLED_EXCLUDED_PARTS = {
+    ".git",
+    "__pycache__",
+    "node_modules",
+    "dist",
+    "build",
+    ".venv",
+    "venv",
+}
+MAX_BUNDLED_FILE_BYTES = 1_000_000
+MAX_BUNDLED_TOTAL_BYTES = 5_000_000
+MAX_BUNDLED_FILES_PER_SKILL = 100
 
 
 def _source_count(path: Path) -> int:
@@ -102,6 +164,66 @@ def _ordered_unique(values: list[str]) -> list[str]:
         seen.add(normalized)
         ordered.append(normalized)
     return ordered
+
+
+def skill_source_dir(relative_path: str) -> str:
+    """Return the source directory for a resolved SKILL.md path."""
+    normalized = (relative_path or "").strip().strip("/")
+    if not normalized or normalized == "SKILL.md":
+        return ""
+    if normalized.lower().endswith("/skill.md"):
+        return normalized.rsplit("/", 1)[0]
+    parent = PurePosixPath(normalized).parent.as_posix()
+    return "" if parent == "." else parent
+
+
+def bundled_relative_path(source_dir: str, repo_path: str) -> str:
+    """Return repo_path relative to source_dir using POSIX separators."""
+    source_dir = (source_dir or "").strip().strip("/")
+    repo_path = (repo_path or "").strip().strip("/")
+    if not source_dir:
+        return repo_path
+    prefix = f"{source_dir}/"
+    if repo_path == source_dir:
+        return ""
+    if not repo_path.startswith(prefix):
+        return ""
+    return repo_path[len(prefix):]
+
+
+def should_recurse_bundled_dir(relative_path: str) -> bool:
+    """Return True when a support subdirectory is safe to inspect."""
+    parts = [part for part in relative_path.strip("/").split("/") if part]
+    if not parts:
+        return False
+    if any(part.startswith(".") or part in BUNDLED_EXCLUDED_PARTS for part in parts):
+        return False
+    return parts[0] in BUNDLED_DIR_ALLOWLIST
+
+
+def is_safe_bundled_file(relative_path: str, size: int) -> bool:
+    """Return True when a bundled support file should be archived."""
+    normalized = relative_path.strip("/")
+    if not normalized or normalized == "SKILL.md":
+        return False
+    if size < 0 or size > MAX_BUNDLED_FILE_BYTES:
+        return False
+
+    parts = [part for part in normalized.split("/") if part]
+    if not parts:
+        return False
+    if any(part.startswith(".") or part in BUNDLED_EXCLUDED_PARTS for part in parts):
+        return False
+
+    filename = parts[-1]
+    if len(parts) == 1:
+        return filename in BUNDLED_ROOT_FILE_ALLOWLIST
+
+    if parts[0] not in BUNDLED_DIR_ALLOWLIST:
+        return False
+    if filename in BUNDLED_ROOT_FILE_ALLOWLIST:
+        return True
+    return PurePosixPath(filename).suffix.lower() in BUNDLED_FILE_EXTENSIONS
 
 
 def build_manifest_key(repo: str, path: str, name: str, category: str) -> str:
@@ -573,6 +695,7 @@ async def download_skills(
         return {
             "downloaded": 0,
             "failed": 0,
+            "bundled_files": 0,
             "total": len(existing),
             "shard_count": shard_count,
             "shard_index": shard_index,
@@ -585,6 +708,7 @@ async def download_skills(
         "downloaded": 0,
         "failed": 0,
         "skipped": len(existing),
+        "bundled_files": 0,
         "url_attempts": 0,
         "manifest_hits": 0,
         "manifest_misses": 0,
@@ -679,6 +803,7 @@ async def download_skills(
         manifest_hit: bool = False,
         branch: str = "",
         relative_path: str = "",
+        bundled_file_count: int = 0,
     ) -> None:
         observations.append(
             {
@@ -696,11 +821,133 @@ async def download_skills(
                 "manifest_hit": manifest_hit,
                 "resolved_branch": branch,
                 "resolved_relative_path": relative_path,
+                "bundled_file_count": bundled_file_count,
             }
         )
 
     for skipped_skill, skipped_reason in pending_skipped_rows:
         add_observation(skipped_skill, outcome="skipped", failure_reason=skipped_reason)
+
+    async def fetch_contents_listing(
+        session: aiohttp.ClientSession,
+        repo: str,
+        branch: str,
+        directory_path: str,
+    ) -> list[dict]:
+        encoded_path = quote(directory_path.strip("/"), safe="/")
+        encoded_ref = quote(branch, safe="")
+        path_suffix = f"/{encoded_path}" if encoded_path else ""
+        url = f"{GITHUB_API_BASE}/repos/{repo}/contents{path_suffix}?ref={encoded_ref}"
+        try:
+            async with session.get(url, timeout=request_timeout) as resp:
+                if resp.status != 200:
+                    return []
+                payload = await resp.json()
+        except Exception:
+            return []
+        return payload if isinstance(payload, list) else []
+
+    async def collect_bundled_file_entries(
+        session: aiohttp.ClientSession,
+        repo: str,
+        branch: str,
+        resolved_skill_path: str,
+    ) -> list[dict]:
+        source_dir = skill_source_dir(resolved_skill_path)
+        queue = [source_dir]
+        seen_dirs = set()
+        candidates: list[dict] = []
+
+        while queue:
+            current_dir = queue.pop(0)
+            if current_dir in seen_dirs:
+                continue
+            seen_dirs.add(current_dir)
+
+            for entry in await fetch_contents_listing(session, repo, branch, current_dir):
+                entry_type = entry.get("type")
+                repo_path = str(entry.get("path") or "").strip("/")
+                rel_path = bundled_relative_path(source_dir, repo_path)
+                if not rel_path:
+                    continue
+
+                if entry_type == "dir":
+                    if should_recurse_bundled_dir(rel_path):
+                        queue.append(repo_path)
+                    continue
+
+                if entry_type != "file":
+                    continue
+
+                try:
+                    size = int(entry.get("size") or 0)
+                except (TypeError, ValueError):
+                    size = -1
+                if is_safe_bundled_file(rel_path, size):
+                    candidates.append(
+                        {
+                            "repo_path": repo_path,
+                            "relative_path": rel_path,
+                            "download_url": entry.get("download_url") or "",
+                            "size": size,
+                        }
+                    )
+
+        selected: list[dict] = []
+        total_size = 0
+        for entry in sorted(candidates, key=lambda item: item["relative_path"]):
+            if len(selected) >= MAX_BUNDLED_FILES_PER_SKILL:
+                break
+            if total_size + entry["size"] > MAX_BUNDLED_TOTAL_BYTES:
+                continue
+            selected.append(entry)
+            total_size += entry["size"]
+        return selected
+
+    async def download_bundled_files(
+        session: aiohttp.ClientSession,
+        repo: str,
+        branch: str,
+        resolved_skill_path: str,
+        skill_dir: Path,
+    ) -> tuple[list[str], list[str]]:
+        archived: list[str] = []
+        failed: list[str] = []
+        entries = await collect_bundled_file_entries(session, repo, branch, resolved_skill_path)
+        if not entries:
+            return archived, failed
+
+        skill_root = skill_dir.resolve()
+        for entry in entries:
+            rel_path = entry["relative_path"]
+            target_path = (skill_dir / rel_path).resolve()
+            try:
+                target_path.relative_to(skill_root)
+            except ValueError:
+                failed.append(rel_path)
+                continue
+
+            url = entry["download_url"] or (
+                f"{GITHUB_RAW_BASE}/{repo}/{branch}/{quote(entry['repo_path'], safe='/')}"
+            )
+            try:
+                async with session.get(url, timeout=request_timeout) as resp:
+                    if resp.status != 200:
+                        failed.append(rel_path)
+                        continue
+                    content = await resp.read()
+            except Exception:
+                failed.append(rel_path)
+                continue
+
+            if len(content) > MAX_BUNDLED_FILE_BYTES:
+                failed.append(rel_path)
+                continue
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            target_path.write_bytes(content)
+            archived.append(rel_path)
+
+        return archived, failed
 
     async def try_download(session: aiohttp.ClientSession, skill: dict) -> bool:
         name = (skill.get("name") or "").strip() or "unknown"
@@ -747,6 +994,31 @@ async def download_skills(
                                     skill_dir.mkdir(parents=True, exist_ok=True)
                                     (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
                                     resolved_path = path or relative_path
+                                    bundled_files, bundled_failures = await download_bundled_files(
+                                        session,
+                                        repo,
+                                        branch,
+                                        relative_path,
+                                        skill_dir,
+                                    )
+                                    if bundled_failures:
+                                        shutil.rmtree(skill_dir, ignore_errors=True)
+                                        failures["bundled_download_failed"].append(
+                                            f"{name}: {', '.join(bundled_failures)}"
+                                        )
+                                        stats["url_attempts"] += attempts
+                                        add_observation(
+                                            skill,
+                                            outcome="failed",
+                                            failure_reason="bundled_download_failed",
+                                            attempts=attempts,
+                                            manifest_hit=manifest_entry is not None,
+                                            branch=branch,
+                                            relative_path=relative_path,
+                                            bundled_file_count=len(bundled_files),
+                                        )
+                                        return False
+                                    stats["bundled_files"] += len(bundled_files)
                                     legal_meta = build_legal_metadata(
                                         repo=repo,
                                         path=resolved_path,
@@ -770,6 +1042,8 @@ async def download_skills(
                                             "stars": skill.get("stars", 0),
                                             "source": skill.get("source", ""),
                                             "dir_name": skill_dir.name,
+                                            "archive_mode": "directory" if bundled_files else "skill-md",
+                                            "bundled_files": bundled_files,
                                             **legal_meta,
                                         }, indent=2, ensure_ascii=False),
                                         encoding="utf-8"
@@ -793,6 +1067,7 @@ async def download_skills(
                                         manifest_hit=manifest_entry is not None,
                                         branch=branch,
                                         relative_path=relative_path,
+                                        bundled_file_count=len(bundled_files),
                                     )
                                     return True
                             elif resp.status == 403:
@@ -877,6 +1152,7 @@ async def download_skills(
     logger.info("DOWNLOAD COMPLETE")
     logger.info("=" * 60)
     logger.info(f"Downloaded: {stats['downloaded']}")
+    logger.info(f"Bundled files archived: {stats['bundled_files']}")
     logger.info(f"Failed: {stats['failed']}")
     logger.info(f"URL attempts: {stats['url_attempts']}")
     logger.info(f"Total skills: {final_count}")

--- a/scripts/sync_and_download.py
+++ b/scripts/sync_and_download.py
@@ -139,6 +139,15 @@ MAX_BUNDLED_TOTAL_BYTES = 5_000_000
 MAX_BUNDLED_FILES_PER_SKILL = 100
 
 
+class BundledListingError(Exception):
+    """Raised when GitHub Contents API cannot list a skill support directory."""
+
+    def __init__(self, directory_path: str, reason: str):
+        self.directory_path = directory_path.strip("/") or "."
+        self.reason = reason
+        super().__init__(f"{self.directory_path}: {reason}")
+
+
 def _source_count(path: Path) -> int:
     """Safely read source count from an existing source JSON file."""
     try:
@@ -841,11 +850,16 @@ async def download_skills(
         try:
             async with session.get(url, timeout=request_timeout) as resp:
                 if resp.status != 200:
-                    return []
+                    raise BundledListingError(directory_path, f"status {resp.status}")
                 payload = await resp.json()
-        except Exception:
-            return []
-        return payload if isinstance(payload, list) else []
+        except BundledListingError:
+            raise
+        except Exception as exc:
+            reason = str(exc) or exc.__class__.__name__
+            raise BundledListingError(directory_path, reason) from exc
+        if not isinstance(payload, list):
+            raise BundledListingError(directory_path, "unexpected payload")
+        return payload
 
     async def collect_bundled_file_entries(
         session: aiohttp.ClientSession,
@@ -910,12 +924,15 @@ async def download_skills(
         branch: str,
         resolved_skill_path: str,
         skill_dir: Path,
-    ) -> tuple[list[str], list[str]]:
+    ) -> tuple[list[str], list[str], str]:
         archived: list[str] = []
         failed: list[str] = []
-        entries = await collect_bundled_file_entries(session, repo, branch, resolved_skill_path)
+        try:
+            entries = await collect_bundled_file_entries(session, repo, branch, resolved_skill_path)
+        except BundledListingError as exc:
+            return archived, [str(exc)], "bundled_listing_failed"
         if not entries:
-            return archived, failed
+            return archived, failed, ""
 
         skill_root = skill_dir.resolve()
         for entry in entries:
@@ -947,7 +964,8 @@ async def download_skills(
             target_path.write_bytes(content)
             archived.append(rel_path)
 
-        return archived, failed
+        failure_reason = "bundled_download_failed" if failed else ""
+        return archived, failed, failure_reason
 
     async def try_download(session: aiohttp.ClientSession, skill: dict) -> bool:
         name = (skill.get("name") or "").strip() or "unknown"
@@ -994,7 +1012,11 @@ async def download_skills(
                                     skill_dir.mkdir(parents=True, exist_ok=True)
                                     (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
                                     resolved_path = path or relative_path
-                                    bundled_files, bundled_failures = await download_bundled_files(
+                                    (
+                                        bundled_files,
+                                        bundled_failures,
+                                        bundled_failure_reason,
+                                    ) = await download_bundled_files(
                                         session,
                                         repo,
                                         branch,
@@ -1002,15 +1024,18 @@ async def download_skills(
                                         skill_dir,
                                     )
                                     if bundled_failures:
+                                        failure_reason = (
+                                            bundled_failure_reason or "bundled_download_failed"
+                                        )
                                         shutil.rmtree(skill_dir, ignore_errors=True)
-                                        failures["bundled_download_failed"].append(
+                                        failures[failure_reason].append(
                                             f"{name}: {', '.join(bundled_failures)}"
                                         )
                                         stats["url_attempts"] += attempts
                                         add_observation(
                                             skill,
                                             outcome="failed",
-                                            failure_reason="bundled_download_failed",
+                                            failure_reason=failure_reason,
                                             attempts=attempts,
                                             manifest_hit=manifest_entry is not None,
                                             branch=branch,

--- a/tests/test_plugin_contract.py
+++ b/tests/test_plugin_contract.py
@@ -75,6 +75,10 @@ def test_build_plugins_index_and_stats_use_plugin_keys(tmp_path):
     )
 
     stats_data = json.loads((output_dir / "stats.json").read_text(encoding="utf-8"))
+    lite_data = json.loads((output_dir / "search-index-lite.json").read_text(encoding="utf-8"))
+    quality_data = json.loads((output_dir / "quality-index.json").read_text(encoding="utf-8"))
+    security_data = json.loads((output_dir / "security-index.json").read_text(encoding="utf-8"))
+    ranking_data = json.loads((output_dir / "ranking-index.json").read_text(encoding="utf-8"))
 
     assert "plugins" in plugins_data
     assert "collections" not in plugins_data
@@ -88,6 +92,56 @@ def test_build_plugins_index_and_stats_use_plugin_keys(tmp_path):
     assert "raw_skill_count" not in stats_data
     assert "dedup_skill_count" not in stats_data
     assert "total_collections" not in stats_data
+    assert stats_data["lite_index_count"] == 1
+    assert stats_data["lite_index_included_count"] == 1
+    assert lite_data["dedupe_key"] == "install|branch"
+    assert lite_data["total_count"] == 1
+    assert lite_data["included_count"] == 1
+    assert lite_data["skills"][0]["id"]
+    assert lite_data["skills"][0]["quality_grade"] in {"S", "A", "B", "C", "unknown", "blocked"}
+    assert lite_data["skills"][0]["security_status"] == "unknown"
+    assert quality_data["count"] == 1
+    assert security_data["count"] == 1
+    assert ranking_data["count"] == 1
+    assert ranking_data["records"][0]["recommended_score"] >= 0
+
+
+def test_build_search_index_lite_dedupes_install_and_branch(tmp_path):
+    output_dir = tmp_path / "docs"
+    skills = [
+        {
+            "name": "demo-weak",
+            "description": "short",
+            "repo": "owner/repo",
+            "path": "skills/demo/SKILL.md",
+            "branch": "main",
+            "category": "development",
+            "tags": [],
+            "stars": 1,
+            "install": "owner/repo/skills/demo/SKILL.md",
+            "source": "test",
+        },
+        {
+            "name": "demo-strong",
+            "description": "A much clearer description for the same install target with richer metadata.",
+            "repo": "owner/repo",
+            "path": "skills/demo/SKILL.md",
+            "branch": "main",
+            "category": "development",
+            "tags": ["demo", "quality", "search"],
+            "stars": 10,
+            "install": "owner/repo/skills/demo/SKILL.md",
+            "source": "test",
+        },
+    ]
+
+    build_search_index.build_search_index(skills, output_dir, source_name="test-skills")
+
+    lite_data = json.loads((output_dir / "search-index-lite.json").read_text(encoding="utf-8"))
+    assert lite_data["raw_count"] == 2
+    assert lite_data["total_count"] == 1
+    assert lite_data["included_count"] == 1
+    assert lite_data["skills"][0]["name"] == "demo-strong"
 
 
 def test_utc_helpers_keep_trailing_z_suffix():

--- a/tests/test_security_scanner.py
+++ b/tests/test_security_scanner.py
@@ -1,0 +1,117 @@
+import importlib.util
+from pathlib import Path
+
+
+def load_module():
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "security_scanner.py"
+    spec = importlib.util.spec_from_file_location("security_scanner_module", module_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_scanner_checks_reference_implementations(tmp_path):
+    module = load_module()
+    skill_dir = tmp_path / "demo"
+    references_dir = skill_dir / "references"
+    references_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: demo
+description: Demo skill used to verify bundled reference scanning.
+---
+
+# Demo
+""",
+        encoding="utf-8",
+    )
+    (references_dir / "helper.py").write_text(
+        "import subprocess\nsubprocess.run('echo unsafe', shell=True)\n",
+        encoding="utf-8",
+    )
+
+    scanner = module.SecurityScanner()
+    is_safe, issues = scanner.scan_file(skill_dir / "SKILL.md")
+
+    assert is_safe is False
+    assert any(
+        issue.get("type") == "dangerous_pattern"
+        and issue.get("pattern") == "shell=True"
+        and "references/helper.py" in issue.get("file", "")
+        for issue in issues
+    )
+
+
+def test_scanner_checks_all_archived_support_dirs(tmp_path):
+    module = load_module()
+    skill_dir = tmp_path / "demo"
+    examples_dir = skill_dir / "examples"
+    templates_dir = skill_dir / "templates"
+    assets_dir = skill_dir / "assets"
+    examples_dir.mkdir(parents=True)
+    templates_dir.mkdir()
+    assets_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: demo
+description: Demo skill used to verify bundled support dir scanning.
+---
+
+# Demo
+""",
+        encoding="utf-8",
+    )
+    (examples_dir / "install.sh").write_text(
+        "python -c \"eval('unsafe')\"\n",
+        encoding="utf-8",
+    )
+    (templates_dir / "postinstall.js").write_text(
+        "const child_process = require('child_process');\n",
+        encoding="utf-8",
+    )
+    (assets_dir / "payload.svg").write_text(
+        "<svg><script>eval('unsafe')</script></svg>\n",
+        encoding="utf-8",
+    )
+
+    scanner = module.SecurityScanner()
+    is_safe, issues = scanner.scan_file(skill_dir / "SKILL.md")
+
+    assert is_safe is False
+    issue_files = {issue.get("file", "") for issue in issues}
+    assert any("examples/install.sh" in file for file in issue_files)
+    assert any("templates/postinstall.js" in file for file in issue_files)
+    assert any("assets/payload.svg" in file for file in issue_files)
+
+
+def test_scanner_checks_root_package_manifest(tmp_path):
+    module = load_module()
+    skill_dir = tmp_path / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: demo
+description: Demo skill used to verify bundled package scanning.
+---
+
+# Demo
+""",
+        encoding="utf-8",
+    )
+    (skill_dir / "package.json").write_text(
+        '{"scripts":{"postinstall":"node -e \\"eval(process.env.PAYLOAD)\\""}}',
+        encoding="utf-8",
+    )
+
+    scanner = module.SecurityScanner()
+    is_safe, issues = scanner.scan_file(skill_dir / "SKILL.md")
+
+    assert is_safe is False
+    assert any(
+        issue.get("type") == "dangerous_pattern"
+        and issue.get("pattern") == "eval"
+        and "package.json" in issue.get("file", "")
+        for issue in issues
+    )

--- a/tests/test_security_scanner.py
+++ b/tests/test_security_scanner.py
@@ -86,6 +86,36 @@ description: Demo skill used to verify bundled support dir scanning.
     assert any("assets/payload.svg" in file for file in issue_files)
 
 
+def test_scanner_size_checks_non_text_support_files(tmp_path):
+    module = load_module()
+    skill_dir = tmp_path / "demo"
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: demo
+description: Demo skill used to verify bundled file size checks.
+---
+
+# Demo
+""",
+        encoding="utf-8",
+    )
+    oversized_file = scripts_dir / "payload.bin"
+    with oversized_file.open("wb") as handle:
+        handle.truncate(10_000_001)
+
+    scanner = module.SecurityScanner()
+    is_safe, issues = scanner.scan_file(skill_dir / "SKILL.md")
+
+    assert is_safe is False
+    assert any(
+        issue.get("type") == "file_too_large"
+        and "scripts/payload.bin" in issue.get("file", "")
+        for issue in issues
+    )
+
+
 def test_scanner_checks_root_package_manifest(tmp_path):
     module = load_module()
     skill_dir = tmp_path / "demo"

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -1,5 +1,8 @@
+import asyncio
 import importlib.util
+import json
 import sys
+import types
 from datetime import timedelta
 from pathlib import Path
 
@@ -9,6 +12,7 @@ import pytest
 def load_module():
     module_path = Path(__file__).resolve().parents[1] / "scripts" / "sync_and_download.py"
     spec = importlib.util.spec_from_file_location("sync_and_download_module", module_path)
+    assert spec is not None
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)
@@ -96,6 +100,149 @@ def test_probe_order_removes_duplicates():
 
     assert branch_order == ["main", "master"]
     assert path_order == ["skills/demo/SKILL.md", "SKILL.md"]
+
+
+def test_skill_source_dir_resolves_skill_parent():
+    module = load_module()
+
+    assert module.skill_source_dir("skills/demo/SKILL.md") == "skills/demo"
+    assert module.skill_source_dir(".claude/skills/demo/SKILL.md") == ".claude/skills/demo"
+    assert module.skill_source_dir("SKILL.md") == ""
+    assert module.skill_source_dir("") == ""
+
+
+def test_bundled_file_allowlist_is_scoped_and_size_limited():
+    module = load_module()
+
+    assert module.bundled_relative_path("", "package.json") == "package.json"
+    assert module.bundled_relative_path("skills/demo", "skills/demo/scripts/run.sh") == "scripts/run.sh"
+    assert module.bundled_relative_path("skills/demo", "other/scripts/run.sh") == ""
+    assert module.should_recurse_bundled_dir("scripts") is True
+    assert module.should_recurse_bundled_dir("references/nested") is True
+    assert module.should_recurse_bundled_dir("docs") is False
+    assert module.is_safe_bundled_file("references/helper.py", 1024) is True
+    assert module.is_safe_bundled_file("scripts/listen.mjs", 1024) is True
+    assert module.is_safe_bundled_file("package.json", 1024) is True
+    assert module.is_safe_bundled_file("docs/helper.py", 1024) is False
+    assert module.is_safe_bundled_file("references/.env", 10) is False
+    assert module.is_safe_bundled_file(
+        "references/huge.py",
+        module.MAX_BUNDLED_FILE_BYTES + 1,
+    ) is False
+
+
+def test_bundled_download_failure_does_not_publish_partial_archive(tmp_path, monkeypatch):
+    module = load_module()
+    registry_path = tmp_path / "registry.json"
+    output_dir = tmp_path / "skills"
+    failure_report_path = tmp_path / "failure_report.json"
+    manifest_path = tmp_path / "manifest.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "skills": [
+                    {
+                        "name": "demo",
+                        "repo": "acme/demo",
+                        "path": "skills/demo",
+                        "category": "development",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class FakeResponse:
+        def __init__(self, status, *, text="", json_payload=None, body=b""):
+            self.status = status
+            self._text = text
+            self._json_payload = json_payload
+            self._body = body
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def text(self):
+            return self._text
+
+        async def json(self):
+            return self._json_payload
+
+        async def read(self):
+            return self._body
+
+    class FakeClientSession:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        def get(self, url, timeout=None):
+            if url == "https://raw.githubusercontent.com/acme/demo/main/skills/demo/SKILL.md":
+                return FakeResponse(
+                    200,
+                    text=(
+                        "---\nname: demo\n"
+                        "description: Demo skill with a helper script.\n---\n# Demo\n"
+                    ),
+                )
+            if url == "https://api.github.com/repos/acme/demo/contents/skills/demo?ref=main":
+                return FakeResponse(
+                    200,
+                    json_payload=[
+                        {
+                            "type": "dir",
+                            "path": "skills/demo/scripts",
+                            "size": 0,
+                        }
+                    ],
+                )
+            if url == "https://api.github.com/repos/acme/demo/contents/skills/demo/scripts?ref=main":
+                return FakeResponse(
+                    200,
+                    json_payload=[
+                        {
+                            "type": "file",
+                            "path": "skills/demo/scripts/run.sh",
+                            "download_url": "https://download.example/run.sh",
+                            "size": 10,
+                        }
+                    ],
+                )
+            if url == "https://download.example/run.sh":
+                return FakeResponse(503)
+            return FakeResponse(404)
+
+    fake_aiohttp = types.SimpleNamespace(
+        TCPConnector=lambda *args, **kwargs: object(),
+        ClientTimeout=lambda *args, **kwargs: object(),
+        ClientSession=FakeClientSession,
+    )
+    monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)
+
+    stats = asyncio.run(
+        module.download_skills(
+            registry_path,
+            output_dir,
+            manifest_path=manifest_path,
+            failure_report_path=failure_report_path,
+        )
+    )
+
+    assert stats["downloaded"] == 0
+    assert stats["failed"] == 1
+    assert stats["bundled_files"] == 0
+    assert not list(output_dir.rglob("SKILL.md"))
+    failure_report = json.loads(failure_report_path.read_text(encoding="utf-8"))
+    assert failure_report["failure_reasons"]["bundled_download_failed"] == 1
 
 
 def test_select_shard_skills_is_deterministic():

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -211,6 +211,7 @@ def test_bundled_download_failure_does_not_publish_partial_archive(tmp_path, mon
                 text=(
                     "---\nname: demo\n"
                     "description: Demo skill with a helper script.\n---\n# Demo\n"
+                    "Run scripts/run.sh before using this skill.\n"
                 ),
             ),
             "https://api.github.com/repos/acme/demo/contents/skills/demo?ref=main": FakeResponse(
@@ -286,6 +287,7 @@ def test_bundled_listing_failure_does_not_publish_skill_md_only(tmp_path, monkey
                 text=(
                     "---\nname: demo\n"
                     "description: Demo skill with references.\n---\n# Demo\n"
+                    "Read references/guide.md before using this skill.\n"
                 ),
             ),
             "https://api.github.com/repos/acme/demo/contents/skills/demo?ref=main": FakeResponse(
@@ -310,6 +312,145 @@ def test_bundled_listing_failure_does_not_publish_skill_md_only(tmp_path, monkey
     failure_report = json.loads(failure_report_path.read_text(encoding="utf-8"))
     assert failure_report["failure_reasons"]["bundled_listing_failed"] == 1
     assert "status 403" in failure_report["failures"]["bundled_listing_failed"][0]
+
+
+def test_bundled_listing_failure_degrades_when_skill_has_no_support_refs(
+    tmp_path,
+    monkeypatch,
+):
+    module = load_module()
+    registry_path = tmp_path / "registry.json"
+    output_dir = tmp_path / "skills"
+    failure_report_path = tmp_path / "failure_report.json"
+    manifest_path = tmp_path / "manifest.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "skills": [
+                    {
+                        "name": "demo",
+                        "repo": "acme/demo",
+                        "path": "skills/demo",
+                        "category": "development",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    install_fake_aiohttp(
+        monkeypatch,
+        {
+            "https://raw.githubusercontent.com/acme/demo/main/skills/demo/SKILL.md": FakeResponse(
+                200,
+                text=(
+                    "---\nname: demo\n"
+                    "description: Demo skill without support files.\n---\n"
+                    "# Demo\nUse this skill directly from the markdown instructions.\n"
+                ),
+            ),
+            "https://api.github.com/repos/acme/demo/contents/skills/demo?ref=main": FakeResponse(
+                403
+            ),
+        },
+    )
+
+    stats = asyncio.run(
+        module.download_skills(
+            registry_path,
+            output_dir,
+            manifest_path=manifest_path,
+            failure_report_path=failure_report_path,
+        )
+    )
+
+    assert stats["downloaded"] == 1
+    assert stats["failed"] == 0
+    assert stats["bundled_files"] == 0
+    skill_dir = next(output_dir.glob("development/*"))
+    metadata = json.loads((skill_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert metadata["archive_mode"] == "skill-md"
+    assert metadata["bundled_files"] == []
+    failure_report = json.loads(failure_report_path.read_text(encoding="utf-8"))
+    assert "bundled_listing_failed" not in failure_report["failure_reasons"]
+
+
+def test_optional_bundled_download_failure_degrades_to_skill_md(
+    tmp_path,
+    monkeypatch,
+):
+    module = load_module()
+    registry_path = tmp_path / "registry.json"
+    output_dir = tmp_path / "skills"
+    failure_report_path = tmp_path / "failure_report.json"
+    manifest_path = tmp_path / "manifest.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "skills": [
+                    {
+                        "name": "demo",
+                        "repo": "acme/demo",
+                        "path": "SKILL.md",
+                        "category": "development",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    install_fake_aiohttp(
+        monkeypatch,
+        {
+            "https://raw.githubusercontent.com/acme/demo/main/SKILL.md": FakeResponse(
+                200,
+                text=(
+                    "---\nname: demo\n"
+                    "description: Demo skill with optional repo files.\n---\n"
+                    "# Demo\nUse this skill directly from the markdown instructions.\n"
+                ),
+            ),
+            "https://api.github.com/repos/acme/demo/contents?ref=main": FakeResponse(
+                200,
+                json_payload=[
+                    {"type": "file", "path": "SKILL.md", "size": 80},
+                    {"type": "dir", "path": "scripts", "size": 0},
+                ],
+            ),
+            "https://api.github.com/repos/acme/demo/contents/scripts?ref=main": FakeResponse(
+                200,
+                json_payload=[
+                    {
+                        "type": "file",
+                        "path": "scripts/optional.py",
+                        "download_url": "https://download.example/optional.py",
+                        "size": 12,
+                    }
+                ],
+            ),
+            "https://download.example/optional.py": FakeResponse(503),
+        },
+    )
+
+    stats = asyncio.run(
+        module.download_skills(
+            registry_path,
+            output_dir,
+            manifest_path=manifest_path,
+            failure_report_path=failure_report_path,
+        )
+    )
+
+    assert stats["downloaded"] == 1
+    assert stats["failed"] == 0
+    assert stats["bundled_files"] == 0
+    skill_dir = next(output_dir.glob("development/*"))
+    metadata = json.loads((skill_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert metadata["archive_mode"] == "skill-md"
+    assert metadata["bundled_files"] == []
+    assert not (skill_dir / "scripts" / "optional.py").exists()
+    failure_report = json.loads(failure_report_path.read_text(encoding="utf-8"))
+    assert "bundled_download_failed" not in failure_report["failure_reasons"]
 
 
 def test_bundled_references_are_archived_with_directory_mode(tmp_path, monkeypatch):

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -19,6 +19,56 @@ def load_module():
     return module
 
 
+class FakeResponse:
+    def __init__(self, status, *, text="", json_payload=None, body=b""):
+        self.status = status
+        self._text = text
+        self._json_payload = json_payload
+        self._body = body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def text(self):
+        return self._text
+
+    async def json(self):
+        return self._json_payload
+
+    async def read(self):
+        return self._body
+
+
+def install_fake_aiohttp(monkeypatch, routes):
+    class FakeClientSession:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        def get(self, url, timeout=None):
+            response = routes.get(url)
+            if isinstance(response, Exception):
+                raise response
+            if response is None:
+                return FakeResponse(404)
+            return response
+
+    fake_aiohttp = types.SimpleNamespace(
+        TCPConnector=lambda *args, **kwargs: object(),
+        ClientTimeout=lambda *args, **kwargs: object(),
+        ClientSession=FakeClientSession,
+    )
+    monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)
+
+
 def test_should_fail_on_empty_download_only_when_all_attempts_fail():
     module = load_module()
 
@@ -153,60 +203,28 @@ def test_bundled_download_failure_does_not_publish_partial_archive(tmp_path, mon
         encoding="utf-8",
     )
 
-    class FakeResponse:
-        def __init__(self, status, *, text="", json_payload=None, body=b""):
-            self.status = status
-            self._text = text
-            self._json_payload = json_payload
-            self._body = body
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return None
-
-        async def text(self):
-            return self._text
-
-        async def json(self):
-            return self._json_payload
-
-        async def read(self):
-            return self._body
-
-    class FakeClientSession:
-        def __init__(self, *args, **kwargs):
-            pass
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return None
-
-        def get(self, url, timeout=None):
-            if url == "https://raw.githubusercontent.com/acme/demo/main/skills/demo/SKILL.md":
-                return FakeResponse(
-                    200,
-                    text=(
-                        "---\nname: demo\n"
-                        "description: Demo skill with a helper script.\n---\n# Demo\n"
-                    ),
-                )
-            if url == "https://api.github.com/repos/acme/demo/contents/skills/demo?ref=main":
-                return FakeResponse(
-                    200,
-                    json_payload=[
-                        {
-                            "type": "dir",
-                            "path": "skills/demo/scripts",
-                            "size": 0,
-                        }
-                    ],
-                )
-            if url == "https://api.github.com/repos/acme/demo/contents/skills/demo/scripts?ref=main":
-                return FakeResponse(
+    install_fake_aiohttp(
+        monkeypatch,
+        {
+            "https://raw.githubusercontent.com/acme/demo/main/skills/demo/SKILL.md": FakeResponse(
+                200,
+                text=(
+                    "---\nname: demo\n"
+                    "description: Demo skill with a helper script.\n---\n# Demo\n"
+                ),
+            ),
+            "https://api.github.com/repos/acme/demo/contents/skills/demo?ref=main": FakeResponse(
+                200,
+                json_payload=[
+                    {
+                        "type": "dir",
+                        "path": "skills/demo/scripts",
+                        "size": 0,
+                    }
+                ],
+            ),
+            "https://api.github.com/repos/acme/demo/contents/skills/demo/scripts?ref=main": (
+                FakeResponse(
                     200,
                     json_payload=[
                         {
@@ -217,16 +235,10 @@ def test_bundled_download_failure_does_not_publish_partial_archive(tmp_path, mon
                         }
                     ],
                 )
-            if url == "https://download.example/run.sh":
-                return FakeResponse(503)
-            return FakeResponse(404)
-
-    fake_aiohttp = types.SimpleNamespace(
-        TCPConnector=lambda *args, **kwargs: object(),
-        ClientTimeout=lambda *args, **kwargs: object(),
-        ClientSession=FakeClientSession,
+            ),
+            "https://download.example/run.sh": FakeResponse(503),
+        },
     )
-    monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)
 
     stats = asyncio.run(
         module.download_skills(
@@ -243,6 +255,134 @@ def test_bundled_download_failure_does_not_publish_partial_archive(tmp_path, mon
     assert not list(output_dir.rglob("SKILL.md"))
     failure_report = json.loads(failure_report_path.read_text(encoding="utf-8"))
     assert failure_report["failure_reasons"]["bundled_download_failed"] == 1
+
+
+def test_bundled_listing_failure_does_not_publish_skill_md_only(tmp_path, monkeypatch):
+    module = load_module()
+    registry_path = tmp_path / "registry.json"
+    output_dir = tmp_path / "skills"
+    failure_report_path = tmp_path / "failure_report.json"
+    manifest_path = tmp_path / "manifest.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "skills": [
+                    {
+                        "name": "demo",
+                        "repo": "acme/demo",
+                        "path": "skills/demo",
+                        "category": "development",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    install_fake_aiohttp(
+        monkeypatch,
+        {
+            "https://raw.githubusercontent.com/acme/demo/main/skills/demo/SKILL.md": FakeResponse(
+                200,
+                text=(
+                    "---\nname: demo\n"
+                    "description: Demo skill with references.\n---\n# Demo\n"
+                ),
+            ),
+            "https://api.github.com/repos/acme/demo/contents/skills/demo?ref=main": FakeResponse(
+                403
+            ),
+        },
+    )
+
+    stats = asyncio.run(
+        module.download_skills(
+            registry_path,
+            output_dir,
+            manifest_path=manifest_path,
+            failure_report_path=failure_report_path,
+        )
+    )
+
+    assert stats["downloaded"] == 0
+    assert stats["failed"] == 1
+    assert stats["bundled_files"] == 0
+    assert not list(output_dir.rglob("SKILL.md"))
+    failure_report = json.loads(failure_report_path.read_text(encoding="utf-8"))
+    assert failure_report["failure_reasons"]["bundled_listing_failed"] == 1
+    assert "status 403" in failure_report["failures"]["bundled_listing_failed"][0]
+
+
+def test_bundled_references_are_archived_with_directory_mode(tmp_path, monkeypatch):
+    module = load_module()
+    registry_path = tmp_path / "registry.json"
+    output_dir = tmp_path / "skills"
+    failure_report_path = tmp_path / "failure_report.json"
+    manifest_path = tmp_path / "manifest.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "skills": [
+                    {
+                        "name": "demo",
+                        "repo": "acme/demo",
+                        "path": "SKILL.md",
+                        "category": "development",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    install_fake_aiohttp(
+        monkeypatch,
+        {
+            "https://raw.githubusercontent.com/acme/demo/main/SKILL.md": FakeResponse(
+                200,
+                text=(
+                    "---\nname: demo\n"
+                    "description: Demo skill with references.\n---\n"
+                    "# Demo\nSee references/guide.md.\n"
+                ),
+            ),
+            "https://api.github.com/repos/acme/demo/contents?ref=main": FakeResponse(
+                200,
+                json_payload=[
+                    {"type": "file", "path": "SKILL.md", "size": 80},
+                    {"type": "dir", "path": "references", "size": 0},
+                ],
+            ),
+            "https://api.github.com/repos/acme/demo/contents/references?ref=main": FakeResponse(
+                200,
+                json_payload=[
+                    {
+                        "type": "file",
+                        "path": "references/guide.md",
+                        "download_url": "https://download.example/guide.md",
+                        "size": 12,
+                    }
+                ],
+            ),
+            "https://download.example/guide.md": FakeResponse(200, body=b"# Guide\n"),
+        },
+    )
+
+    stats = asyncio.run(
+        module.download_skills(
+            registry_path,
+            output_dir,
+            manifest_path=manifest_path,
+            failure_report_path=failure_report_path,
+        )
+    )
+
+    assert stats["downloaded"] == 1
+    assert stats["failed"] == 0
+    assert stats["bundled_files"] == 1
+    skill_dir = next(output_dir.glob("development/*"))
+    metadata = json.loads((skill_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert metadata["archive_mode"] == "directory"
+    assert metadata["bundled_files"] == ["references/guide.md"]
+    assert (skill_dir / "references" / "guide.md").read_text(encoding="utf-8") == "# Guide\n"
 
 
 def test_select_shard_skills_is_deterministic():

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -385,6 +385,77 @@ def test_bundled_references_are_archived_with_directory_mode(tmp_path, monkeypat
     assert (skill_dir / "references" / "guide.md").read_text(encoding="utf-8") == "# Guide\n"
 
 
+def test_bundled_collection_skips_github_submodule_entries(tmp_path, monkeypatch):
+    module = load_module()
+    registry_path = tmp_path / "registry.json"
+    output_dir = tmp_path / "skills"
+    failure_report_path = tmp_path / "failure_report.json"
+    manifest_path = tmp_path / "manifest.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "skills": [
+                    {
+                        "name": "demo",
+                        "repo": "acme/demo",
+                        "path": "SKILL.md",
+                        "category": "development",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    install_fake_aiohttp(
+        monkeypatch,
+        {
+            "https://raw.githubusercontent.com/acme/demo/main/SKILL.md": FakeResponse(
+                200,
+                text=(
+                    "---\nname: demo\n"
+                    "description: Demo skill with a submodule path.\n---\n# Demo\n"
+                ),
+            ),
+            "https://api.github.com/repos/acme/demo/contents?ref=main": FakeResponse(
+                200,
+                json_payload=[
+                    {"type": "file", "path": "SKILL.md", "size": 80},
+                    {"type": "dir", "path": "scripts", "size": 0},
+                ],
+            ),
+            "https://api.github.com/repos/acme/demo/contents/scripts?ref=main": FakeResponse(
+                200,
+                json_payload=[
+                    {
+                        "type": "file",
+                        "path": "scripts/tool.py",
+                        "size": 0,
+                        "download_url": None,
+                        "submodule_git_url": "https://github.com/acme/tool.git",
+                    }
+                ],
+            ),
+        },
+    )
+
+    stats = asyncio.run(
+        module.download_skills(
+            registry_path,
+            output_dir,
+            manifest_path=manifest_path,
+            failure_report_path=failure_report_path,
+        )
+    )
+
+    assert stats["downloaded"] == 1
+    assert stats["failed"] == 0
+    skill_dir = next(output_dir.glob("development/*"))
+    metadata = json.loads((skill_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert metadata["archive_mode"] == "skill-md"
+    assert metadata["bundled_files"] == []
+    assert not (skill_dir / "scripts" / "tool.py").exists()
+
+
 def test_select_shard_skills_is_deterministic():
     module = load_module()
     skills = [


### PR DESCRIPTION
## What changed

This PR expands the core registry pipeline in two connected ways:

- supports directory-style skill archives by scanning every `SKILL.md` recursively instead of relying only on the old category-root shape
- adds generated catalog index artifacts:
  - `search-index-lite.json` and `.gz`
  - `quality-index.json`
  - `security-index.json`
  - `ranking-index.json`

## Why

The web catalog needs a smaller first-load index and explicit trust signals so users can search, filter, and compare skills by more than name/stars. This keeps the core repo as the source of truth for generated catalog contracts and lets the web app consume stable, publishable artifacts.

## Product impact

The new index contract enables:

- fast catalog preload through the lite index
- quality grades and scores
- install status
- security status placeholders for scanner-backed results
- trust ranking inputs
- compatible-agent hints
- stable skill IDs derived from install path and branch

## Validation

- `python -m py_compile scripts/build_search_index.py`
- `ruff check scripts/build_search_index.py tests/test_plugin_contract.py`
- `pytest tests/test_plugin_contract.py -q`
- generated a temporary real registry from 155,318 entries and verified:
  - lite total count: 155,315
  - lite included count: 5,000
  - `search-index-lite.json`: about 3.35 MB
  - `search-index-lite.json.gz`: about 555 KB

## Notes

The lite index intentionally includes a ranked subset first. Full catalog search should move to sharded or server-backed search rather than forcing the browser to load the legacy full index.
