### PR TITLE
Block malicious skill sources in registry pipeline

### DIFF
--- a/.github/workflows/sync-data.yml
+++ b/.github/workflows/sync-data.yml
@@ -69,6 +69,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y clamav clamav-freshclam
+          sudo systemctl stop clamav-freshclam || true
           sudo freshclam
           clamscan --version
 

--- a/.github/workflows/sync-data.yml
+++ b/.github/workflows/sync-data.yml
@@ -237,21 +237,18 @@ jobs:
       - name: Security scan (skills full)
         if: steps.security_scope.outputs.mode == 'full'
         id: security_full
-        continue-on-error: true
         run: |
           echo "🔒 Running full security scan on skills..."
-          python scripts/security_scanner.py skills/ --quiet --report-only --output security-report.json
+          python scripts/security_scanner.py skills/ --quiet --output security-report.json
 
       - name: Security scan (skills daily incremental)
         if: steps.security_scope.outputs.mode != 'full'
         id: security_daily
-        continue-on-error: true
         run: |
           echo "🔒 Running incremental security scan on changed skills..."
           python scripts/security_scanner.py \
             skills/ \
             --quiet \
-            --report-only \
             --output security-report.json \
             --file-list "${{ steps.security_scope.outputs.file_list }}"
 

--- a/.github/workflows/sync-data.yml
+++ b/.github/workflows/sync-data.yml
@@ -65,6 +65,13 @@ jobs:
       - name: Install dependencies
         run: pip install pyyaml aiohttp requests jsonschema
 
+      - name: Install ClamAV
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clamav clamav-freshclam
+          sudo freshclam
+          clamscan --version
+
       - name: Resolve discovery profile
         id: discovery
         env:
@@ -252,6 +259,29 @@ jobs:
             --output security-report.json \
             --file-list "${{ steps.security_scope.outputs.file_list }}"
 
+      - name: ClamAV scan (skills full)
+        if: steps.security_scope.outputs.mode == 'full'
+        id: clamav_full
+        run: |
+          echo "🛡️ Running full ClamAV scan on skills..."
+          clamscan --recursive --infected --log=clamav-report.txt skills
+
+      - name: ClamAV scan (skills daily incremental)
+        if: steps.security_scope.outputs.mode != 'full'
+        id: clamav_daily
+        run: |
+          echo "🛡️ Running incremental ClamAV scan on changed skills..."
+          CLAMAV_FILE_LIST="$RUNNER_TEMP/clamav-scan-files.txt"
+          {
+            git -C skills diff --name-only --diff-filter=AM || true
+            git -C skills ls-files --others --exclude-standard || true
+          } | sed 's#^#skills/#' | sort -u > "$CLAMAV_FILE_LIST"
+          if [ ! -s "$CLAMAV_FILE_LIST" ]; then
+            echo "No changed archive files for ClamAV scan." | tee clamav-report.txt
+            exit 0
+          fi
+          clamscan --infected --log=clamav-report.txt --file-list "$CLAMAV_FILE_LIST"
+
       - name: Print security outcome
         if: always()
         env:
@@ -259,17 +289,22 @@ jobs:
           CHANGED_COUNT: ${{ steps.security_scope.outputs.changed_count }}
           FULL_OUTCOME: ${{ steps.security_full.outcome }}
           DAILY_OUTCOME: ${{ steps.security_daily.outcome }}
+          CLAMAV_FULL_OUTCOME: ${{ steps.clamav_full.outcome }}
+          CLAMAV_DAILY_OUTCOME: ${{ steps.clamav_daily.outcome }}
         run: |
           if [ "$MODE" = "full" ]; then
             outcome="$FULL_OUTCOME"
+            clamav_outcome="$CLAMAV_FULL_OUTCOME"
           else
             outcome="$DAILY_OUTCOME"
+            clamav_outcome="$CLAMAV_DAILY_OUTCOME"
           fi
           echo "Security mode: ${MODE:-unknown}"
           if [ "$MODE" != "full" ]; then
             echo "Security changed files: ${CHANGED_COUNT:-0}"
           fi
           echo "Security scan outcome: ${outcome:-not-run}"
+          echo "ClamAV scan outcome: ${clamav_outcome:-not-run}"
 
       - name: Resolve metadata scope
         id: metadata_scope
@@ -308,6 +343,14 @@ jobs:
         with:
           name: security-report
           path: security-report.json
+
+      - name: Upload ClamAV report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: clamav-report
+          path: clamav-report.txt
+          if-no-files-found: ignore
 
       - name: Upload metadata compliance report
         if: always()

--- a/.github/workflows/sync-data.yml
+++ b/.github/workflows/sync-data.yml
@@ -227,8 +227,8 @@ jobs:
           fi
 
           {
-            git -C skills diff --name-only --diff-filter=AM | grep '/SKILL.md$' || true
-            git -C skills ls-files --others --exclude-standard | grep '/SKILL.md$' || true
+            git -C skills diff --name-only --diff-filter=AM || true
+            git -C skills ls-files --others --exclude-standard || true
           } | sort -u > "$FILE_LIST"
 
           COUNT=$(wc -l < "$FILE_LIST" | tr -d '[:space:]')
@@ -239,7 +239,7 @@ jobs:
           echo "mode=daily-incremental" >> "$GITHUB_OUTPUT"
           echo "file_list=$FILE_LIST" >> "$GITHUB_OUTPUT"
           echo "changed_count=$COUNT" >> "$GITHUB_OUTPUT"
-          echo "Security scope: daily-incremental ($COUNT files)"
+          echo "Security scope: daily-incremental ($COUNT archive files)"
 
       - name: Security scan (skills full)
         if: steps.security_scope.outputs.mode == 'full'

--- a/docs/plan/malware-supply-chain-remediation-spec.md
+++ b/docs/plan/malware-supply-chain-remediation-spec.md
@@ -1,0 +1,395 @@
+# Malware Supply Chain Remediation Spec
+
+## Status
+
+Draft for immediate implementation.
+
+## Incident
+
+Three public issues report that published registry artifacts contain malware or
+malware-like exploit payloads:
+
+- Main artifact issue: https://github.com/majiayu000/claude-skill-registry/issues/27
+- Core pipeline issue: https://github.com/majiayu000/claude-skill-registry-core/issues/43
+- Data archive issue: https://github.com/majiayu000/claude-skill-registry-data/issues/2
+
+Confirmed local and remote evidence:
+
+- `claude-skill-registry` publishes
+  `skills/other/other/php-code-injection/SKILL.md`.
+- `claude-skill-registry-data` stores the same archive as
+  `other/other/php-code-injection/SKILL.md`.
+- Its metadata points to `blacklanternsecurity/red-run` at
+  `skills/web/php-code-injection/SKILL.md`.
+- Its metadata is `license: NOASSERTION`, `distribution: restricted`, and
+  `security_status: null`.
+- Text-only inspection finds repeated high-risk shell and webshell execution
+  patterns in the published `SKILL.md`.
+
+Not yet independently confirmed:
+
+- The exact Windows Defender signatures listed by the reporter. Local macOS
+  did not have an AV engine such as `clamscan` or `yara` available during
+  initial triage.
+
+## Severity
+
+P0 supply chain incident.
+
+Reason: generated public artifacts can place AV-triggering payloads onto user
+machines during clone, pull, or download. This is higher priority than normal
+metadata correctness, catalog quality, or PR intake work.
+
+## Scope
+
+In scope:
+
+1. Stop the pipeline from re-publishing known malicious or high-risk sources.
+2. Remove known bad archived directories from `claude-skill-registry-data`.
+3. Regenerate and publish `claude-skill-registry` from clean `core + data`.
+4. Make the core security gate fail closed when malware or blocked sources are
+   detected.
+5. Preserve evidence and provide issue updates with verified facts.
+
+Out of scope for the first emergency fix:
+
+- Proving every reporter AV signature with the same engine.
+- Rewriting the discovery architecture.
+- Normal catalog quality scoring.
+- Third-party commercial scoring actions.
+
+## Repository Routing
+
+Follow the core-first policy:
+
+- `claude-skill-registry-core` owns blocklist policy, scanner behavior,
+  download filtering, workflow gates, index generation, and publish
+  orchestration.
+- `claude-skill-registry-data` owns deleting archived bad skill directories.
+- `claude-skill-registry` is a merged artifact. Do not hand-edit generated
+  `skills/**`, `registry.json`, `registry_summary.json`, `docs/search-index.json`,
+  `docs/stats.json`, or `docs/categories/**`.
+
+Main is fixed by re-publishing from clean core and data outputs.
+
+## Known Bad Inputs
+
+Initial source repo blocklist, based on issue #27:
+
+```json
+[
+  "blacklanternsecurity/red-run",
+  "SnailSploit/Claude-Red",
+  "trilwu/secskills",
+  "macaugh/super-rouge-hunter-skills",
+  "zebbern/SecOps-CLI-Guides",
+  "AgentSecOps/SecOpsAgentKit",
+  "openclaw/skills",
+  "YPYT1/All-skills",
+  "aifinlab/FinClaw"
+]
+```
+
+Initial published artifact paths reported by issue #27:
+
+```text
+skills/other/other/lfi/
+skills/other/other/sql-injection-stacked/
+skills/other/other/offensive-sqli/
+skills/security/testing-web-applications-trilwu-secskills/
+skills/security/testing-web-applications/
+skills/other/payload-generation-macaugh-super-rouge-hunter-s-2/
+skills/other/payload-generation-macaugh-super-rouge-hunter-s/
+skills/other/payload-generation/
+skills/design/establishing-persistence-trilwu-secskills/
+skills/design/establishing-persistence/
+skills/data/enumerating-network-services/
+skills/other/other/file-upload-bypass/
+skills/other/other/database-enumeration/
+skills/other/other/php-code-injection/
+skills/other/other/smb-share-webshell/
+skills/other/oscp-cheat-sheet-zebbern-secops-cli-guides-2/
+skills/other/oscp-cheat-sheet-zebbern-secops-cli-guides/
+skills/other/oscp-cheat-sheet/
+skills/data/network-netcat/
+skills/other/network-netcat-agentsecops-secopsagentkit-2/
+skills/other/network-netcat-agentsecops-secopsagentkit/
+skills/other/network-netcat/
+skills/data/oscp-cheat-sheet/
+skills/other/amir/
+skills/data/amir/
+skills/data/clawbhub/
+skills/other/other/codingagent/
+skills/other/other/autoupdater/
+skills/other/other/summarize-aifinlab-finclaw/
+skills/data/payload-generation/
+```
+
+For `claude-skill-registry-data`, strip the leading `skills/` path prefix.
+These paths are the reporter-confirmed incident set. The remediation cleanup
+must go further: delete every archive directory whose `metadata.json` references
+one of the blocked source repos above. The first cleanup pass found the 30
+reported paths plus 775 additional directories from the same blocked sources.
+
+## Current Gap
+
+The existing `scripts/security_scanner.py` is useful but insufficient:
+
+- It is a custom pattern scanner, not an AV or malware signature engine.
+- The `sync-data` workflow currently runs the scanner with `--report-only`.
+- The scanner step uses `continue-on-error: true`.
+- `security_status: null` and restricted metadata can still reach generated
+  catalog artifacts.
+
+This means the pipeline can produce a report while still continuing to publish.
+For this incident, security failures must block downstream rebuild and publish
+steps.
+
+## Requirements
+
+### R1. Emergency publish freeze
+
+Disable or pause workflows that can regenerate and publish contaminated
+artifacts until the blocklist and removal PRs are ready:
+
+- `claude-skill-registry-core/.github/workflows/sync-data.yml`
+- `claude-skill-registry-core/.github/workflows/build-index.yml`
+- `claude-skill-registry/.github/workflows/publish-from-core.yml`
+
+No registry generation PR should be merged during the freeze unless it is part
+of this remediation.
+
+### R2. Source blocklist
+
+Add a core-owned blocklist, recommended path:
+
+```text
+sources/security_blocklist.json
+```
+
+Required fields:
+
+- `repo`: GitHub `owner/name`, case-insensitive match.
+- `reason`: short human-readable reason.
+- `source_issue`: GitHub issue URL or incident note.
+- `action`: initially only `reject`.
+- `added_at`: ISO date.
+
+The downloader must reject any candidate whose repo matches the blocklist before
+network download or archive write. Rejected candidates must be counted in
+`failure_report.json` as `blocked_source`.
+
+### R3. Restricted and unknown distribution gate
+
+Automatic publish must not include new entries when metadata has:
+
+- `license: NOASSERTION`
+- `distribution: restricted`
+- missing or null `security_status`
+
+Emergency behavior:
+
+- Existing restricted entries may remain only if they are not in the incident
+  blocklist and do not fail scanner gates.
+- New or changed restricted entries must go to quarantine or fail the job until
+  manually reviewed.
+
+Recommended quarantine manifest:
+
+```text
+sources/security_quarantine.json
+```
+
+### R4. Scanner must fail closed
+
+For publish workflows, scanner failures must stop rebuild and publish:
+
+- Remove `--report-only` from blocking scan paths, or add an explicit
+  `--fail-on-error` mode.
+- Remove `continue-on-error: true` from the blocking gate.
+- Keep advisory scans only for non-publish PR reports.
+- `check_sync_pipeline_health.py` must fail if `security-report.json` is missing,
+  invalid, or has `failed > 0` for a publish run.
+
+### R5. Malware engine gate
+
+Add at least one AV or signature-backed scan in core CI before publish.
+
+Minimum acceptable first implementation:
+
+- Install and run ClamAV in the sync workflow.
+- Scan changed archived files on daily runs.
+- Scan the full archive on full runs and before unfreezing publish.
+- Save the scanner output as a workflow artifact.
+- Treat scanner process errors or positive detections as publish-blocking.
+
+Follow-up implementation:
+
+- Add YARA support for repo-owned signatures.
+- Run a Windows Defender validation job for the known affected paths if a
+  Windows runner is available.
+
+### R6. Data archive cleanup
+
+Delete all archive directories from `claude-skill-registry-data` whose
+`metadata.json` references one of the blocked source repos.
+
+Validation must prove:
+
+- Each reporter-listed data path is absent.
+- No metadata in data references the initial 9 blocked repos.
+- No `SKILL.md` under data contains the known affected directory names after
+  cleanup.
+
+### R7. Main artifact regeneration
+
+After core and data are clean:
+
+1. Run the canonical publish flow:
+   `core sync-data -> data commit -> core metadata commit -> core build-index -> main publish-from-core`.
+2. Verify `claude-skill-registry/provenance/merge-source.json` points to the
+   clean core and data commits.
+3. Verify all known `skills/**` affected paths are absent from main.
+4. Verify `registry.json`, `registry_summary.json`, `docs/search-index.json`,
+   `docs/stats.json`, and `docs/categories/**` do not index known affected
+   skill IDs or blocked repos.
+
+### R8. Issue communication
+
+Post one concise update to each issue after the emergency PRs are opened, and
+again after remediation is verified.
+
+The update must distinguish:
+
+- Confirmed artifact existence.
+- Confirmed pipeline gap.
+- Unconfirmed exact third-party AV signatures, unless independently reproduced.
+- Exact PRs and commits used for removal and gate hardening.
+
+## Implementation Plan
+
+### Phase 0. Freeze
+
+1. Disable or pause publish-generating workflows.
+2. Record the disabled workflow names and timestamps.
+3. Announce that remediation is in progress on issues #27, #43, and data #2.
+
+### Phase 1. Core hardening PR
+
+1. Add `sources/security_blocklist.json`.
+2. Wire blocklist checks into `scripts/sync_and_download.py`.
+3. Add unit tests in `tests/test_sync_and_download.py`.
+4. Update `scripts/security_scanner.py` or `scripts/check_sync_pipeline_health.py`
+   so failed scan reports block publish.
+5. Update `.github/workflows/sync-data.yml` to use the blocking gate.
+6. Add tests in `tests/test_security_scanner.py` and
+   `tests/test_check_sync_pipeline_health.py`.
+
+### Phase 2. Data cleanup PR
+
+1. Delete all data archive directories from the 9 blocked source repos.
+2. Add a cleanup verification script or one-off checked command documented in
+   the PR body.
+3. Verify no metadata references the blocked repos.
+
+### Phase 3. Full scan and rebuild
+
+1. Run the core test suite.
+2. Run a full scanner pass over the data archive.
+3. Rebuild catalog indexes from the cleaned data.
+4. Publish main from clean core and data commits.
+
+### Phase 4. Unfreeze
+
+1. Re-enable workflows only after the blocking gates are active.
+2. Trigger one controlled sync run.
+3. Confirm no blocked source is downloaded or indexed.
+
+## Validation Commands
+
+Core PR:
+
+```bash
+python -m pytest tests/test_sync_and_download.py tests/test_security_scanner.py tests/test_check_sync_pipeline_health.py
+python -m pytest
+```
+
+Data cleanup:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+
+blocked_repos = {
+    "blacklanternsecurity/red-run",
+    "SnailSploit/Claude-Red",
+    "trilwu/secskills",
+    "macaugh/super-rouge-hunter-skills",
+    "zebbern/SecOps-CLI-Guides",
+    "AgentSecOps/SecOpsAgentKit",
+    "openclaw/skills",
+    "YPYT1/All-skills",
+    "aifinlab/FinClaw",
+}
+
+root = Path("claude-skill-registry-data")
+hits = []
+for metadata in root.rglob("metadata.json"):
+    text = metadata.read_text(encoding="utf-8", errors="replace")
+    if any(repo in text for repo in blocked_repos):
+        hits.append(str(metadata))
+
+if hits:
+    raise SystemExit("blocked repo references remain:\n" + "\n".join(hits))
+
+print("blocked repo references absent")
+PY
+```
+
+Main publish verification:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+
+known_paths = [
+    "skills/other/other/php-code-injection",
+    "skills/other/other/lfi",
+    "skills/other/other/sql-injection-stacked",
+    "skills/other/other/offensive-sqli",
+    "skills/other/other/file-upload-bypass",
+    "skills/other/other/database-enumeration",
+    "skills/other/other/smb-share-webshell",
+]
+
+root = Path("claude-skill-registry")
+remaining = [path for path in known_paths if (root / path).exists()]
+if remaining:
+    raise SystemExit("known affected paths remain:\n" + "\n".join(remaining))
+
+print("known affected main paths absent")
+PY
+```
+
+## Done When
+
+- Publish-generating workflows are frozen until remediation PRs are ready.
+- Core rejects the initial 9 blocked repos before download.
+- Publish workflows fail closed on security scan failure.
+- Data no longer contains the reporter-listed paths or any metadata reference to
+  the 9 blocked source repos.
+- Main has been regenerated from clean core and data commits.
+- All known affected main paths are absent.
+- Issues #27, #43, and data #2 have verified remediation comments.
+
+## Rollback
+
+If the new gate blocks legitimate publish work:
+
+1. Keep the blocklist active.
+2. Revert only the scanner strictness change behind a temporary explicit
+   `SECURITY_GATE_ADVISORY_ONLY` workflow input.
+3. Do not re-enable automatic publish until the blocklist and data cleanup remain
+   in place.
+4. Open a follow-up issue for any false positive with the exact path, repo,
+   scanner reason, and reviewer decision.

--- a/scripts/check_sync_pipeline_health.py
+++ b/scripts/check_sync_pipeline_health.py
@@ -56,6 +56,10 @@ def _validate_security_report(report_path: Path) -> list[str]:
     if invalid_keys:
         return [f"security report has non-integer fields: {', '.join(sorted(invalid_keys))}"]
 
+    failed = int(payload.get("failed", 0))
+    if failed > 0:
+        return [f"security report contains failed scans: failed={failed}"]
+
     return []
 
 

--- a/scripts/security_blocklist.py
+++ b/scripts/security_blocklist.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Shared security blocklist helpers for source repositories."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT_DIR = SCRIPT_DIR.parent
+DEFAULT_BLOCKLIST_PATH = ROOT_DIR / "sources" / "security_blocklist.json"
+
+
+def normalize_repo_id(repo: str) -> str:
+    """Normalize GitHub repo identifiers to lowercase owner/name form."""
+    repo = (repo or "").strip()
+    for prefix in ("https://github.com/", "http://github.com/", "github.com/"):
+        if repo.startswith(prefix):
+            repo = repo[len(prefix):]
+            break
+    repo = repo.split("/tree/")[0]
+    repo = repo.split("/blob/")[0]
+    repo = repo.strip("/")
+    parts = [part for part in repo.split("/") if part]
+    if len(parts) >= 2:
+        return f"{parts[0]}/{parts[1]}".lower()
+    return repo.lower()
+
+
+def load_security_blocklist(path: Path | None = None) -> dict[str, dict[str, Any]]:
+    """Load blocked source repos keyed by normalized repo id."""
+    blocklist_path = path or DEFAULT_BLOCKLIST_PATH
+    if not blocklist_path.exists():
+        raise FileNotFoundError(f"security blocklist is missing: {blocklist_path}")
+
+    payload = json.loads(blocklist_path.read_text(encoding="utf-8"))
+    entries = payload.get("blocked_repos", payload) if isinstance(payload, dict) else payload
+    if not isinstance(entries, list):
+        raise ValueError(f"security blocklist must be a list: {blocklist_path}")
+
+    blocked: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError(f"security blocklist entry must be an object: {entry!r}")
+        repo = normalize_repo_id(str(entry.get("repo") or ""))
+        if not repo:
+            raise ValueError(f"security blocklist entry missing repo: {entry!r}")
+        action = str(entry.get("action") or "reject").strip().lower()
+        if action != "reject":
+            raise ValueError(f"unsupported security blocklist action for {repo}: {action}")
+        blocked[repo] = {**entry, "repo": repo, "action": action}
+    return blocked
+
+
+def blocked_repo_entry(repo: str, blocklist: dict[str, dict[str, Any]]) -> dict[str, Any] | None:
+    """Return the blocklist entry for repo, if any."""
+    return blocklist.get(normalize_repo_id(repo))

--- a/scripts/security_scanner.py
+++ b/scripts/security_scanner.py
@@ -12,6 +12,8 @@ from typing import Dict, List, Tuple
 import jsonschema
 import yaml
 
+from security_blocklist import blocked_repo_entry, load_security_blocklist
+
 # Load schema
 SCHEMA_PATH = Path(__file__).parent.parent / "schema" / "skill.schema.json"
 
@@ -163,6 +165,7 @@ class SecurityScanner:
     def __init__(self, schema_path: str = None):
         self.schema_path = schema_path or SCHEMA_PATH
         self.schema = self._load_schema()
+        self.security_blocklist = load_security_blocklist()
         self.issues = []
 
     def _load_schema(self) -> dict:
@@ -223,13 +226,16 @@ class SecurityScanner:
         # 5. Check bundled scripts and reference implementations
         self._scan_bundled_files(skill_path.parent)
 
-        # 6. Prompt injection detection
+        # 6. Block known malicious or high-risk source repositories
+        self._scan_blocked_source(skill_path)
+
+        # 7. Prompt injection detection
         self._detect_prompt_injection(content)
 
-        # 7. Hardcoded credentials detection
+        # 8. Hardcoded credentials detection
         self._detect_credentials(content, skill_path)
 
-        # 8. Obfuscation-to-execution chains
+        # 9. Obfuscation-to-execution chains
         self._detect_obfuscation_exec(content, skill_path)
 
         # Determine if safe (only fail on truly dangerous issues)
@@ -239,6 +245,8 @@ class SecurityScanner:
             'dangerous_pattern',
             'file_too_large',
             'hardcoded_credential',
+            'metadata_read_error',
+            'blocked_source',
         }
         has_critical = any(
             i['severity'] == 'error' and i.get('type') in critical_types
@@ -368,6 +376,39 @@ class SecurityScanner:
             self._detect_obfuscation_exec(content, bundled_file)
         except (OSError, UnicodeDecodeError):
             pass
+
+    def _scan_blocked_source(self, skill_path: Path):
+        """Fail archived skills sourced from a repo on the security blocklist."""
+        metadata_path = skill_path.parent / "metadata.json"
+        if not metadata_path.exists():
+            return
+
+        try:
+            metadata = json.loads(metadata_path.read_text(encoding='utf-8'))
+        except (OSError, json.JSONDecodeError) as exc:
+            self.issues.append({
+                'severity': 'error',
+                'type': 'metadata_read_error',
+                'file': str(metadata_path),
+                'message': f'Cannot read metadata for blocklist scan: {exc}',
+            })
+            return
+
+        repo = str(metadata.get("repo") or "")
+        blocked_entry = blocked_repo_entry(repo, self.security_blocklist)
+        if not blocked_entry:
+            return
+
+        self.issues.append({
+            'severity': 'error',
+            'type': 'blocked_source',
+            'file': str(metadata_path),
+            'repo': blocked_entry["repo"],
+            'message': (
+                f'Skill source repo "{blocked_entry["repo"]}" is blocked: '
+                f'{blocked_entry.get("reason", "security blocklist")}'
+            ),
+        })
 
     def _detect_credentials(self, content: str, file_path: Path):
         """Detect hardcoded credentials and secret key formats"""

--- a/scripts/security_scanner.py
+++ b/scripts/security_scanner.py
@@ -475,8 +475,9 @@ class SecurityScanner:
 
 def resolve_scan_file_list(skills_dir: Path, file_list_path: Path) -> List[Path]:
     """
-    Resolve a newline-delimited file list into SKILL.md paths under skills_dir.
-    Lines may be absolute or relative paths.
+    Resolve a newline-delimited archive file list into SKILL.md paths under skills_dir.
+    Lines may be absolute or relative paths. Non-SKILL.md files map to the
+    nearest parent directory that owns a SKILL.md.
     """
     if not file_list_path.exists():
         return []
@@ -484,6 +485,16 @@ def resolve_scan_file_list(skills_dir: Path, file_list_path: Path) -> List[Path]
     skills_root = skills_dir.resolve()
     selected = []
     seen = set()
+
+    def owning_skill_file(candidate: Path) -> Path | None:
+        current = candidate if candidate.is_dir() else candidate.parent
+        while True:
+            skill_file = current / "SKILL.md"
+            if skill_file.is_file():
+                return skill_file
+            if current == skills_root:
+                return None
+            current = current.parent
 
     for raw in file_list_path.read_text(encoding='utf-8', errors='ignore').splitlines():
         line = raw.strip()
@@ -501,16 +512,18 @@ def resolve_scan_file_list(skills_dir: Path, file_list_path: Path) -> List[Path]
             # Ignore paths outside scan root for safety.
             continue
 
-        if candidate.name != "SKILL.md":
-            continue
-        if not candidate.exists() or not candidate.is_file():
+        if not candidate.exists():
             continue
 
-        key = str(candidate)
+        skill_file = candidate if candidate.name == "SKILL.md" else owning_skill_file(candidate)
+        if not skill_file:
+            continue
+
+        key = str(skill_file)
         if key in seen:
             continue
         seen.add(key)
-        selected.append(candidate)
+        selected.append(skill_file)
 
     return selected
 

--- a/scripts/sync_and_download.py
+++ b/scripts/sync_and_download.py
@@ -431,6 +431,52 @@ def filter_pending_skills(
     return filtered, skipped, skipped_rows
 
 
+def validate_existing_archive_sources(
+    output_dir: Path,
+    security_blocklist: dict[str, dict],
+) -> None:
+    """Fail when existing archived skills are sourced from blocked repos."""
+    exclude = {".git", ".github-skills", ".template", ".templates", ".attic"}
+    blocked_archives: list[str] = []
+    metadata_errors: list[str] = []
+
+    for dirpath, dirnames, filenames in os.walk(output_dir):
+        dirnames[:] = [dirname for dirname in dirnames if dirname not in exclude]
+        if "metadata.json" not in filenames or "SKILL.md" not in filenames:
+            continue
+
+        meta_path = Path(dirpath) / "metadata.json"
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            metadata_errors.append(f"{meta_path}: {exc}")
+            continue
+
+        repo = str(meta.get("repo") or "")
+        blocked_entry = blocked_repo_entry(repo, security_blocklist)
+        if not blocked_entry:
+            continue
+
+        blocked_archives.append(
+            f"{meta_path.parent}: {blocked_entry['repo']} "
+            f"({blocked_entry.get('reason', 'security blocklist')})"
+        )
+
+    if metadata_errors:
+        sample = "\n".join(metadata_errors[:20])
+        raise RuntimeError(
+            "Cannot validate existing archive metadata for security blocklist:\n"
+            f"{sample}"
+        )
+
+    if blocked_archives:
+        sample = "\n".join(blocked_archives[:50])
+        raise RuntimeError(
+            "Existing archive contains blocked source repos:\n"
+            f"{sample}"
+        )
+
+
 def build_branch_probe_order(
     repo: str,
     preferred_branch_by_repo: dict[str, str],
@@ -640,6 +686,7 @@ async def download_skills(
     )
     security_blocklist = load_security_blocklist()
     logger.info("Security blocklist loaded: %s repos", len(security_blocklist))
+    validate_existing_archive_sources(output_dir, security_blocklist)
 
     # Check existing (across all categories)
     exclude = {".git", ".github-skills", ".template", ".templates", ".attic"}

--- a/scripts/sync_and_download.py
+++ b/scripts/sync_and_download.py
@@ -42,6 +42,7 @@ sys.path.insert(0, str(ROOT_DIR))
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from discover_by_topic import GitHubTopicDiscovery
+from security_blocklist import blocked_repo_entry, load_security_blocklist
 from utils import build_legal_metadata, build_skill_key, ensure_unique_dir, normalize_name
 
 from crawler.skillsmp_sync import SkillsMPSync
@@ -637,6 +638,8 @@ async def download_skills(
         len(manifest_entries),
         manifest_file,
     )
+    security_blocklist = load_security_blocklist()
+    logger.info("Security blocklist loaded: %s repos", len(security_blocklist))
 
     # Check existing (across all categories)
     exclude = {".git", ".github-skills", ".template", ".templates", ".attic"}
@@ -1017,6 +1020,13 @@ async def download_skills(
         if not repo:
             failures["no_repo"].append(name)
             add_observation(skill, outcome="failed", failure_reason="no_repo")
+            return False
+        blocked_entry = blocked_repo_entry(repo, security_blocklist)
+        if blocked_entry:
+            reason = blocked_entry.get("reason") or "blocked source repo"
+            failures["blocked_source"].append(f"{repo}: {name} ({reason})")
+            add_observation(skill, outcome="failed", failure_reason="blocked_source")
+            logger.warning("Blocked security-listed source repo: %s (%s)", repo, name)
             return False
 
         manifest_key = build_manifest_key(repo, path, name, category)

--- a/sources/security_blocklist.json
+++ b/sources/security_blocklist.json
@@ -1,0 +1,69 @@
+{
+  "version": 1,
+  "updated_at": "2026-05-04",
+  "blocked_repos": [
+    {
+      "repo": "blacklanternsecurity/red-run",
+      "reason": "Reported malware/backdoor payloads in published SKILL.md artifacts.",
+      "source_issue": "https://github.com/majiayu000/claude-skill-registry/issues/27",
+      "action": "reject",
+      "added_at": "2026-05-04"
+    },
+    {
+      "repo": "SnailSploit/Claude-Red",
+      "reason": "Reported malware/backdoor payloads in published SKILL.md artifacts.",
+      "source_issue": "https://github.com/majiayu000/claude-skill-registry/issues/27",
+      "action": "reject",
+      "added_at": "2026-05-04"
+    },
+    {
+      "repo": "trilwu/secskills",
+      "reason": "Reported malware/backdoor payloads in published SKILL.md artifacts.",
+      "source_issue": "https://github.com/majiayu000/claude-skill-registry/issues/27",
+      "action": "reject",
+      "added_at": "2026-05-04"
+    },
+    {
+      "repo": "macaugh/super-rouge-hunter-skills",
+      "reason": "Reported malware/backdoor payloads in published SKILL.md artifacts.",
+      "source_issue": "https://github.com/majiayu000/claude-skill-registry/issues/27",
+      "action": "reject",
+      "added_at": "2026-05-04"
+    },
+    {
+      "repo": "zebbern/SecOps-CLI-Guides",
+      "reason": "Reported reverse-shell payloads in published SKILL.md artifacts.",
+      "source_issue": "https://github.com/majiayu000/claude-skill-registry/issues/27",
+      "action": "reject",
+      "added_at": "2026-05-04"
+    },
+    {
+      "repo": "AgentSecOps/SecOpsAgentKit",
+      "reason": "Reported reverse-shell payloads in published SKILL.md artifacts.",
+      "source_issue": "https://github.com/majiayu000/claude-skill-registry/issues/27",
+      "action": "reject",
+      "added_at": "2026-05-04"
+    },
+    {
+      "repo": "openclaw/skills",
+      "reason": "Reported AI-agent trojan payloads in published SKILL.md artifacts.",
+      "source_issue": "https://github.com/majiayu000/claude-skill-registry/issues/27",
+      "action": "reject",
+      "added_at": "2026-05-04"
+    },
+    {
+      "repo": "YPYT1/All-skills",
+      "reason": "Reported AI-agent trojan payloads in published SKILL.md artifacts.",
+      "source_issue": "https://github.com/majiayu000/claude-skill-registry/issues/27",
+      "action": "reject",
+      "added_at": "2026-05-04"
+    },
+    {
+      "repo": "aifinlab/FinClaw",
+      "reason": "Reported AI-agent trojan payloads in published SKILL.md artifacts.",
+      "source_issue": "https://github.com/majiayu000/claude-skill-registry/issues/27",
+      "action": "reject",
+      "added_at": "2026-05-04"
+    }
+  ]
+}

--- a/tests/test_check_sync_pipeline_health.py
+++ b/tests/test_check_sync_pipeline_health.py
@@ -58,3 +58,23 @@ def test_validate_pipeline_health_requires_report_when_security_passes(tmp_path)
     assert errors == [
         f"required security report is missing: {tmp_path / 'security-report.json'}"
     ]
+
+
+def test_validate_pipeline_health_rejects_failed_security_report(tmp_path):
+    report_path = tmp_path / "security-report.json"
+    report_path.write_text(
+        json.dumps({"total": 3, "passed": 2, "failed": 1}),
+        encoding="utf-8",
+    )
+
+    errors = validate_pipeline_health(
+        PipelineHealthInput(
+            discovery_outcome="success",
+            download_outcome="success",
+            security_outcome="success",
+            security_report=report_path,
+            require_security_report=True,
+        )
+    )
+
+    assert errors == ["security report contains failed scans: failed=1"]

--- a/tests/test_security_blocklist.py
+++ b/tests/test_security_blocklist.py
@@ -1,0 +1,49 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def load_module():
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "security_blocklist.py"
+    spec = importlib.util.spec_from_file_location("security_blocklist_module", module_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_load_security_blocklist_fails_when_file_missing(tmp_path):
+    module = load_module()
+
+    with pytest.raises(FileNotFoundError):
+        module.load_security_blocklist(tmp_path / "missing.json")
+
+
+def test_blocked_repo_entry_normalizes_urls(tmp_path):
+    module = load_module()
+    blocklist_path = tmp_path / "security_blocklist.json"
+    blocklist_path.write_text(
+        """
+{
+  "blocked_repos": [
+    {
+      "repo": "Owner/Repo",
+      "reason": "test",
+      "action": "reject"
+    }
+  ]
+}
+""",
+        encoding="utf-8",
+    )
+
+    blocklist = module.load_security_blocklist(blocklist_path)
+    entry = module.blocked_repo_entry(
+        "https://github.com/owner/repo/blob/main/SKILL.md",
+        blocklist,
+    )
+
+    assert entry is not None
+    assert entry["repo"] == "owner/repo"

--- a/tests/test_security_scanner.py
+++ b/tests/test_security_scanner.py
@@ -98,6 +98,35 @@ description: Demo skill used to verify fail-closed metadata scanning.
     assert any(issue["type"] == "metadata_read_error" for issue in issues)
 
 
+def test_file_list_maps_changed_support_file_to_owner_skill(tmp_path):
+    module = load_module()
+    skill_dir = tmp_path / "demo"
+    examples_dir = skill_dir / "examples"
+    examples_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: demo
+description: Demo skill used to verify file list ownership.
+---
+
+# Demo
+""",
+        encoding="utf-8",
+    )
+    (skill_dir / "metadata.json").write_text("{}", encoding="utf-8")
+    (examples_dir / "install.sh").write_text("echo ok\n", encoding="utf-8")
+    file_list = tmp_path / "changed-files.txt"
+    file_list.write_text(
+        "demo/examples/install.sh\n"
+        "demo/metadata.json\n",
+        encoding="utf-8",
+    )
+
+    selected = module.resolve_scan_file_list(tmp_path, file_list)
+
+    assert selected == [(skill_dir / "SKILL.md").resolve()]
+
+
 def test_scanner_checks_all_archived_support_dirs(tmp_path):
     module = load_module()
     skill_dir = tmp_path / "demo"

--- a/tests/test_security_scanner.py
+++ b/tests/test_security_scanner.py
@@ -1,9 +1,14 @@
 import importlib.util
+import json
+import sys
 from pathlib import Path
 
 
 def load_module():
-    module_path = Path(__file__).resolve().parents[1] / "scripts" / "security_scanner.py"
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    module_path = scripts_dir / "security_scanner.py"
     spec = importlib.util.spec_from_file_location("security_scanner_module", module_path)
     assert spec is not None
     module = importlib.util.module_from_spec(spec)
@@ -42,6 +47,55 @@ description: Demo skill used to verify bundled reference scanning.
         and "references/helper.py" in issue.get("file", "")
         for issue in issues
     )
+
+
+def test_scanner_blocks_security_listed_source_repo(tmp_path):
+    module = load_module()
+    skill_dir = tmp_path / "php-code-injection"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: php-code-injection
+description: Demo skill used to verify source blocklist scanning.
+---
+
+# Demo
+""",
+        encoding="utf-8",
+    )
+    (skill_dir / "metadata.json").write_text(
+        json.dumps({"repo": "blacklanternsecurity/red-run"}),
+        encoding="utf-8",
+    )
+
+    scanner = module.SecurityScanner()
+    is_safe, issues = scanner.scan_file(skill_dir / "SKILL.md")
+
+    assert is_safe is False
+    assert any(issue["type"] == "blocked_source" for issue in issues)
+
+
+def test_scanner_fails_closed_when_metadata_is_unreadable(tmp_path):
+    module = load_module()
+    skill_dir = tmp_path / "bad-metadata"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: bad-metadata
+description: Demo skill used to verify fail-closed metadata scanning.
+---
+
+# Demo
+""",
+        encoding="utf-8",
+    )
+    (skill_dir / "metadata.json").write_text("{", encoding="utf-8")
+
+    scanner = module.SecurityScanner()
+    is_safe, issues = scanner.scan_file(skill_dir / "SKILL.md")
+
+    assert is_safe is False
+    assert any(issue["type"] == "metadata_read_error" for issue in issues)
 
 
 def test_scanner_checks_all_archived_support_dirs(tmp_path):

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -115,6 +115,40 @@ def test_download_blocks_security_listed_source_repo(tmp_path, monkeypatch):
     assert failure_report["failure_reasons"]["blocked_source"] == 1
 
 
+def test_existing_blocked_archive_fails_before_existing_skip(tmp_path, monkeypatch):
+    module = load_module()
+    registry_path = tmp_path / "registry.json"
+    output_dir = tmp_path / "skills"
+    skill_dir = output_dir / "other" / "php-code-injection"
+    failure_report_path = tmp_path / "failure_report.json"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: php-code-injection
+description: Existing blocked archive.
+---
+
+# Demo
+""",
+        encoding="utf-8",
+    )
+    (skill_dir / "metadata.json").write_text(
+        json.dumps({"repo": "blacklanternsecurity/red-run"}),
+        encoding="utf-8",
+    )
+    registry_path.write_text(json.dumps({"skills": []}), encoding="utf-8")
+    install_fake_aiohttp(monkeypatch, {})
+
+    with pytest.raises(RuntimeError, match="Existing archive contains blocked source repos"):
+        asyncio.run(
+            module.download_skills(
+                registry_path,
+                output_dir,
+                failure_report_path=failure_report_path,
+            )
+        )
+
+
 def test_manifest_round_trip(tmp_path):
     module = load_module()
     manifest_path = tmp_path / "acquisition_manifest.json"

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -78,6 +78,43 @@ def test_should_fail_on_empty_download_only_when_all_attempts_fail():
     assert module.should_fail_on_empty_download({"downloaded": 0, "failed": 3, "skipped": 10}) is False
 
 
+def test_download_blocks_security_listed_source_repo(tmp_path, monkeypatch):
+    module = load_module()
+    registry_path = tmp_path / "registry.json"
+    output_dir = tmp_path / "skills"
+    failure_report_path = tmp_path / "failure_report.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "skills": [
+                    {
+                        "name": "php-code-injection",
+                        "repo": "blacklanternsecurity/red-run",
+                        "path": "skills/web/php-code-injection/SKILL.md",
+                        "category": "other",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    install_fake_aiohttp(monkeypatch, {})
+
+    stats = asyncio.run(
+        module.download_skills(
+            registry_path,
+            output_dir,
+            failure_report_path=failure_report_path,
+        )
+    )
+
+    assert stats["downloaded"] == 0
+    assert stats["failed"] == 1
+    assert not list(output_dir.rglob("SKILL.md"))
+    failure_report = json.loads(failure_report_path.read_text(encoding="utf-8"))
+    assert failure_report["failure_reasons"]["blocked_source"] == 1
+
+
 def test_manifest_round_trip(tmp_path):
     module = load_module()
     manifest_path = tmp_path / "acquisition_manifest.json"


### PR DESCRIPTION
## Summary

Emergency supply-chain hardening for the malware reports in:

- https://github.com/majiayu000/claude-skill-registry/issues/27
- https://github.com/majiayu000/claude-skill-registry-core/issues/43
- https://github.com/majiayu000/claude-skill-registry-data/issues/2

Changes:

- Add a core-owned security source blocklist for the 9 reported source repos.
- Reject blocklisted source repos during sync/download before network fetch or archive write.
- Fail security scanning when archived skill metadata points at a blocked source repo.
- Fail closed when metadata cannot be read during blocklist scanning.
- Make publish-path security scans blocking by removing report-only/continue-on-error behavior.
- Make pipeline health fail if `security-report.json` has failed scans.
- Add a publish-path ClamAV gate: full runs scan the archive; daily runs scan all newly added/modified archive files; reports are uploaded as artifacts.
- Add the incident remediation spec under `docs/plan/`.

## Validation

- `python -m pytest` -> 61 passed
- `git diff --check`
- Workflow YAML parse check -> `workflow_yaml_ok`
- Data cleanup validation in companion PR: 805 deleted skill directories, 0 remaining metadata refs to the blocked repos, 0 reporter-listed affected paths still present

## Notes

Publishing workflows are intentionally still frozen. After this and the data cleanup PR merge, main should be regenerated from clean core + data, not patched by hand.
