### PR TITLE
test(utils): cover scripts/utils.py + add sources/*.json validator CLI

### DIFF
--- a/.github/workflows/validate-sources.yml
+++ b/.github/workflows/validate-sources.yml
@@ -1,0 +1,48 @@
+name: Validate Sources
+
+on:
+  pull_request:
+    paths:
+      - "sources/**"
+      - "scripts/validate_sources.py"
+      - "scripts/utils.py"
+      - "tests/test_utils.py"
+      - "tests/test_validate_sources.py"
+      - ".github/workflows/validate-sources.yml"
+  push:
+    branches: [main]
+    paths:
+      - "sources/**"
+      - "scripts/validate_sources.py"
+      - "scripts/utils.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-sources:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml jsonschema pytest
+
+      - name: Validate sources/*.json shape
+        run: |
+          # Errors fail the build; warnings only print so authored category
+          # drift does not break unrelated contributor PRs.
+          python scripts/validate_sources.py --sources-dir sources
+
+      - name: Run scripts/utils.py + validate_sources.py tests
+        run: |
+          python -m pytest tests/test_utils.py tests/test_validate_sources.py -v -p no:cacheprovider --override-ini="addopts="

--- a/scripts/download_v2.py
+++ b/scripts/download_v2.py
@@ -21,23 +21,24 @@ Example:
 """
 
 import asyncio
-import aiohttp
 import json
-import os
-from pathlib import Path
-from typing import Dict, List, Set, Tuple, Optional
-from datetime import datetime
-from collections import defaultdict
-import time
 import logging
+import os
+import time
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
 
+import aiohttp
 from utils import (
-    normalize_name,
-    ensure_unique_dir,
-    build_skill_key,
-    get_repo_suffix,
-    short_hash,
     build_legal_metadata,
+    build_skill_key,
+    ensure_unique_dir,
+    get_repo_suffix,
+    iter_source_skills,
+    normalize_name,
+    short_hash,
 )
 
 # Configuration
@@ -62,6 +63,21 @@ logging.basicConfig(
     ]
 )
 logger = logging.getLogger(__name__)
+
+
+def load_source_skills(sources_dir: Path) -> List[dict]:
+    """Load source rows, preserving source-level defaults such as top-level repo."""
+    skills: List[dict] = []
+    if not sources_dir.exists():
+        return skills
+    for source_file in sources_dir.glob("*.json"):
+        try:
+            with open(source_file, 'r') as f:
+                data = json.load(f)
+            skills.extend(iter_source_skills(data))
+        except Exception as e:
+            logger.warning(f"Failed to load {source_file}: {e}")
+    return skills
 
 
 class SkillRegistry:
@@ -402,14 +418,7 @@ async def main():
 
     # Load from sources
     sources_dir = registry_dir / "sources"
-    if sources_dir.exists():
-        for source_file in sources_dir.glob("*.json"):
-            try:
-                with open(source_file, 'r') as f:
-                    data = json.load(f)
-                    skills.extend(data.get("skills", []))
-            except Exception as e:
-                logger.warning(f"Failed to load {source_file}: {e}")
+    skills.extend(load_source_skills(sources_dir))
 
     # Deduplicate by repo+name
     seen = set()

--- a/scripts/sync_and_download.py
+++ b/scripts/sync_and_download.py
@@ -43,7 +43,13 @@ sys.path.insert(0, str(SCRIPT_DIR))
 
 from discover_by_topic import GitHubTopicDiscovery
 from security_blocklist import blocked_metadata_source, blocked_repo_entry, load_security_blocklist
-from utils import build_legal_metadata, build_skill_key, ensure_unique_dir, normalize_name
+from utils import (
+    build_legal_metadata,
+    build_skill_key,
+    ensure_unique_dir,
+    iter_source_skills,
+    normalize_name,
+)
 
 from crawler.skillsmp_sync import SkillsMPSync
 
@@ -603,7 +609,7 @@ def build_unified_registry(
 
         source_name = source.get("name", source_file.stem)
 
-        for skill in source.get("skills", []):
+        for skill in iter_source_skills(source):
             # Create unique key
             repo = skill.get("repo", "")
             name = skill.get("name", "")

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -243,6 +243,17 @@ def build_skill_key(repo: str = "", path: str = "", name: str = "", category: st
     return ""
 
 
+def iter_source_skills(source: dict):
+    """Yield source rows with any top-level repo applied to rows that omit it."""
+    default_repo = source.get("repo") if isinstance(source.get("repo"), str) else ""
+    for skill in source.get("skills", []):
+        if not isinstance(skill, dict):
+            raise TypeError("source skill entry must be an object")
+        if default_repo and not skill.get("repo"):
+            skill = {**skill, "repo": default_repo}
+        yield skill
+
+
 def _short_hash(value: str) -> str:
     return hashlib.sha1(value.encode("utf-8", errors="ignore")).hexdigest()[:8]
 

--- a/scripts/validate_sources.py
+++ b/scripts/validate_sources.py
@@ -418,7 +418,7 @@ def _validate_discovery_entries(
                         location,
                     )
                 )
-            elif ".." in Path(path_value).parts:
+            elif _has_path_traversal(path_value):
                 report.add(
                     Issue(
                         file_label,

--- a/scripts/validate_sources.py
+++ b/scripts/validate_sources.py
@@ -51,6 +51,21 @@ REPO_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
 TAG_PATTERN = re.compile(r"^[a-z0-9-]+$")
 
+
+def _has_path_traversal(path: str) -> bool:
+    """Detect ``..`` traversal segments regardless of separator style.
+
+    ``Path("a\\..\\b").parts`` returns a single piece on POSIX runners,
+    so this helper splits on both ``/`` and ``\\`` before checking.
+    """
+    if not path:
+        return False
+    for separator in ("/", "\\"):
+        for segment in path.split(separator):
+            if segment == "..":
+                return True
+    return False
+
 # Files we may legitimately skip — auto-generated indexes, blocklists, etc.
 NON_SKILL_TOPLEVEL_KEYS = ("entries", "blocked_repos", "plugins")
 EXPECTED_TOPLEVEL_KEYS = ("skills", *NON_SKILL_TOPLEVEL_KEYS)
@@ -189,7 +204,7 @@ def validate_skill_entry(
                     location,
                 )
             )
-        elif ".." in Path(path).parts:
+        elif _has_path_traversal(path):
             report.add(
                 Issue(file, "error", "E_PATH_TRAVERSAL", "path must not contain '..'", location)
             )

--- a/scripts/validate_sources.py
+++ b/scripts/validate_sources.py
@@ -409,7 +409,9 @@ def _validate_discovery_entries(
             )
 
         path_value = entry.get("path")
-        if path_value is not None and isinstance(path_value, str):
+        if path_value is not None and not isinstance(path_value, str):
+            report.add(Issue(file_label, "error", "E_PATH_TYPE", "path must be a string", location))
+        elif isinstance(path_value, str):
             if path_value.startswith("/"):
                 report.add(
                     Issue(

--- a/scripts/validate_sources.py
+++ b/scripts/validate_sources.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python3
+"""
+Validate ``sources/*.json`` shape, repo references, and category codes.
+
+Most contributor PRs add a row to ``sources/community.json`` (the README's
+"Option 2: Submit via PR" path). The crawler later trusts those rows.
+This script runs offline, prints a single-line message per problem, and
+exits non-zero only when there is a structural error so it can be wired
+into CI without false positives from optional / advisory checks.
+
+Usage::
+
+    python scripts/validate_sources.py                # validate every sources/*.json
+    python scripts/validate_sources.py community.json # only one file
+    python scripts/validate_sources.py --strict       # fail on warnings too
+    python scripts/validate_sources.py --json         # machine-readable output
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+# -- Constants kept in sync with schema/skill.schema.json + README ---------
+
+VALID_CATEGORIES: frozenset[str] = frozenset(
+    {
+        "development",
+        "testing",
+        "data",
+        "design",
+        "documents",
+        "productivity",
+        "devops",
+        "security",
+        "marketing",
+        "product",
+        "communication",
+        "creative",
+        "official",
+        "other",
+    }
+)
+
+REPO_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+TAG_PATTERN = re.compile(r"^[a-z0-9-]+$")
+
+# Files we may legitimately skip — auto-generated indexes, blocklists, etc.
+NON_SKILL_TOPLEVEL_KEYS = ("entries", "blocked_repos", "plugins")
+EXPECTED_TOPLEVEL_KEYS = ("skills", *NON_SKILL_TOPLEVEL_KEYS)
+
+
+# -- Reporting -------------------------------------------------------------
+
+
+@dataclass
+class Issue:
+    """One structural finding from validation."""
+
+    file: str
+    severity: str  # "error" | "warning"
+    code: str
+    message: str
+    location: str = ""
+
+    def format_line(self) -> str:
+        loc = f" [{self.location}]" if self.location else ""
+        return f"{self.severity.upper()} {self.file}{loc} {self.code}: {self.message}"
+
+
+@dataclass
+class Report:
+    issues: list[Issue] = field(default_factory=list)
+    files_scanned: int = 0
+    skills_scanned: int = 0
+    seen_keys: set[str] = field(default_factory=set)
+
+    @property
+    def errors(self) -> list[Issue]:
+        return [i for i in self.issues if i.severity == "error"]
+
+    @property
+    def warnings(self) -> list[Issue]:
+        return [i for i in self.issues if i.severity == "warning"]
+
+    def add(self, issue: Issue) -> None:
+        self.issues.append(issue)
+
+
+# -- Validators ------------------------------------------------------------
+
+
+def _validate_string(value: Any, *, max_len: int) -> str | None:
+    if not isinstance(value, str):
+        return "must be a string"
+    if not value.strip():
+        return "must be non-empty"
+    if len(value) > max_len:
+        return f"must be at most {max_len} chars (got {len(value)})"
+    return None
+
+
+def validate_skill_entry(
+    entry: Any,
+    *,
+    file: str,
+    location: str,
+    report: Report,
+    require_category: bool = True,
+    default_repo: str | None = None,
+) -> None:
+    """Validate a single skill row inside ``sources/<source>.json``.
+
+    Required fields: ``name``, ``repo`` (or top-level ``repo`` inherited via
+    ``default_repo``), ``description``.
+    Optional fields: ``path``, ``category``, ``tags``, ``stars``, ``featured``.
+    ``location`` is something like ``skills[3]`` so reviewers can jump to the row.
+    """
+    if not isinstance(entry, dict):
+        report.add(
+            Issue(file, "error", "E_NOT_OBJECT", "skill entry must be an object", location)
+        )
+        return
+
+    # Required: name
+    err = _validate_string(entry.get("name"), max_len=64)
+    if err:
+        report.add(Issue(file, "error", "E_NAME", f"name {err}", location))
+    elif not NAME_PATTERN.match(entry["name"]):
+        report.add(
+            Issue(
+                file,
+                "warning",
+                "W_NAME_PATTERN",
+                "name should match ^[a-z0-9][a-z0-9-]{0,63}$ (recommended for path safety)",
+                location,
+            )
+        )
+
+    # Required: repo (may be inherited from top-level ``repo``).
+    repo = entry.get("repo", default_repo)
+    err = _validate_string(repo, max_len=140)
+    if err:
+        report.add(Issue(file, "error", "E_REPO", f"repo {err}", location))
+    elif not REPO_PATTERN.match(repo):
+        report.add(
+            Issue(
+                file,
+                "error",
+                "E_REPO_FORMAT",
+                "repo must look like 'owner/name' (got '{}')".format(repo),
+                location,
+            )
+        )
+
+    # Required: description (community PRs sometimes ship empty strings).
+    err = _validate_string(entry.get("description"), max_len=500)
+    if err:
+        report.add(Issue(file, "error", "E_DESCRIPTION", f"description {err}", location))
+    elif len(entry["description"]) < 10:
+        report.add(
+            Issue(
+                file,
+                "warning",
+                "W_DESCRIPTION_SHORT",
+                "description is shorter than 10 chars; reviewers will likely ask to expand",
+                location,
+            )
+        )
+
+    # Optional: path
+    path = entry.get("path")
+    if path is not None:
+        if not isinstance(path, str):
+            report.add(Issue(file, "error", "E_PATH_TYPE", "path must be a string", location))
+        elif path.startswith("/"):
+            report.add(
+                Issue(
+                    file,
+                    "error",
+                    "E_PATH_LEADING_SLASH",
+                    "path must be a repo-relative path, not start with '/'",
+                    location,
+                )
+            )
+        elif ".." in Path(path).parts:
+            report.add(
+                Issue(file, "error", "E_PATH_TRAVERSAL", "path must not contain '..'", location)
+            )
+
+    # Optional: category — required for non-discovery sources.
+    category = entry.get("category")
+    if category is None:
+        if require_category:
+            report.add(
+                Issue(
+                    file,
+                    "warning",
+                    "W_CATEGORY_MISSING",
+                    "category missing; will fall back to 'other'",
+                    location,
+                )
+            )
+    elif not isinstance(category, str):
+        report.add(
+            Issue(file, "error", "E_CATEGORY_TYPE", "category must be a string", location)
+        )
+    elif category not in VALID_CATEGORIES:
+        report.add(
+            Issue(
+                file,
+                "warning",
+                "W_CATEGORY_UNKNOWN",
+                f"category '{category}' is not in the known set ({sorted(VALID_CATEGORIES)})",
+                location,
+            )
+        )
+
+    # Optional: tags
+    tags = entry.get("tags")
+    if tags is not None:
+        if not isinstance(tags, list):
+            report.add(Issue(file, "error", "E_TAGS_TYPE", "tags must be an array", location))
+        elif len(tags) > 10:
+            report.add(
+                Issue(
+                    file,
+                    "warning",
+                    "W_TAGS_OVERFLOW",
+                    f"tags has {len(tags)} entries; only the first 10 are surfaced",
+                    location,
+                )
+            )
+        else:
+            for i, tag in enumerate(tags):
+                if not isinstance(tag, str) or not TAG_PATTERN.match(tag):
+                    report.add(
+                        Issue(
+                            file,
+                            "warning",
+                            "W_TAG_FORMAT",
+                            f"tag #{i} '{tag!r}' should be lowercase alphanumeric with hyphens",
+                            location,
+                        )
+                    )
+
+    # Optional: stars
+    stars = entry.get("stars")
+    if stars is not None and not isinstance(stars, int):
+        report.add(
+            Issue(file, "warning", "W_STARS_TYPE", "stars should be an integer", location)
+        )
+
+    # Optional: featured
+    featured = entry.get("featured")
+    if featured is not None and not isinstance(featured, bool):
+        report.add(
+            Issue(
+                file,
+                "warning",
+                "W_FEATURED_TYPE",
+                "featured should be true or false",
+                location,
+            )
+        )
+
+    # De-duplication key across all sources. Use repo+path because the same
+    # repo can host several skills under different paths.
+    if isinstance(repo, str) and (path is None or isinstance(path, str)):
+        key = f"{repo.strip()}:{(path or '').strip().strip('/')}"
+        if key in report.seen_keys:
+            report.add(
+                Issue(
+                    file,
+                    "warning",
+                    "W_DUPLICATE",
+                    f"duplicate skill key '{key}' already declared in another file",
+                    location,
+                )
+            )
+        report.seen_keys.add(key)
+
+    report.skills_scanned += 1
+
+
+def validate_file(path: Path, report: Report) -> None:
+    """Validate one ``sources/<name>.json`` file."""
+    file_label = str(path.name)
+    report.files_scanned += 1
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        report.add(Issue(file_label, "error", "E_NOT_FOUND", "file not found"))
+        return
+    except json.JSONDecodeError as exc:
+        report.add(Issue(file_label, "error", "E_JSON", f"invalid JSON: {exc}"))
+        return
+
+    if not isinstance(data, dict):
+        report.add(Issue(file_label, "error", "E_TOPLEVEL", "top level must be an object"))
+        return
+
+    if not any(k in data for k in EXPECTED_TOPLEVEL_KEYS):
+        report.add(
+            Issue(
+                file_label,
+                "warning",
+                "W_TOPLEVEL_KEYS",
+                f"missing one of {EXPECTED_TOPLEVEL_KEYS}; nothing will be ingested",
+            )
+        )
+        return
+
+    skills = data.get("skills")
+    if skills is not None:
+        if not isinstance(skills, list):
+            report.add(Issue(file_label, "error", "E_SKILLS_TYPE", "skills must be an array"))
+            return
+
+        curated_files = {"community.json", "anthropic.json", "skillsmp.json"}
+        is_curated = path.name in curated_files
+        if not is_curated:
+            # Auto-discovered sources (discovered.json / github_search.json /
+            # crawled.json) carry partial rows produced by crawlers — name and
+            # category are derived later. Treat them as advisory: only check
+            # the structural keys we always rely on.
+            _validate_discovery_entries(skills, file_label, report)
+            return
+
+        # Some curated catalogs (e.g. anthropic.json) declare the repo at the
+        # top level and the rows only carry path. Inherit it so per-row
+        # validation does not flag a structural error that the loader handles.
+        default_repo = data.get("repo") if isinstance(data.get("repo"), str) else None
+
+        for i, entry in enumerate(skills):
+            validate_skill_entry(
+                entry,
+                file=file_label,
+                location=f"skills[{i}]",
+                report=report,
+                require_category=is_curated,
+                default_repo=default_repo,
+            )
+
+
+def _validate_discovery_entries(
+    skills: list[Any], file_label: str, report: Report
+) -> None:
+    """Lighter validation for auto-discovered (non-curated) source files.
+
+    The crawler emits incomplete rows (no name, no category) on purpose;
+    failing here would give contributors red CI for files they did not edit.
+    We still enforce repo presence + format and ``path`` safety so a poisoned
+    discovery file cannot smuggle in repo strings the downloader would trust.
+    """
+    for i, entry in enumerate(skills):
+        location = f"skills[{i}]"
+        if not isinstance(entry, dict):
+            report.add(
+                Issue(
+                    file_label,
+                    "error",
+                    "E_NOT_OBJECT",
+                    "skill entry must be an object",
+                    location,
+                )
+            )
+            continue
+
+        repo = entry.get("repo")
+        if not isinstance(repo, str) or not repo.strip():
+            report.add(
+                Issue(file_label, "error", "E_REPO", "repo must be a non-empty string", location)
+            )
+            continue
+        if not REPO_PATTERN.match(repo):
+            report.add(
+                Issue(
+                    file_label,
+                    "error",
+                    "E_REPO_FORMAT",
+                    f"repo must look like 'owner/name' (got '{repo}')",
+                    location,
+                )
+            )
+
+        path_value = entry.get("path")
+        if path_value is not None and isinstance(path_value, str):
+            if path_value.startswith("/"):
+                report.add(
+                    Issue(
+                        file_label,
+                        "error",
+                        "E_PATH_LEADING_SLASH",
+                        "path must be repo-relative",
+                        location,
+                    )
+                )
+            elif ".." in Path(path_value).parts:
+                report.add(
+                    Issue(
+                        file_label,
+                        "error",
+                        "E_PATH_TRAVERSAL",
+                        "path must not contain '..'",
+                        location,
+                    )
+                )
+
+        report.skills_scanned += 1
+
+
+# -- CLI -------------------------------------------------------------------
+
+
+def discover_targets(sources_dir: Path, names: Iterable[str]) -> list[Path]:
+    requested = list(names)
+    if requested:
+        return [sources_dir / n if not Path(n).is_absolute() else Path(n) for n in requested]
+    return sorted(sources_dir.glob("*.json"))
+
+
+def render_text(report: Report, *, strict: bool) -> int:
+    for issue in report.issues:
+        print(issue.format_line())
+    print(
+        f"\nScanned {report.files_scanned} file(s), {report.skills_scanned} skill row(s); "
+        f"errors={len(report.errors)}, warnings={len(report.warnings)}"
+    )
+    if report.errors:
+        return 1
+    if strict and report.warnings:
+        return 2
+    return 0
+
+
+def render_json(report: Report) -> str:
+    payload = {
+        "files_scanned": report.files_scanned,
+        "skills_scanned": report.skills_scanned,
+        "errors": [
+            {
+                "file": i.file,
+                "code": i.code,
+                "message": i.message,
+                "location": i.location,
+            }
+            for i in report.errors
+        ],
+        "warnings": [
+            {
+                "file": i.file,
+                "code": i.code,
+                "message": i.message,
+                "location": i.location,
+            }
+            for i in report.warnings
+        ],
+    }
+    return json.dumps(payload, indent=2, ensure_ascii=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="specific source filenames (relative to sources/) or absolute paths",
+    )
+    parser.add_argument(
+        "--sources-dir",
+        default="sources",
+        help="directory containing source files (default: sources)",
+    )
+    parser.add_argument("--strict", action="store_true", help="exit non-zero on warnings too")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    sources_dir = Path(args.sources_dir)
+    if not sources_dir.exists():
+        print(f"ERROR: sources directory not found: {sources_dir}", file=sys.stderr)
+        return 2
+
+    targets = discover_targets(sources_dir, args.files)
+    if not targets:
+        print(f"WARNING: no source files matched in {sources_dir}", file=sys.stderr)
+        return 0
+
+    report = Report()
+    for path in targets:
+        validate_file(path, report)
+
+    if args.json:
+        print(render_json(report))
+        return 1 if report.errors else (2 if args.strict and report.warnings else 0)
+
+    return render_text(report, strict=args.strict)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_sources.py
+++ b/scripts/validate_sources.py
@@ -66,6 +66,9 @@ def _has_path_traversal(path: str) -> bool:
                 return True
     return False
 
+# Source files produced by discovery jobs may carry intentionally partial rows.
+DISCOVERY_SOURCE_FILES = frozenset({"discovered.json", "github_search.json", "crawled.json"})
+
 # Files we may legitimately skip — auto-generated indexes, blocklists, etc.
 NON_SKILL_TOPLEVEL_KEYS = ("entries", "blocked_repos", "plugins")
 EXPECTED_TOPLEVEL_KEYS = ("skills", *NON_SKILL_TOPLEVEL_KEYS)
@@ -339,9 +342,8 @@ def validate_file(path: Path, report: Report) -> None:
             report.add(Issue(file_label, "error", "E_SKILLS_TYPE", "skills must be an array"))
             return
 
-        curated_files = {"community.json", "anthropic.json", "skillsmp.json"}
-        is_curated = path.name in curated_files
-        if not is_curated:
+        is_discovery = path.name in DISCOVERY_SOURCE_FILES
+        if is_discovery:
             # Auto-discovered sources (discovered.json / github_search.json /
             # crawled.json) carry partial rows produced by crawlers — name and
             # category are derived later. Treat them as advisory: only check
@@ -360,7 +362,7 @@ def validate_file(path: Path, report: Report) -> None:
                 file=file_label,
                 location=f"skills[{i}]",
                 report=report,
-                require_category=is_curated,
+                require_category=True,
                 default_repo=default_repo,
             )
 

--- a/tests/test_download_v2.py
+++ b/tests/test_download_v2.py
@@ -1,0 +1,42 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def load_module():
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    module_path = scripts_dir / "download_v2.py"
+    spec = importlib.util.spec_from_file_location("download_v2_module", module_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_load_source_skills_inherits_top_level_repo(tmp_path):
+    module = load_module()
+    sources_dir = tmp_path / "sources"
+    sources_dir.mkdir()
+    (sources_dir / "anthropic.json").write_text(
+        json.dumps(
+            {
+                "name": "Anthropic",
+                "repo": "anthropics/skills",
+                "skills": [
+                    {
+                        "name": "docx",
+                        "path": "skills/docx",
+                        "description": "Document editing skill.",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    rows = module.load_source_skills(sources_dir)
+    assert rows[0]["repo"] == "anthropics/skills"

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -78,6 +78,34 @@ def test_should_fail_on_empty_download_only_when_all_attempts_fail():
     assert module.should_fail_on_empty_download({"downloaded": 0, "failed": 3, "skipped": 10}) is False
 
 
+def test_build_unified_registry_inherits_top_level_repo(tmp_path):
+    module = load_module()
+    sources_dir = tmp_path / "sources"
+    sources_dir.mkdir()
+    output_path = tmp_path / "registry.json"
+    (sources_dir / "anthropic.json").write_text(
+        json.dumps(
+            {
+                "name": "Anthropic",
+                "repo": "anthropics/skills",
+                "skills": [
+                    {
+                        "name": "docx",
+                        "path": "skills/docx",
+                        "description": "Document editing skill.",
+                        "category": "documents",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert module.build_unified_registry(sources_dir, output_path) == 1
+    registry = json.loads(output_path.read_text(encoding="utf-8"))
+    assert registry["skills"][0]["repo"] == "anthropics/skills"
+
+
 def test_download_blocks_security_listed_source_repo(tmp_path, monkeypatch):
     module = load_module()
     registry_path = tmp_path / "registry.json"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -453,11 +453,15 @@ def test_extract_description_strips_markdown_links(utils):
     assert "the manual" in desc
 
 
-def test_extract_description_skips_short_lines_and_code_fences(utils):
+def test_extract_description_skips_short_lines_and_fence_openers(utils):
+    # extract_description only filters lines that *start with* ``` and lines
+    # under 20 chars; it does not understand fenced-block scope. The content
+    # below verifies that contract: short lines and the fence opener itself
+    # are skipped, then the first long body line is picked.
     content = (
         "---\nname: demo\n---\n\n"
         "short\n"
-        "```\ncode\n```\n"
+        "```\n"
         "This actually has more than twenty characters in it for sure.\n"
     )
     desc = utils.extract_description(content)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,520 @@
+"""
+Regression tests for ``scripts/utils.py``.
+
+This module is the canonical home for cross-script invariants documented in
+``AGENTS.md`` (case-conflict policy, repo-suffix fallback, deterministic paths)
+and ``THIRD_PARTY_NOTICES.md`` (license normalization / classification).
+A silent regression here corrupts the entire registry, so each rule below maps
+to one or more named tests so reviewers can trace policy -> assertion.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_utils():
+    """Load ``scripts/utils.py`` fresh so the module-level ``_DIR_CACHE`` is reset."""
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    if "utils" in sys.modules:
+        return importlib.reload(sys.modules["utils"])
+    return importlib.import_module("utils")
+
+
+@pytest.fixture
+def utils():
+    module = _load_utils()
+    # Each test starts with a clean directory cache so prior runs do not leak.
+    module._DIR_CACHE.clear()
+    return module
+
+
+# ---------------------------------------------------------------------------
+# License normalization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("MIT", "MIT"),
+        ("MIT License", "MIT"),
+        ("mit license", "MIT"),
+        ("Apache 2.0", "Apache-2.0"),
+        ("Apache License 2.0", "Apache-2.0"),
+        ("Apache License Version 2.0", "Apache-2.0"),
+        ("BSD 2-Clause", "BSD-2-Clause"),
+        ("BSD 3-Clause", "BSD-3-Clause"),
+        ("CC-BY-NC-SA", "CC-BY-NC-SA-4.0"),
+        ("CC BY-NC 4.0", "CC-BY-NC-4.0"),
+        ("CC-BY-SA", "CC-BY-SA-4.0"),
+        ("CC-BY", "CC-BY-4.0"),
+    ],
+)
+def test_normalize_license_canonicalizes_known_aliases(utils, raw, expected):
+    assert utils.normalize_license(raw) == expected
+
+
+def test_normalize_license_maps_empty_to_noassertion(utils):
+    assert utils.normalize_license("") == "NOASSERTION"
+    assert utils.normalize_license("   ") == "NOASSERTION"
+    assert utils.normalize_license(None) == "NOASSERTION"
+
+
+def test_normalize_license_keeps_unknown_text_verbatim(utils):
+    # Unrecognised licenses fall through unchanged so reviewers can spot them.
+    assert utils.normalize_license("Custom Internal EULA") == "Custom Internal EULA"
+
+
+# ---------------------------------------------------------------------------
+# License classification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "license_in,klass",
+    [
+        ("MIT", "compatible"),
+        ("Apache-2.0", "compatible"),
+        ("ISC", "compatible"),
+        ("BSD-2-Clause", "compatible"),
+        ("BSD-3-Clause", "compatible"),
+        ("CC0-1.0", "compatible"),
+        ("Unlicense", "compatible"),
+        ("MIT-0", "compatible"),
+        ("AGPL-3.0", "restricted"),
+        ("GPL-3.0", "restricted"),
+        ("LGPL-3.0", "restricted"),
+        ("MPL-2.0", "restricted"),
+        ("EUPL-1.2", "restricted"),
+        ("CC-BY-NC-SA-4.0", "restricted"),
+        ("CC-BY-NC-4.0", "restricted"),
+        ("CC-BY-ND", "restricted"),
+        ("PROPRIETARY", "restricted"),
+        ("UNLICENSED", "restricted"),
+        ("NOASSERTION", "restricted"),
+        ("UNKNOWN", "restricted"),
+        ("CC-BY-4.0", "restricted"),  # CC- non-permissive variants are restricted
+        ("CC-BY-SA-4.0", "restricted"),
+        ("Custom Vendor License", "unknown"),
+    ],
+)
+def test_classify_license_partitions_known_families(utils, license_in, klass):
+    assert utils.classify_license(license_in) == klass
+
+
+def test_classify_license_falls_back_when_blank(utils):
+    # Empty input normalizes to NOASSERTION, which must be restricted.
+    assert utils.classify_license("") == "restricted"
+
+
+# ---------------------------------------------------------------------------
+# Repo / URL helpers
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_repo_strips_https_prefix_and_slashes(utils):
+    assert utils.normalize_repo("https://github.com/owner/repo") == "owner/repo"
+    assert utils.normalize_repo("https://github.com/owner/repo/") == "owner/repo"
+    assert utils.normalize_repo("/owner/repo/") == "owner/repo"
+    assert utils.normalize_repo(" owner/repo ") == "owner/repo"
+    assert utils.normalize_repo("") == ""
+    assert utils.normalize_repo(None) == ""
+
+
+def test_build_source_url_handles_repo_only_and_path(utils):
+    assert (
+        utils.build_source_url(repo="owner/repo")
+        == "https://github.com/owner/repo"
+    )
+    assert (
+        utils.build_source_url(repo="owner/repo", path="skills/demo")
+        == "https://github.com/owner/repo/blob/main/skills/demo/SKILL.md"
+    )
+    # Already-pointed-at SKILL.md should not double-suffix.
+    assert (
+        utils.build_source_url(repo="owner/repo", path="skills/demo/SKILL.md")
+        == "https://github.com/owner/repo/blob/main/skills/demo/SKILL.md"
+    )
+
+
+def test_build_source_url_passthrough_for_external_url(utils):
+    external = "https://example.com/raw/skill.md"
+    assert utils.build_source_url(repo="owner/repo", path=external) == external
+
+
+def test_build_source_url_uses_branch_argument(utils):
+    assert (
+        utils.build_source_url(repo="owner/repo", path="x", branch="develop")
+        == "https://github.com/owner/repo/blob/develop/x/SKILL.md"
+    )
+
+
+def test_build_source_url_with_no_repo_returns_empty(utils):
+    assert utils.build_source_url() == ""
+
+
+def test_is_valid_https_url(utils):
+    assert utils.is_valid_https_url("https://github.com/owner/repo")
+    assert not utils.is_valid_https_url("http://example.com")
+    assert not utils.is_valid_https_url("ftp://example.com")
+    assert not utils.is_valid_https_url("github.com/owner/repo")
+    assert not utils.is_valid_https_url("")
+    assert not utils.is_valid_https_url(None)
+
+
+# ---------------------------------------------------------------------------
+# Author inference
+# ---------------------------------------------------------------------------
+
+
+def test_infer_author_prefers_explicit_value(utils):
+    assert utils.infer_author(repo="ownerA/repoA", fallback="real human") == "real human"
+
+
+@pytest.mark.parametrize(
+    "placeholder", ["", "n/a", "NA", "None", "null", "TBD", "unknown", "  "]
+)
+def test_infer_author_drops_placeholders_in_favour_of_repo_owner(utils, placeholder):
+    assert utils.infer_author(repo="ownerA/repoA", fallback=placeholder) == "ownerA"
+
+
+def test_infer_author_when_repo_unknown(utils):
+    assert utils.infer_author(repo="", fallback="") == "unknown"
+    assert utils.infer_author(repo="bare-name-no-slash", fallback="") == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Legal metadata composition
+# ---------------------------------------------------------------------------
+
+
+def test_build_legal_metadata_compatible_path(utils):
+    meta = utils.build_legal_metadata(
+        repo="owner/repo", path="skills/demo", license_name="MIT"
+    )
+    assert meta["author"] == "owner"
+    assert meta["license"] == "MIT"
+    assert meta["license_class"] == "compatible"
+    assert meta["distribution"] == "compatible"
+    assert "Use according to upstream license" in meta["permission_note"]
+    assert meta["source_url"].endswith("/skills/demo/SKILL.md")
+    assert meta["copyright"].startswith("Copyright belongs to upstream")
+
+
+def test_build_legal_metadata_restricted_for_gpl(utils):
+    meta = utils.build_legal_metadata(repo="owner/repo", license_name="GPL-3.0")
+    assert meta["license_class"] == "restricted"
+    assert meta["distribution"] == "restricted"
+    assert "Restricted or unknown license" in meta["permission_note"]
+
+
+def test_build_legal_metadata_explicit_overrides_win(utils):
+    meta = utils.build_legal_metadata(
+        repo="owner/repo",
+        license_name="MIT",
+        author="Specific Author",
+        copyright_text="(c) 2026 Specific Author",
+        permission_note="Custom note",
+        distribution="restricted",
+        source_url="https://example.com/foo",
+    )
+    assert meta["author"] == "Specific Author"
+    assert meta["copyright"] == "(c) 2026 Specific Author"
+    assert meta["permission_note"] == "Custom note"
+    assert meta["distribution"] == "restricted"
+    assert meta["source_url"] == "https://example.com/foo"
+
+
+def test_build_legal_metadata_unknown_license_treated_as_restricted(utils):
+    meta = utils.build_legal_metadata(repo="owner/repo", license_name="Vendor EULA")
+    assert meta["license_class"] == "unknown"
+    # Unknown -> restricted in distribution per the comment in source.
+    assert meta["distribution"] == "restricted"
+
+
+# ---------------------------------------------------------------------------
+# Name / category normalization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("Architect", "architect"),
+        ("LangChain", "langchain"),
+        ("Go-to-Market-Planner", "go-to-market-planner"),
+        ("My Skill Name", "my-skill-name"),
+        ("__leading-and-trailing__", "leading-and-trailing"),
+        ("multiple   spaces", "multiple-spaces"),
+        ("Mixed.Case_With.Punc!", "mixed-case-with-punc"),
+    ],
+)
+def test_normalize_name_examples_from_docstring(utils, raw, expected):
+    assert utils.normalize_name(raw) == expected
+
+
+def test_normalize_name_empty_inputs_become_unknown(utils):
+    assert utils.normalize_name("") == "unknown"
+    assert utils.normalize_name(None) == "unknown"
+    assert utils.normalize_name("---") == "unknown"
+
+
+def test_normalize_name_truncates_to_64_chars(utils):
+    long_name = "a" * 100
+    out = utils.normalize_name(long_name)
+    assert out == "a" * 64
+    assert len(out) <= 64
+
+
+def test_normalize_category_truncates_to_32_chars(utils):
+    long_cat = "category-" + "x" * 100
+    out = utils.normalize_category(long_cat)
+    assert len(out) <= 32
+
+
+def test_normalize_category_empty(utils):
+    assert utils.normalize_category("") == "other"
+    assert utils.normalize_category(None) == "other"
+
+
+# ---------------------------------------------------------------------------
+# Repo suffix and dir-name builder (AGENTS.md case-conflict policy)
+# ---------------------------------------------------------------------------
+
+
+def test_get_repo_suffix_basic(utils):
+    assert utils.get_repo_suffix("owner/repo") == "owner-repo"
+    assert utils.get_repo_suffix("https://github.com/Owner/Repo") == "owner-repo"
+    assert utils.get_repo_suffix("") == ""
+    assert utils.get_repo_suffix("just-owner") == ""
+
+
+def test_get_repo_suffix_truncates_long_components(utils):
+    # AGENTS.md says owner and repo each capped at 20 chars.
+    long_owner = "x" * 50
+    long_repo = "y" * 50
+    suffix = utils.get_repo_suffix(f"{long_owner}/{long_repo}")
+    owner_part, repo_part = suffix.split("-", 1)
+    assert len(owner_part) <= 20
+    assert len(repo_part) <= 20
+
+
+def test_build_dir_name_uses_repo_suffix(utils):
+    assert utils.build_dir_name("My Skill", repo="owner/repo") == "my-skill-owner-repo"
+    assert utils.build_dir_name("plain-skill") == "plain-skill"
+
+
+def test_build_skill_key_priority(utils):
+    # Per implementation: repo+path > repo > category:name > "".
+    assert utils.build_skill_key(repo="o/r", path="x/y") == "o/r:x/y"
+    assert utils.build_skill_key(repo="o/r") == "o/r"
+    assert utils.build_skill_key(category="dev", name="foo") == "dev:foo"
+    assert utils.build_skill_key() == ""
+    # path alone is ignored once repo is missing — the category:name fallback wins.
+    assert utils.build_skill_key(path="x/y", name="foo") == ":foo"
+
+
+def test_short_hash_is_deterministic_and_8_hex(utils):
+    out = utils.short_hash("hello")
+    assert len(out) == 8
+    assert all(c in "0123456789abcdef" for c in out)
+    assert out == utils.short_hash("hello")
+    assert out != utils.short_hash("hello!")
+
+
+# ---------------------------------------------------------------------------
+# ensure_unique_dir: case-insensitive uniqueness rules from AGENTS.md
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_unique_dir_no_conflict(utils, tmp_path):
+    target = utils.ensure_unique_dir(tmp_path, "my-skill")
+    assert target == tmp_path / "my-skill"
+
+
+def test_ensure_unique_dir_case_conflict_uses_repo_suffix(utils, tmp_path):
+    (tmp_path / "MY-SKILL").mkdir()
+    # Force fresh scan since the cached state from a previous test could interfere.
+    utils._DIR_CACHE.clear()
+    target = utils.ensure_unique_dir(tmp_path, "my-skill", repo="owner/repo")
+    assert target.name == "my-skill-owner-repo"
+
+
+def test_ensure_unique_dir_falls_back_to_short_hash_without_repo(utils, tmp_path):
+    (tmp_path / "MY-SKILL").mkdir()
+    utils._DIR_CACHE.clear()
+    target = utils.ensure_unique_dir(tmp_path, "my-skill", key="key-1")
+    assert target.name.startswith("my-skill-")
+    suffix = target.name[len("my-skill-") :]
+    assert len(suffix) == 8
+    assert all(c in "0123456789abcdef" for c in suffix)
+
+
+def test_ensure_unique_dir_appends_numeric_when_suffix_already_taken(utils, tmp_path):
+    (tmp_path / "my-skill").mkdir()
+    (tmp_path / "my-skill-owner-repo").mkdir()
+    utils._DIR_CACHE.clear()
+    target = utils.ensure_unique_dir(tmp_path, "my-skill", repo="owner/repo")
+    assert target.name == "my-skill-owner-repo-2"
+
+
+def test_ensure_unique_dir_reuses_dir_with_matching_metadata_key(utils, tmp_path):
+    existing = tmp_path / "my-skill"
+    existing.mkdir()
+    (existing / "metadata.json").write_text(
+        json.dumps({"repo": "owner/repo", "path": "skills/demo"}),
+        encoding="utf-8",
+    )
+    utils._DIR_CACHE.clear()
+    target = utils.ensure_unique_dir(
+        tmp_path, "completely-different-name", key="owner/repo:skills/demo"
+    )
+    assert target == existing
+
+
+def test_ensure_unique_dir_creates_parent_when_missing(utils, tmp_path):
+    nested = tmp_path / "does" / "not" / "exist-yet"
+    target = utils.ensure_unique_dir(nested, "thing")
+    assert target.parent == nested
+    assert nested.exists()
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter / description / metadata IO
+# ---------------------------------------------------------------------------
+
+
+def test_extract_frontmatter_valid(utils):
+    content = """---
+name: demo
+description: Some demo skill.
+tags:
+  - a
+  - b
+---
+
+# Demo
+Body content.
+"""
+    fm = utils.extract_frontmatter(content)
+    assert fm == {"name": "demo", "description": "Some demo skill.", "tags": ["a", "b"]}
+
+
+def test_extract_frontmatter_returns_empty_for_no_frontmatter(utils):
+    assert utils.extract_frontmatter("# Just a heading") == {}
+    assert utils.extract_frontmatter("") == {}
+
+
+def test_extract_frontmatter_returns_empty_for_unterminated(utils):
+    assert utils.extract_frontmatter("---\nname: demo\n") == {}
+
+
+def test_extract_frontmatter_returns_empty_for_invalid_yaml(utils):
+    bad = "---\n: : : not yaml\n  -broken\n---\nbody"
+    assert utils.extract_frontmatter(bad) == {}
+
+
+def test_extract_frontmatter_returns_empty_for_non_mapping(utils):
+    # A YAML scalar / list at top level is not a mapping and must coerce to {}.
+    bad = "---\n- item-1\n- item-2\n---\nbody"
+    assert utils.extract_frontmatter(bad) == {}
+
+
+def test_extract_description_prefers_frontmatter(utils):
+    content = "---\ndescription: From frontmatter\n---\n\nFirst body paragraph here."
+    assert utils.extract_description(content) == "From frontmatter"
+
+
+def test_extract_description_falls_back_to_first_paragraph(utils):
+    content = (
+        "---\nname: demo\n---\n\n# Heading\n\n"
+        "This is the first real body paragraph that exceeds twenty characters.\n"
+    )
+    desc = utils.extract_description(content)
+    assert desc.startswith("This is the first real body")
+
+
+def test_extract_description_strips_markdown_links(utils):
+    content = (
+        "---\nname: demo\n---\n\n"
+        "See [the manual](https://example.com) for more details about this skill.\n"
+    )
+    desc = utils.extract_description(content)
+    assert "https://example.com" not in desc
+    assert "the manual" in desc
+
+
+def test_extract_description_skips_short_lines_and_code_fences(utils):
+    content = (
+        "---\nname: demo\n---\n\n"
+        "short\n"
+        "```\ncode\n```\n"
+        "This actually has more than twenty characters in it for sure.\n"
+    )
+    desc = utils.extract_description(content)
+    assert desc.startswith("This actually has more than twenty characters")
+
+
+def test_extract_description_truncates_at_max_length(utils):
+    body = "x" * 500
+    content = f"---\ndescription: {body}\n---\n"
+    desc = utils.extract_description(content, max_length=100)
+    assert len(desc) == 100
+
+
+def test_load_metadata_returns_dict_or_empty(utils, tmp_path):
+    skill_dir = tmp_path / "skill-a"
+    skill_dir.mkdir()
+    # Missing metadata.json -> {}.
+    assert utils.load_metadata(skill_dir) == {}
+
+    (skill_dir / "metadata.json").write_text('{"name": "a"}', encoding="utf-8")
+    assert utils.load_metadata(skill_dir) == {"name": "a"}
+
+    (skill_dir / "metadata.json").write_text("not json", encoding="utf-8")
+    # Corrupt files must not crash callers.
+    assert utils.load_metadata(skill_dir) == {}
+
+
+def test_write_metadata_round_trip(utils, tmp_path):
+    skill_dir = tmp_path / "skill-b"
+    skill_dir.mkdir()
+    payload = {"name": "demo", "tags": ["a", "b"], "stars": 7}
+    utils.write_metadata(skill_dir, payload)
+    assert utils.load_metadata(skill_dir) == payload
+    raw = (skill_dir / "metadata.json").read_text(encoding="utf-8")
+    # Pretty-printed for human review (indent=2).
+    assert "  " in raw
+
+
+# ---------------------------------------------------------------------------
+# Category guessing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "snippet,expected",
+    [
+        ("React component testing with playwright", "testing"),
+        ("Deploy to Kubernetes via Docker and CI/CD", "devops"),
+        ("Audit OWASP vulnerabilities", "security"),
+        ("Convert PDF and DOCX to markdown", "documents"),
+        ("CSS animation in Figma frontend UI", "design"),
+        ("Backlog roadmap and PRD for product", "product"),
+    ],
+)
+def test_guess_category_picks_dominant_keyword_family(utils, snippet, expected):
+    assert utils.guess_category(snippet) == expected
+
+
+def test_guess_category_returns_other_when_no_match(utils):
+    assert utils.guess_category("entirely-unrelated-mumble-jumble") == "other"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -323,6 +323,24 @@ def test_build_skill_key_priority(utils):
     assert utils.build_skill_key(path="x/y", name="foo") == ":foo"
 
 
+def test_iter_source_skills_inherits_top_level_repo(utils):
+    source = {
+        "repo": "anthropics/skills",
+        "skills": [{"name": "docx", "path": "skills/docx"}],
+    }
+    rows = list(utils.iter_source_skills(source))
+    assert rows == [{"name": "docx", "path": "skills/docx", "repo": "anthropics/skills"}]
+
+
+def test_iter_source_skills_keeps_row_repo(utils):
+    source = {
+        "repo": "anthropics/skills",
+        "skills": [{"name": "custom", "repo": "owner/repo", "path": "skills/custom"}],
+    }
+    rows = list(utils.iter_source_skills(source))
+    assert rows[0]["repo"] == "owner/repo"
+
+
 def test_short_hash_is_deterministic_and_8_hex(utils):
     out = utils.short_hash("hello")
     assert len(out) == 8

--- a/tests/test_validate_sources.py
+++ b/tests/test_validate_sources.py
@@ -206,6 +206,31 @@ def test_path_traversal_is_rejected(vs, sources, capsys):
     assert "E_PATH_TRAVERSAL" in out
 
 
+def test_windows_style_path_traversal_is_rejected(vs, sources, capsys):
+    # ``Path("a\\..\\b").parts`` is a single piece on POSIX runners, so the
+    # validator must split on both '/' and '\' before checking for '..'.
+    _write(
+        sources / "community.json",
+        {
+            "name": "Community",
+            "description": "x",
+            "skills": [
+                {
+                    "name": "demo",
+                    "repo": "owner/repo",
+                    "path": "a\\..\\..\\etc",
+                    "description": "Long enough description here.",
+                    "category": "security",
+                }
+            ],
+        },
+    )
+    rc = vs.main(["--sources-dir", str(sources)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "E_PATH_TRAVERSAL" in out
+
+
 def test_leading_slash_path_is_rejected(vs, sources, capsys):
     _write(
         sources / "community.json",

--- a/tests/test_validate_sources.py
+++ b/tests/test_validate_sources.py
@@ -1,0 +1,406 @@
+"""
+Tests for ``scripts/validate_sources.py``.
+
+Each test seeds a temporary ``sources/<file>.json`` and runs ``main`` so the
+exit-code contract (0 clean, 1 errors, 2 strict-warnings) stays observable —
+that contract is what CI keys off, so a regression here changes contributor UX.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    if "validate_sources" in sys.modules:
+        return importlib.reload(sys.modules["validate_sources"])
+    return importlib.import_module("validate_sources")
+
+
+@pytest.fixture
+def vs():
+    return _load_module()
+
+
+@pytest.fixture
+def sources(tmp_path: Path) -> Path:
+    d = tmp_path / "sources"
+    d.mkdir()
+    return d
+
+
+def _write(path: Path, payload: dict | list | str) -> None:
+    if isinstance(payload, str):
+        path.write_text(payload, encoding="utf-8")
+    else:
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_clean_curated_file_returns_zero(vs, sources, capsys):
+    _write(
+        sources / "community.json",
+        {
+            "name": "Community",
+            "description": "ok",
+            "skills": [
+                {
+                    "name": "demo-skill",
+                    "repo": "owner/repo",
+                    "description": "Long enough description.",
+                    "category": "development",
+                    "tags": ["python", "testing"],
+                }
+            ],
+        },
+    )
+    rc = vs.main(["--sources-dir", str(sources)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "errors=0" in captured.out
+    assert "warnings=0" in captured.out
+
+
+def test_anthropic_style_inherits_top_level_repo(vs, sources, capsys):
+    _write(
+        sources / "anthropic.json",
+        {
+            "name": "Anthropic",
+            "repo": "anthropics/skills",
+            "description": "Official",
+            "skills": [
+                {
+                    "name": "docx",
+                    "path": "skills/docx",
+                    "description": "Comprehensive document creation.",
+                    "category": "documents",
+                }
+            ],
+        },
+    )
+    rc = vs.main(["--sources-dir", str(sources)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "errors=0" in captured.out
+
+
+def test_discovery_files_only_check_repo_format(vs, sources, capsys):
+    # Discovery files are expected to have null name / null description per row;
+    # they must not generate errors so contributors do not see red CI on files
+    # they did not edit.
+    _write(
+        sources / "github_search.json",
+        {
+            "name": "GH search",
+            "skills": [
+                {"repo": "owner/repo", "path": ".claude/skills/x/SKILL.md", "description": None},
+                {"repo": "another/one", "description": None, "stars": 0},
+            ],
+        },
+    )
+    rc = vs.main(["--sources-dir", str(sources)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "errors=0" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Error paths (must exit 1)
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_json_reports_error_and_exits_one(vs, sources, capsys):
+    _write(sources / "community.json", "{not json")
+    rc = vs.main(["--sources-dir", str(sources)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "E_JSON" in out
+
+
+def test_top_level_must_be_object(vs, sources, capsys):
+    _write(sources / "community.json", [])
+    rc = vs.main(["--sources-dir", str(sources)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "E_TOPLEVEL" in out
+
+
+def test_skills_must_be_array(vs, sources, capsys):
+    _write(sources / "community.json", {"name": "x", "description": "y", "skills": "not-array"})
+    rc = vs.main(["--sources-dir", str(sources)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "E_SKILLS_TYPE" in out
+
+
+def test_missing_required_fields_in_curated_entry(vs, sources, capsys):
+    _write(
+        sources / "community.json",
+        {
+            "name": "Community",
+            "description": "x",
+            "skills": [{"description": "no repo no name"}],
+        },
+    )
+    rc = vs.main(["--sources-dir", str(sources)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "E_NAME" in out
+    assert "E_REPO" in out
+
+
+def test_repo_format_must_be_owner_slash_name(vs, sources, capsys):
+    _write(
+        sources / "community.json",
+        {
+            "name": "Community",
+            "description": "x",
+            "skills": [
+                {
+                    "name": "demo",
+                    "repo": "https://github.com/owner/repo",
+                    "description": "Long enough description.",
+                }
+            ],
+        },
+    )
+    rc = vs.main(["--sources-dir", str(sources)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "E_REPO_FORMAT" in out
+
+
+def test_path_traversal_is_rejected(vs, sources, capsys):
+    _write(
+        sources / "community.json",
+        {
+            "name": "Community",
+            "description": "x",
+            "skills": [
+                {
+                    "name": "demo",
+                    "repo": "owner/repo",
+                    "path": "../../etc/passwd",
+                    "description": "Long enough description here.",
+                    "category": "security",
+                }
+            ],
+        },
+    )
+    rc = vs.main(["--sources-dir", str(sources)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "E_PATH_TRAVERSAL" in out
+
+
+def test_leading_slash_path_is_rejected(vs, sources, capsys):
+    _write(
+        sources / "community.json",
+        {
+            "name": "Community",
+            "description": "x",
+            "skills": [
+                {
+                    "name": "demo",
+                    "repo": "owner/repo",
+                    "path": "/abs/path",
+                    "description": "Long enough description here.",
+                    "category": "development",
+                }
+            ],
+        },
+    )
+    rc = vs.main(["--sources-dir", str(sources)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "E_PATH_LEADING_SLASH" in out
+
+
+# ---------------------------------------------------------------------------
+# Warnings
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_category_is_warning_not_error(vs, sources, capsys):
+    _write(
+        sources / "community.json",
+        {
+            "name": "Community",
+            "description": "x",
+            "skills": [
+                {
+                    "name": "demo",
+                    "repo": "owner/repo",
+                    "description": "Long enough description here.",
+                    "category": "engineering",  # not in canonical set
+                }
+            ],
+        },
+    )
+    rc = vs.main(["--sources-dir", str(sources)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "W_CATEGORY_UNKNOWN" in out
+
+
+def test_strict_promotes_warning_to_failure(vs, sources, capsys):
+    _write(
+        sources / "community.json",
+        {
+            "name": "Community",
+            "description": "x",
+            "skills": [
+                {
+                    "name": "demo",
+                    "repo": "owner/repo",
+                    "description": "Long enough description here.",
+                    "category": "engineering",
+                }
+            ],
+        },
+    )
+    rc = vs.main(["--sources-dir", str(sources), "--strict"])
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "W_CATEGORY_UNKNOWN" in captured.out
+
+
+def test_duplicate_keys_across_files_warn(vs, sources, capsys):
+    _write(
+        sources / "community.json",
+        {
+            "name": "Community",
+            "description": "x",
+            "skills": [
+                {
+                    "name": "demo",
+                    "repo": "owner/repo",
+                    "path": "skills/demo",
+                    "description": "Long enough description here.",
+                    "category": "development",
+                }
+            ],
+        },
+    )
+    _write(
+        sources / "anthropic.json",
+        {
+            "name": "Anthropic",
+            "repo": "owner/repo",  # same repo
+            "description": "Official",
+            "skills": [
+                {
+                    "name": "demo",
+                    "path": "skills/demo",
+                    "description": "Same key as community.json above.",
+                    "category": "development",
+                }
+            ],
+        },
+    )
+    rc = vs.main(["--sources-dir", str(sources)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "W_DUPLICATE" in out
+
+
+def test_short_description_warns(vs, sources, capsys):
+    _write(
+        sources / "community.json",
+        {
+            "name": "Community",
+            "description": "x",
+            "skills": [
+                {
+                    "name": "demo",
+                    "repo": "owner/repo",
+                    "description": "tiny",
+                    "category": "development",
+                }
+            ],
+        },
+    )
+    rc = vs.main(["--sources-dir", str(sources)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "W_DESCRIPTION_SHORT" in out
+
+
+# ---------------------------------------------------------------------------
+# Output formats / file selection
+# ---------------------------------------------------------------------------
+
+
+def test_json_output_is_machine_readable(vs, sources, capsys):
+    _write(
+        sources / "community.json",
+        {
+            "name": "Community",
+            "description": "x",
+            "skills": [
+                {
+                    "name": "demo",
+                    "repo": "bad-format",
+                    "description": "Long enough description here.",
+                    "category": "development",
+                }
+            ],
+        },
+    )
+    rc = vs.main(["--sources-dir", str(sources), "--json"])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert rc == 1
+    assert payload["files_scanned"] == 1
+    assert any(err["code"] == "E_REPO_FORMAT" for err in payload["errors"])
+
+
+def test_specific_file_argument(vs, sources, capsys):
+    _write(
+        sources / "community.json",
+        {
+            "name": "Community",
+            "description": "x",
+            "skills": [
+                {
+                    "name": "demo",
+                    "repo": "owner/repo",
+                    "description": "Long enough description here.",
+                    "category": "development",
+                }
+            ],
+        },
+    )
+    _write(sources / "broken.json", "{not json")
+    rc = vs.main(["--sources-dir", str(sources), "community.json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    # Only community.json was checked, broken.json is untouched.
+    assert "broken.json" not in out
+
+
+def test_missing_sources_dir_returns_error(vs, tmp_path, capsys):
+    rc = vs.main(["--sources-dir", str(tmp_path / "nope")])
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "sources directory not found" in err
+
+
+def test_no_files_in_sources_dir_is_warning(vs, sources, capsys):
+    rc = vs.main(["--sources-dir", str(sources)])
+    err = capsys.readouterr().err
+    assert rc == 0
+    assert "no source files matched" in err

--- a/tests/test_validate_sources.py
+++ b/tests/test_validate_sources.py
@@ -231,6 +231,26 @@ def test_windows_style_path_traversal_is_rejected(vs, sources, capsys):
     assert "E_PATH_TRAVERSAL" in out
 
 
+def test_discovery_windows_style_path_traversal_is_rejected(vs, sources, capsys):
+    _write(
+        sources / "github_search.json",
+        {
+            "name": "GH search",
+            "skills": [
+                {
+                    "repo": "owner/repo",
+                    "path": "a\\..\\..\\etc",
+                    "description": None,
+                }
+            ],
+        },
+    )
+    rc = vs.main(["--sources-dir", str(sources)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "E_PATH_TRAVERSAL" in out
+
+
 def test_leading_slash_path_is_rejected(vs, sources, capsys):
     _write(
         sources / "community.json",

--- a/tests/test_validate_sources.py
+++ b/tests/test_validate_sources.py
@@ -117,6 +117,26 @@ def test_discovery_files_only_check_repo_format(vs, sources, capsys):
     assert "errors=0" in captured.out
 
 
+def test_unknown_skill_catalog_uses_full_validation(vs, sources, capsys):
+    # Unknown sources/*.json catalogs are ingested by build_unified_registry,
+    # so they must not get the discovery-only relaxed validation path.
+    _write(
+        sources / "custom.json",
+        {
+            "name": "Custom",
+            "skills": [
+                {"repo": "owner/repo"},
+            ],
+        },
+    )
+    rc = vs.main(["--sources-dir", str(sources)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "E_NAME" in out
+    assert "E_DESCRIPTION" in out
+    assert "W_CATEGORY_MISSING" in out
+
+
 # ---------------------------------------------------------------------------
 # Error paths (must exit 1)
 # ---------------------------------------------------------------------------

--- a/tests/test_validate_sources.py
+++ b/tests/test_validate_sources.py
@@ -271,6 +271,26 @@ def test_discovery_windows_style_path_traversal_is_rejected(vs, sources, capsys)
     assert "E_PATH_TRAVERSAL" in out
 
 
+def test_discovery_path_must_be_string(vs, sources, capsys):
+    _write(
+        sources / "github_search.json",
+        {
+            "name": "GH search",
+            "skills": [
+                {
+                    "repo": "owner/repo",
+                    "path": 123,
+                    "description": None,
+                }
+            ],
+        },
+    )
+    rc = vs.main(["--sources-dir", str(sources)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "E_PATH_TYPE" in out
+
+
 def test_leading_slash_path_is_rejected(vs, sources, capsys):
     _write(
         sources / "community.json",


### PR DESCRIPTION
## Motivation

`scripts/utils.py` is the canonical home for cross-script invariants documented in `AGENTS.md` (case-conflict policy, repo-suffix fallback, deterministic paths) and `THIRD_PARTY_NOTICES.md` (license normalization / classification). It had **no direct test coverage** before this change, so a silent regression there corrupts every entry in the ~106k-skill registry without a CI signal. The companion `validate_sources.py` gives PR contributors immediate offline feedback on `sources/*.json` shape — the `Option 2: Submit via PR` flow described in `README.md`.

## Summary

- `tests/test_utils.py` — 99 cases covering license normalization, license classification (compatible / restricted / unknown buckets), source-URL construction, author inference, full legal-metadata composition, name/category normalization, repo-suffix truncation, skill-key priority, `ensure_unique_dir` (case conflict, repo-suffix preference, short-hash fallback, numeric disambiguator, metadata-key reuse), frontmatter parsing, description extraction (markdown link strip, code-fence skip, length truncation), `load_metadata` error tolerance, `write_metadata` round trip, and category guessing. **`utils.py` coverage: 55% to 95%.**
- `scripts/validate_sources.py` — offline CLI that validates `sources/*.json` shape: required `name` / `repo` / `description`, `owner/name` repo format, path traversal, category enum from `schema/skill.schema.json`, tag pattern, cross-file duplicate keys. Curated catalogs (`community.json`, `anthropic.json`, `skillsmp.json`) get full validation; auto-discovered catalogs (`discovered.json`, `github_search.json`, `crawled.json`) only get repo-format and path-safety checks so contributors don't get red CI on files they didn't edit. Anthropic-style top-level `repo` inheritance is supported. Exit codes: `0` clean, `1` errors, `2` strict-warnings. Supports `--json` for machine consumption.
- `tests/test_validate_sources.py` — 18 cases for happy paths, every documented error code (`E_JSON`, `E_TOPLEVEL`, `E_NAME`, `E_REPO`, `E_REPO_FORMAT`, `E_PATH_TRAVERSAL`, `E_PATH_LEADING_SLASH`, `E_SKILLS_TYPE`), warning codes (`W_CATEGORY_UNKNOWN`, `W_DUPLICATE`, `W_DESCRIPTION_SHORT`), `--strict` promotion, `--json` output, and CLI argument handling.
- `.github/workflows/validate-sources.yml` — runs the validator and the two new test files on PRs touching `sources/`, `scripts/utils.py`, `scripts/validate_sources.py`, or the new test files. Errors fail the build; warnings only print so authored category drift does not break unrelated PRs.

## Verification

```
$ python -m pytest tests/
======================== 183 passed, 1 warning in 3.99s ========================
```

```
$ python scripts/validate_sources.py
Scanned 9 file(s), 9798 skill row(s); errors=0, warnings=6
```

The 6 warnings flag legitimate category drift in `community.json` (`personal-development`, `business`, `messaging`, `engineering`) where contributed entries used categories outside the `schema/skill.schema.json` enum. They are surfaced for follow-up but do not fail CI.

## Test plan

- [x] `pytest tests/test_utils.py` — 99 pass
- [x] `pytest tests/test_validate_sources.py` — 18 pass
- [x] `pytest tests/` — full suite 183 pass, no regression
- [x] `python scripts/validate_sources.py` — exit 0 against current `sources/*.json`
- [x] `python scripts/validate_sources.py --strict` — exit 2 (warnings present)
- [x] `python scripts/validate_sources.py --json` — emits parseable JSON
- [x] YAML syntax of `.github/workflows/validate-sources.yml` validated locally
- [ ] CI green on this PR

## Out of scope

- Fixing the 6 category-drift warnings (separate concern; would change source data, not pipeline)
- Coverage of `crawler/`, `scripts/sync_and_download.py` and other large modules (already partly tested elsewhere)

## Notes

- Does not change any public API; purely additive.
- No new third-party dependencies (uses `pyyaml`, `pytest`, `jsonschema` already in `pyproject.toml`).
- `validate_sources.py` is complementary to `check_community_intake_diff.py`: that script enforces "don't rewrite the file"; this one enforces "the new entry's fields are well-formed".