### PR TITLE
Reject unsafe discovered skills before archive commit

### DIFF
--- a/scripts/discover_by_topic.py
+++ b/scripts/discover_by_topic.py
@@ -8,11 +8,14 @@ import os
 import json
 import time
 import logging
+import shutil
 from collections import defaultdict
 import requests
 from datetime import datetime
 from pathlib import Path
 
+from security_blocklist import blocked_metadata_source, load_security_blocklist
+from security_scanner import SecurityScanner
 from utils import normalize_name, ensure_unique_dir, build_skill_key, build_legal_metadata
 
 logging.basicConfig(level=logging.INFO)
@@ -66,6 +69,8 @@ class GitHubTopicDiscovery:
 
         self.discovered_repos = set()
         self.skills = []
+        self.security_blocklist = load_security_blocklist()
+        self.security_scanner = SecurityScanner()
         self.repo_candidates = {}
         self.path_candidates = {}
         self.topic_stats = defaultdict(
@@ -293,6 +298,20 @@ class GitHubTopicDiscovery:
 
     def download_skill(self, repo, path, output_dir):
         """Download a SKILL.md file"""
+        blocked_source = blocked_metadata_source(
+            {"repo": repo, "path": path},
+            self.security_blocklist,
+        )
+        if blocked_source:
+            blocked_entry, source_field = blocked_source
+            logger.warning(
+                "Blocked security-listed discovered source: %s via %s (%s)",
+                blocked_entry["repo"],
+                source_field,
+                path,
+            )
+            return False
+
         # Extract skill name from path
         parts = path.rsplit('/', 1)
         if len(parts) == 2:
@@ -343,6 +362,20 @@ class GitHubTopicDiscovery:
                     (skill_path / 'metadata.json').write_text(
                         json.dumps(metadata, indent=2), encoding='utf-8'
                     )
+
+                    is_safe, issues = self.security_scanner.scan_file(skill_path / 'SKILL.md')
+                    if not is_safe:
+                        issue_types = sorted(
+                            {str(issue.get("type") or "unknown") for issue in issues}
+                        )
+                        shutil.rmtree(skill_path, ignore_errors=True)
+                        logger.warning(
+                            "Rejected discovered skill after security scan: %s/%s (%s)",
+                            repo,
+                            path,
+                            ", ".join(issue_types[:8]),
+                        )
+                        return False
 
                     return True
             except Exception as e:

--- a/tests/test_discover_by_topic_learning_outputs.py
+++ b/tests/test_discover_by_topic_learning_outputs.py
@@ -15,6 +15,21 @@ def load_module():
     return module
 
 
+class FakeResponse:
+    def __init__(self, status_code, text=""):
+        self.status_code = status_code
+        self.text = text
+
+
+class FakeSession:
+    def __init__(self, response):
+        self.response = response
+        self.headers = {}
+
+    def get(self, url, timeout=None):
+        return self.response
+
+
 def test_write_candidates_jsonl_emits_repo_and_path_rows(tmp_path):
     module = load_module()
     discovery = module.GitHubTopicDiscovery(request_delay=0.0)
@@ -102,3 +117,46 @@ def test_update_priors_accumulates_stats_across_runs(tmp_path):
     assert repo["selected_runs"] == 2
     assert repo["downloaded_skills"] == 2
     assert priors["topic_yield"]["claude-skills"]["downloaded_skills"] == 2
+
+
+def test_download_skill_rejects_security_listed_path(tmp_path):
+    module = load_module()
+    discovery = module.GitHubTopicDiscovery(request_delay=0.0)
+    discovery.session = FakeSession(FakeResponse(200, "---\nname: demo\n---\n# Demo\n"))
+
+    downloaded = discovery.download_skill(
+        "nowork-studio/toprank",
+        "openclaw/skills/toprank/SKILL.md",
+        tmp_path / "skills",
+    )
+
+    assert downloaded is False
+    assert not list(tmp_path.rglob("SKILL.md"))
+
+
+def test_download_skill_removes_security_scan_failure(tmp_path):
+    module = load_module()
+    discovery = module.GitHubTopicDiscovery(request_delay=0.0)
+    discovery.session = FakeSession(
+        FakeResponse(
+            200,
+            (
+                "---\nname: unsafe-demo\n"
+                "description: Demo skill with unsafe shell execution.\n---\n"
+                "# Unsafe Demo\n"
+                "```python\n"
+                "import subprocess\n"
+                "subprocess.run('echo unsafe', shell=True)\n"
+                "```\n"
+            ),
+        )
+    )
+
+    downloaded = discovery.download_skill(
+        "acme/unsafe-demo",
+        "skills/unsafe-demo/SKILL.md",
+        tmp_path / "skills",
+    )
+
+    assert downloaded is False
+    assert not list(tmp_path.rglob("SKILL.md"))


### PR DESCRIPTION
## Summary
- apply the security blocklist before topic-discovered skills are fetched
- scan downloaded topic-discovered SKILL.md files before committing them to the archive output
- remove rejected discovery outputs so unsafe files do not reach the later sync-data security gate

## Tests
- uv run --no-project --with pytest --with pytest-cov --with pytest-asyncio --with aiohttp --with requests --with pyyaml --with jsonschema python -m pytest tests/test_discover_by_topic_learning_outputs.py tests/test_sync_and_download.py tests/test_security_blocklist.py tests/test_security_scanner.py
- uv run --no-project --with pytest --with pytest-cov --with pytest-asyncio --with aiohttp --with requests --with pyyaml --with jsonschema python -m pytest
- git diff --check
- bash -n scripts/sync_main_repo.sh