### PR TITLE
Reject unsafe downloaded skills before archive commit

### DIFF
--- a/scripts/sync_and_download.py
+++ b/scripts/sync_and_download.py
@@ -42,7 +42,7 @@ sys.path.insert(0, str(ROOT_DIR))
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from discover_by_topic import GitHubTopicDiscovery
-from security_blocklist import blocked_metadata_source, blocked_repo_entry, load_security_blocklist
+from security_blocklist import blocked_metadata_source, load_security_blocklist
 from utils import (
     build_legal_metadata,
     build_skill_key,
@@ -709,6 +709,7 @@ async def download_skills(
     from collections import defaultdict
 
     import aiohttp
+    from security_scanner import SecurityScanner
 
     GITHUB_RAW_BASE = "https://raw.githubusercontent.com"
     BRANCHES = ("main", "master")
@@ -731,6 +732,7 @@ async def download_skills(
     )
     security_blocklist = load_security_blocklist()
     logger.info("Security blocklist loaded: %s repos", len(security_blocklist))
+    security_scanner = SecurityScanner()
     removed_blocked_archives = validate_existing_archive_sources(
         output_dir,
         security_blocklist,
@@ -1119,12 +1121,28 @@ async def download_skills(
             failures["no_repo"].append(name)
             add_observation(skill, outcome="failed", failure_reason="no_repo")
             return False
-        blocked_entry = blocked_repo_entry(repo, security_blocklist)
-        if blocked_entry:
+        blocked_source = blocked_metadata_source(
+            {
+                **skill,
+                "repo": repo,
+                "path": path or skill.get("path", ""),
+                "github_path": skill.get("github_path", ""),
+            },
+            security_blocklist,
+        )
+        if blocked_source:
+            blocked_entry, source_field = blocked_source
             reason = blocked_entry.get("reason") or "blocked source repo"
-            failures["blocked_source"].append(f"{repo}: {name} ({reason})")
+            failures["blocked_source"].append(
+                f"{blocked_entry['repo']}: {name} via {source_field} ({reason})"
+            )
             add_observation(skill, outcome="failed", failure_reason="blocked_source")
-            logger.warning("Blocked security-listed source repo: %s (%s)", repo, name)
+            logger.warning(
+                "Blocked security-listed source before download: %s via %s (%s)",
+                blocked_entry["repo"],
+                source_field,
+                name,
+            )
             return False
 
         manifest_key = build_manifest_key(repo, path, name, category)
@@ -1221,6 +1239,38 @@ async def download_skills(
                                         }, indent=2, ensure_ascii=False),
                                         encoding="utf-8"
                                     )
+                                    is_safe, security_issues = security_scanner.scan_file(
+                                        skill_dir / "SKILL.md"
+                                    )
+                                    if not is_safe:
+                                        issue_types = sorted(
+                                            {
+                                                str(issue.get("type") or "unknown")
+                                                for issue in security_issues
+                                            }
+                                        )
+                                        shutil.rmtree(skill_dir, ignore_errors=True)
+                                        failures["security_scan_failed"].append(
+                                            f"{repo}: {name} ({', '.join(issue_types[:8])})"
+                                        )
+                                        stats["url_attempts"] += attempts
+                                        add_observation(
+                                            skill,
+                                            outcome="failed",
+                                            failure_reason="security_scan_failed",
+                                            attempts=attempts,
+                                            manifest_hit=manifest_entry is not None,
+                                            branch=branch,
+                                            relative_path=relative_path,
+                                            bundled_file_count=len(bundled_files),
+                                        )
+                                        logger.warning(
+                                            "Rejected downloaded skill after security scan: %s/%s (%s)",
+                                            repo,
+                                            relative_path,
+                                            ", ".join(issue_types[:8]),
+                                        )
+                                        return False
                                     preferred_branch_by_repo[repo] = branch
                                     manifest_entries[manifest_key] = {
                                         "repo": repo,

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -143,6 +143,96 @@ def test_download_blocks_security_listed_source_repo(tmp_path, monkeypatch):
     assert failure_report["failure_reasons"]["blocked_source"] == 1
 
 
+def test_download_blocks_security_listed_source_path_alias(tmp_path, monkeypatch):
+    module = load_module()
+    registry_path = tmp_path / "registry.json"
+    output_dir = tmp_path / "skills"
+    failure_report_path = tmp_path / "failure_report.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "skills": [
+                    {
+                        "name": "toprank",
+                        "repo": "nowork-studio/toprank",
+                        "path": "openclaw/skills/toprank/SKILL.md",
+                        "category": "development",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    install_fake_aiohttp(monkeypatch, {})
+
+    stats = asyncio.run(
+        module.download_skills(
+            registry_path,
+            output_dir,
+            failure_report_path=failure_report_path,
+        )
+    )
+
+    assert stats["downloaded"] == 0
+    assert stats["failed"] == 1
+    assert not list(output_dir.rglob("SKILL.md"))
+    failure_report = json.loads(failure_report_path.read_text(encoding="utf-8"))
+    assert failure_report["failure_reasons"]["blocked_source"] == 1
+
+
+def test_download_removes_skill_that_fails_security_scan(tmp_path, monkeypatch):
+    module = load_module()
+    registry_path = tmp_path / "registry.json"
+    output_dir = tmp_path / "skills"
+    failure_report_path = tmp_path / "failure_report.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "skills": [
+                    {
+                        "name": "unsafe-demo",
+                        "repo": "acme/unsafe-demo",
+                        "path": "SKILL.md",
+                        "category": "development",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    install_fake_aiohttp(
+        monkeypatch,
+        {
+            "https://raw.githubusercontent.com/acme/unsafe-demo/main/SKILL.md": FakeResponse(
+                200,
+                text=(
+                    "---\nname: unsafe-demo\n"
+                    "description: Demo skill with unsafe shell execution.\n---\n"
+                    "# Unsafe Demo\n"
+                    "```python\n"
+                    "import subprocess\n"
+                    "subprocess.run('echo unsafe', shell=True)\n"
+                    "```\n"
+                ),
+            ),
+        },
+    )
+
+    stats = asyncio.run(
+        module.download_skills(
+            registry_path,
+            output_dir,
+            failure_report_path=failure_report_path,
+        )
+    )
+
+    assert stats["downloaded"] == 0
+    assert stats["failed"] == 1
+    assert not list(output_dir.rglob("SKILL.md"))
+    failure_report = json.loads(failure_report_path.read_text(encoding="utf-8"))
+    assert failure_report["failure_reasons"]["security_scan_failed"] == 1
+
+
 def test_download_removes_existing_blocked_archive_before_existing_skip(tmp_path, monkeypatch):
     module = load_module()
     registry_path = tmp_path / "registry.json"


### PR DESCRIPTION
## Summary\n- reject registry entries whose path aliases a blocked source before download\n- run the existing security scanner on each newly downloaded archive before accepting it\n- remove unsafe downloaded skill directories and record security_scan_failed in the failure report\n\n## Verification\n- uv run --no-project --with pytest --with pytest-cov --with pytest-asyncio --with aiohttp --with requests --with pyyaml --with jsonschema python -m pytest\n- git diff --check\n- bash -n scripts/sync_main_repo.sh