### PR TITLE
Clean CI archive leftovers before download

### DIFF
--- a/scripts/sync_and_download.py
+++ b/scripts/sync_and_download.py
@@ -29,6 +29,7 @@ import json
 import logging
 import os
 import shutil
+import subprocess
 import sys
 import time
 from datetime import datetime, timedelta, timezone
@@ -522,6 +523,65 @@ def validate_existing_archive_sources(
     return []
 
 
+def remove_ci_untracked_archive_files(output_dir: Path) -> int:
+    """Remove stale untracked archive files from CI data checkouts.
+
+    The core repo still has a legacy ``skills/`` tree. In GitHub Actions the
+    data repo is checked out into that same path, so old core files can remain
+    as untracked files inside the data checkout and then fail incremental scans.
+    Only do this cleanup in CI; local untracked files are user work.
+    """
+    if os.environ.get("GITHUB_ACTIONS") != "true":
+        return 0
+    if not (output_dir / ".git").exists():
+        return 0
+
+    result = subprocess.run(
+        ["git", "-C", str(output_dir), "ls-files", "--others", "--exclude-standard", "-z"],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(f"Cannot list untracked archive files in {output_dir}: {stderr}")
+
+    output_root = output_dir.resolve()
+    removed = 0
+    touched_parents: set[Path] = set()
+    for raw_path in result.stdout.split(b"\0"):
+        if not raw_path:
+            continue
+        rel_path = Path(raw_path.decode("utf-8", errors="surrogateescape"))
+        if rel_path.is_absolute() or ".." in rel_path.parts:
+            raise RuntimeError(f"Refusing unsafe untracked archive path: {rel_path}")
+        target = (output_dir / rel_path).resolve()
+        try:
+            target.relative_to(output_root)
+        except ValueError as exc:
+            raise RuntimeError(f"Refusing untracked archive path outside output dir: {target}") from exc
+        if target.is_dir():
+            shutil.rmtree(target)
+        elif target.exists() or target.is_symlink():
+            target.unlink()
+        else:
+            continue
+        removed += 1
+        touched_parents.add(target.parent)
+
+    for parent in sorted(touched_parents, key=lambda path: len(path.parts), reverse=True):
+        current = parent
+        while current != output_root and current.exists():
+            try:
+                current.rmdir()
+            except OSError:
+                break
+            current = current.parent
+
+    if removed:
+        logger.warning("Removed %s CI-only untracked archive file(s) before download", removed)
+    return removed
+
+
 def build_branch_probe_order(
     repo: str,
     preferred_branch_by_repo: dict[str, str],
@@ -738,6 +798,7 @@ async def download_skills(
         security_blocklist,
         remove_blocked=True,
     )
+    removed_ci_untracked_files = remove_ci_untracked_archive_files(output_dir)
 
     # Check existing (across all categories)
     exclude = {".git", ".github-skills", ".template", ".templates", ".attic"}
@@ -834,6 +895,7 @@ async def download_skills(
             "prefiltered_no_repo": pending_skipped["no_repo"],
             "skipped_cooldown_not_found": pending_skipped["cooldown_not_found"],
             "blocked_archives_removed": len(removed_blocked_archives),
+            "ci_untracked_files_removed": removed_ci_untracked_files,
         }
 
     stats = {
@@ -850,6 +912,7 @@ async def download_skills(
         "prefiltered_no_repo": pending_skipped["no_repo"],
         "skipped_cooldown_not_found": pending_skipped["cooldown_not_found"],
         "blocked_archives_removed": len(removed_blocked_archives),
+        "ci_untracked_files_removed": removed_ci_untracked_files,
     }
     failures = defaultdict(list)
     observations: list[dict] = []

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -1,6 +1,7 @@
 import asyncio
 import importlib.util
 import json
+import subprocess
 import sys
 import types
 from datetime import timedelta
@@ -268,6 +269,41 @@ description: Existing blocked archive.
     assert stats["blocked_archives_removed"] == 1
     assert stats["downloaded"] == 0
     assert not skill_dir.exists()
+
+
+def test_download_removes_ci_untracked_archive_leftovers(tmp_path, monkeypatch):
+    module = load_module()
+    registry_path = tmp_path / "registry.json"
+    output_dir = tmp_path / "skills"
+    stale_dir = output_dir / "other" / "old-core-leftover"
+    stale_dir.mkdir(parents=True)
+    (stale_dir / "SKILL.md").write_text(
+        """---
+name: old-core-leftover
+description: Stale file left by the core checkout.
+---
+
+# Demo
+""",
+        encoding="utf-8",
+    )
+    (stale_dir / "metadata.json").write_text("{}", encoding="utf-8")
+    registry_path.write_text(json.dumps({"skills": []}), encoding="utf-8")
+    install_fake_aiohttp(monkeypatch, {})
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+
+    subprocess_result = subprocess.run(
+        ["git", "init"],
+        cwd=output_dir,
+        check=True,
+        capture_output=True,
+    )
+    assert subprocess_result.returncode == 0
+
+    stats = asyncio.run(module.download_skills(registry_path, output_dir))
+
+    assert stats["ci_untracked_files_removed"] == 2
+    assert not stale_dir.exists()
 
 
 def test_existing_archive_blocks_security_listed_github_path(tmp_path):


### PR DESCRIPTION
## Summary\n- remove CI-only untracked archive leftovers from the data checkout before download\n- keep local runs safe by gating cleanup on GITHUB_ACTIONS=true\n- add coverage for stale core skills left under a git-backed archive dir\n\n## Verification\n- uv run --no-project --with pytest --with pytest-cov --with pytest-asyncio --with aiohttp --with requests --with pyyaml --with jsonschema python -m pytest\n- git diff --check\n- bash -n scripts/sync_main_repo.sh