### PR TITLE
fix: address post-merge catalog review

### DIFF
--- a/scripts/build_search_index.py
+++ b/scripts/build_search_index.py
@@ -413,6 +413,7 @@ def build_search_index(
             "quality_score": quality_score,
             "trust_score": trust_score,
             "compatible_agents": compatible_agents,
+            "_description_length": len(description),
         }
         dedupe_key = f"{install}|{branch}"
         existing = lite_skills_by_key.get(dedupe_key)
@@ -423,7 +424,7 @@ def build_search_index(
         ) > (
             int(existing.get("stars", 0) or 0),
             int(existing.get("quality_score", 0) or 0),
-            len(str(existing.get("description", ""))),
+            int(existing.get("_description_length", 0) or 0),
         ):
             lite_skills_by_key[dedupe_key] = lite_record
             quality_records_by_id[skill_id] = {
@@ -469,6 +470,10 @@ def build_search_index(
         ),
         reverse=True,
     )
+    all_lite_skills = [
+        {key: value for key, value in skill.items() if not key.startswith("_")}
+        for skill in all_lite_skills
+    ]
     lite_skills = all_lite_skills[:LITE_INDEX_LIMIT]
     ranking_records = sorted(
         ranking_records_by_id.values(),

--- a/scripts/sync_and_download.py
+++ b/scripts/sync_and_download.py
@@ -230,6 +230,8 @@ def is_safe_bundled_file(relative_path: str, size: int) -> bool:
         return False
 
     filename = parts[-1]
+    if filename.lower() == "skill.md":
+        return False
     if len(parts) == 1:
         return filename in BUNDLED_ROOT_FILE_ALLOWLIST
 

--- a/tests/test_plugin_contract.py
+++ b/tests/test_plugin_contract.py
@@ -144,6 +144,46 @@ def test_build_search_index_lite_dedupes_install_and_branch(tmp_path):
     assert lite_data["skills"][0]["name"] == "demo-strong"
 
 
+def test_build_search_index_lite_dedupe_uses_untruncated_description_length(tmp_path):
+    output_dir = tmp_path / "docs"
+    install = "owner/repo/skills/demo/SKILL.md"
+    long_description = "a" * 240
+    shorter_but_over_truncation = "b" * 181
+    skills = [
+        {
+            "name": "demo-long",
+            "description": long_description,
+            "repo": "owner/repo",
+            "path": "skills/demo/SKILL.md",
+            "branch": "main",
+            "category": "development",
+            "tags": ["demo", "quality", "search"],
+            "stars": 10,
+            "install": install,
+            "source": "test",
+        },
+        {
+            "name": "demo-shorter",
+            "description": shorter_but_over_truncation,
+            "repo": "owner/repo",
+            "path": "skills/demo/SKILL.md",
+            "branch": "main",
+            "category": "development",
+            "tags": ["demo", "quality", "search"],
+            "stars": 10,
+            "install": install,
+            "source": "test",
+        },
+    ]
+
+    build_search_index.build_search_index(skills, output_dir, source_name="test-skills")
+
+    lite_data = json.loads((output_dir / "search-index-lite.json").read_text(encoding="utf-8"))
+    assert lite_data["total_count"] == 1
+    assert lite_data["skills"][0]["name"] == "demo-long"
+    assert "_description_length" not in lite_data["skills"][0]
+
+
 def test_utc_helpers_keep_trailing_z_suffix():
     assert build_search_index.utc_now_isoformat().endswith("Z")
     assert rebuild_registry.utc_now_isoformat().endswith("Z")

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -173,6 +173,8 @@ def test_bundled_file_allowlist_is_scoped_and_size_limited():
     assert module.is_safe_bundled_file("references/helper.py", 1024) is True
     assert module.is_safe_bundled_file("scripts/listen.mjs", 1024) is True
     assert module.is_safe_bundled_file("package.json", 1024) is True
+    assert module.is_safe_bundled_file("references/SKILL.md", 1024) is False
+    assert module.is_safe_bundled_file("examples/SKILL.md", 1024) is False
     assert module.is_safe_bundled_file("docs/helper.py", 1024) is False
     assert module.is_safe_bundled_file("references/.env", 10) is False
     assert module.is_safe_bundled_file(


### PR DESCRIPTION
## What changed

- Exclude any bundled support file whose basename is `SKILL.md`, preventing nested `references/SKILL.md` / `examples/SKILL.md` files from being archived and later indexed as phantom standalone skills.
- Use an internal raw description length when deduping lite index records, so the tie-breaker is not based on the already-truncated public description.

## Validation

- `python -m ruff check scripts/sync_and_download.py scripts/build_search_index.py tests/test_sync_and_download.py tests/test_plugin_contract.py`
- `python -m pytest tests/test_sync_and_download.py tests/test_plugin_contract.py`
- `python -m pytest`

## Review context

Follow-up to post-merge Codex review on #40:

- https://github.com/majiayu000/claude-skill-registry-core/pull/40#discussion_r3177728964
- https://github.com/majiayu000/claude-skill-registry-core/pull/40#discussion_r3177728965
