### PR TITLE
Block archived source path aliases

### DIFF
--- a/scripts/security_blocklist.py
+++ b/scripts/security_blocklist.py
@@ -56,3 +56,37 @@ def load_security_blocklist(path: Path | None = None) -> dict[str, dict[str, Any
 def blocked_repo_entry(repo: str, blocklist: dict[str, dict[str, Any]]) -> dict[str, Any] | None:
     """Return the blocklist entry for repo, if any."""
     return blocklist.get(normalize_repo_id(repo))
+
+
+def blocked_metadata_source(
+    metadata: dict[str, Any],
+    blocklist: dict[str, dict[str, Any]],
+) -> tuple[dict[str, Any], str] | None:
+    """Return the blocked repo entry and metadata field, if metadata identifies one."""
+    for field in (
+        "repo",
+        "source",
+        "source_url",
+        "github_url",
+        "repository",
+        "repository_url",
+        "html_url",
+        "url",
+    ):
+        value = metadata.get(field)
+        if not isinstance(value, str):
+            continue
+        entry = blocked_repo_entry(value, blocklist)
+        if entry:
+            return entry, field
+
+    for field in ("github_path", "path"):
+        value = metadata.get(field)
+        if not isinstance(value, str):
+            continue
+        normalized_path = value.strip().strip("/").lower()
+        for repo, entry in blocklist.items():
+            if normalized_path == repo or normalized_path.startswith(f"{repo}/"):
+                return entry, field
+
+    return None

--- a/scripts/security_scanner.py
+++ b/scripts/security_scanner.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Tuple
 import jsonschema
 import yaml
 
-from security_blocklist import blocked_repo_entry, load_security_blocklist
+from security_blocklist import blocked_metadata_source, load_security_blocklist
 
 # Load schema
 SCHEMA_PATH = Path(__file__).parent.parent / "schema" / "skill.schema.json"
@@ -394,16 +394,17 @@ class SecurityScanner:
             })
             return
 
-        repo = str(metadata.get("repo") or "")
-        blocked_entry = blocked_repo_entry(repo, self.security_blocklist)
-        if not blocked_entry:
+        blocked_source = blocked_metadata_source(metadata, self.security_blocklist)
+        if not blocked_source:
             return
+        blocked_entry, source_field = blocked_source
 
         self.issues.append({
             'severity': 'error',
             'type': 'blocked_source',
             'file': str(metadata_path),
             'repo': blocked_entry["repo"],
+            'metadata_field': source_field,
             'message': (
                 f'Skill source repo "{blocked_entry["repo"]}" is blocked: '
                 f'{blocked_entry.get("reason", "security blocklist")}'

--- a/scripts/sync_and_download.py
+++ b/scripts/sync_and_download.py
@@ -42,7 +42,7 @@ sys.path.insert(0, str(ROOT_DIR))
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from discover_by_topic import GitHubTopicDiscovery
-from security_blocklist import blocked_repo_entry, load_security_blocklist
+from security_blocklist import blocked_metadata_source, blocked_repo_entry, load_security_blocklist
 from utils import build_legal_metadata, build_skill_key, ensure_unique_dir, normalize_name
 
 from crawler.skillsmp_sync import SkillsMPSync
@@ -452,14 +452,14 @@ def validate_existing_archive_sources(
             metadata_errors.append(f"{meta_path}: {exc}")
             continue
 
-        repo = str(meta.get("repo") or "")
-        blocked_entry = blocked_repo_entry(repo, security_blocklist)
-        if not blocked_entry:
+        blocked_source = blocked_metadata_source(meta, security_blocklist)
+        if not blocked_source:
             continue
+        blocked_entry, source_field = blocked_source
 
         blocked_archives.append(
             f"{meta_path.parent}: {blocked_entry['repo']} "
-            f"({blocked_entry.get('reason', 'security blocklist')})"
+            f"via {source_field} ({blocked_entry.get('reason', 'security blocklist')})"
         )
 
     if metadata_errors:

--- a/tests/test_security_blocklist.py
+++ b/tests/test_security_blocklist.py
@@ -47,3 +47,27 @@ def test_blocked_repo_entry_normalizes_urls(tmp_path):
 
     assert entry is not None
     assert entry["repo"] == "owner/repo"
+
+
+def test_blocked_metadata_source_matches_github_path_prefix():
+    module = load_module()
+    blocklist = {
+        "openclaw/skills": {
+            "repo": "openclaw/skills",
+            "reason": "test",
+            "action": "reject",
+        }
+    }
+
+    result = module.blocked_metadata_source(
+        {
+            "repo": "blisspixel/primr",
+            "github_path": "openclaw/skills/primr-strategy",
+        },
+        blocklist,
+    )
+
+    assert result is not None
+    entry, field = result
+    assert entry["repo"] == "openclaw/skills"
+    assert field == "github_path"

--- a/tests/test_security_scanner.py
+++ b/tests/test_security_scanner.py
@@ -75,6 +75,42 @@ description: Demo skill used to verify source blocklist scanning.
     assert any(issue["type"] == "blocked_source" for issue in issues)
 
 
+def test_scanner_blocks_security_listed_github_path(tmp_path):
+    module = load_module()
+    skill_dir = tmp_path / "primr-strategy"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: primr-strategy
+description: Demo skill used to verify github_path blocklist scanning.
+---
+
+# Demo
+""",
+        encoding="utf-8",
+    )
+    (skill_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "repo": "blisspixel/primr",
+                "github_path": "openclaw/skills/primr-strategy",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    scanner = module.SecurityScanner()
+    is_safe, issues = scanner.scan_file(skill_dir / "SKILL.md")
+
+    assert is_safe is False
+    assert any(
+        issue["type"] == "blocked_source"
+        and issue["repo"] == "openclaw/skills"
+        and issue["metadata_field"] == "github_path"
+        for issue in issues
+    )
+
+
 def test_scanner_fails_closed_when_metadata_is_unreadable(tmp_path):
     module = load_module()
     skill_dir = tmp_path / "bad-metadata"

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -149,6 +149,38 @@ description: Existing blocked archive.
         )
 
 
+def test_existing_archive_blocks_security_listed_github_path(tmp_path):
+    module = load_module()
+    output_dir = tmp_path / "skills"
+    skill_dir = output_dir / "other" / "primr-strategy"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: primr-strategy
+description: Existing archive with blocked github_path.
+---
+
+# Demo
+""",
+        encoding="utf-8",
+    )
+    (skill_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "repo": "blisspixel/primr",
+                "github_path": "openclaw/skills/primr-strategy",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="Existing archive contains blocked source repos"):
+        module.validate_existing_archive_sources(
+            output_dir,
+            module.load_security_blocklist(),
+        )
+
+
 def test_manifest_round_trip(tmp_path):
     module = load_module()
     manifest_path = tmp_path / "acquisition_manifest.json"


### PR DESCRIPTION
## Summary
- block archived metadata whose github_path/path points into a security-blocklisted repo
- reuse the metadata source matcher in the scanner and sync validation
- add regressions for the primr/openclaw-style path alias case

## Verification
- python -m pytest
- git diff --check