### PR TITLE
Fix pipeline search index guards

### DIFF
--- a/.github/workflows/build-index.yml
+++ b/.github/workflows/build-index.yml
@@ -3,6 +3,12 @@ name: Build Search Index
 on:
   # Manual trigger
   workflow_dispatch:
+    inputs:
+      allow_missing_security_report:
+        description: "Allow building without the latest security-report artifact"
+        required: false
+        type: boolean
+        default: false
 
   # Run when registry or site sources change
   push:
@@ -53,10 +59,24 @@ jobs:
 
       - name: Download latest security report
         uses: actions/github-script@v9
+        env:
+          ALLOW_MISSING_SECURITY_REPORT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.allow_missing_security_report == 'true' }}
         with:
           script: |
             const {owner, repo} = context.repo;
             const workflow_id = 'sync-data.yml';
+            const allowMissing = process.env.ALLOW_MISSING_SECURITY_REPORT === 'true';
+            const fs = require('fs');
+            const path = require('path');
+            const markerPath = path.join(process.env.GITHUB_WORKSPACE, 'security-report-missing.allowed');
+            function handleMissing(message) {
+              if (allowMissing) {
+                core.warning(`${message} Continuing because allow_missing_security_report=true.`);
+                fs.writeFileSync(markerPath, `${message}\n`);
+                return;
+              }
+              core.setFailed(message);
+            }
             const runs = await github.rest.actions.listWorkflowRuns({
               owner,
               repo,
@@ -66,14 +86,14 @@ jobs:
               per_page: 1
             });
             if (!runs.data.workflow_runs.length) {
-              core.warning('No successful sync-data runs found.');
+              handleMissing('No successful sync-data runs found.');
               return;
             }
             const run_id = runs.data.workflow_runs[0].id;
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({ owner, repo, run_id });
             const artifact = artifacts.data.artifacts.find(a => a.name === 'security-report');
             if (!artifact) {
-              core.warning('No security-report artifact found.');
+              handleMissing('No security-report artifact found.');
               return;
             }
             const download = await github.rest.actions.downloadArtifact({
@@ -82,15 +102,22 @@ jobs:
               artifact_id: artifact.id,
               archive_format: 'zip'
             });
-            const fs = require('fs');
-            const path = require('path');
             const zipPath = path.join(process.env.GITHUB_WORKSPACE, 'security-report.zip');
             fs.writeFileSync(zipPath, Buffer.from(download.data));
 
       - name: Extract security report
         run: |
-          unzip -o security-report.zip -d docs || true
-          ls -la docs/security-report.json || true
+          if [ ! -f security-report.zip ]; then
+            if [ -f security-report-missing.allowed ]; then
+              echo "::warning::security-report artifact is missing by explicit workflow_dispatch override."
+              exit 0
+            fi
+            echo "security-report.zip missing."
+            exit 1
+          fi
+          unzip -o security-report.zip -d docs
+          test -f docs/security-report.json
+          ls -la docs/security-report.json
 
       - name: Build search index
         run: |

--- a/.github/workflows/metadata-compliance.yml
+++ b/.github/workflows/metadata-compliance.yml
@@ -20,6 +20,11 @@ on:
         required: false
         type: boolean
         default: false
+      allow_missing_data_repo:
+        description: "Allow advisory scan when the data repo checkout is unavailable"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -65,10 +70,20 @@ jobs:
           fetch-depth: 0
 
       - name: Ensure skills workspace exists
+        env:
+          ALLOW_MISSING_DATA_REPO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.allow_missing_data_repo == 'true' }}
+          IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
         run: |
+          mkdir -p .tmp
           mkdir -p skills
           if [ ! -d skills/.git ]; then
-            echo "::warning::skills data repo not available in this context; compliance scan will have zero targets."
+            if [ "$ALLOW_MISSING_DATA_REPO" = "true" ] || [ "$IS_FORK_PR" = "true" ]; then
+              echo "::warning::skills data repo not available in this context; metadata compliance will run with zero targets."
+              echo "skills data repo unavailable" > .tmp/metadata-advisory-zero-targets
+            else
+              echo "skills data repo checkout failed; refusing to run metadata compliance with zero targets."
+              exit 1
+            fi
           fi
 
       - name: Set up Python
@@ -91,6 +106,7 @@ jobs:
               git -C skills ls-files --others --exclude-standard
             } | sed 's#^#skills/#' | sort -u > .tmp/changed-files.txt
           else
+            echo "::warning::skills data repo unavailable; changed metadata target list is empty by explicit advisory path."
             : > .tmp/changed-files.txt
           fi
           echo "Changed skill files:"

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -5,7 +5,8 @@
  */
 
 const CONFIG = {
-    INDEX_URL: 'search-index.json',
+    INDEX_URL: 'search-index-lite.json',
+    LEGACY_INDEX_URL: 'search-index.json',
     FEATURED_URL: 'featured.json',
     CATEGORIES_URL: 'categories/index.json',
     PLUGINS_URL: 'plugins.json',
@@ -41,6 +42,11 @@ const CATEGORY_NAMES = {
     'off': 'Official',
     'oth': 'Other'
 };
+
+// Full category name to short code mapping
+const CATEGORY_CODES_REVERSE = Object.fromEntries(
+    Object.entries(CATEGORY_NAMES).map(([code, name]) => [name.toLowerCase(), code])
+);
 
 // Category colors for charts
 const CATEGORY_COLORS = {
@@ -125,12 +131,88 @@ const elements = {
     themeIcon: document.getElementById('theme-icon')
 };
 
+async function fetchJson(url) {
+    const response = await fetch(url);
+    if (!response.ok) {
+        throw new Error(`${url} returned ${response.status}`);
+    }
+    return response.json();
+}
+
+function normalizeCategoryCode(category) {
+    if (!category) {
+        return 'oth';
+    }
+
+    const normalized = String(category).trim().toLowerCase();
+    if (CATEGORY_NAMES[normalized]) {
+        return normalized;
+    }
+    return CATEGORY_CODES_REVERSE[normalized] || 'oth';
+}
+
+function normalizeSkillRecord(skill) {
+    if (skill.n) {
+        return skill;
+    }
+
+    return {
+        n: skill.name || 'Unknown skill',
+        d: skill.description || '',
+        c: normalizeCategoryCode(skill.category),
+        g: Array.isArray(skill.tags) ? skill.tags.slice(0, 5) : [],
+        r: Number(skill.stars || 0),
+        i: skill.install || skill.id || skill.name || '',
+        b: skill.branch || 'main'
+    };
+}
+
+function normalizeSearchIndex(indexData) {
+    if (Array.isArray(indexData.s)) {
+        return {
+            ...indexData,
+            s: indexData.s.map(normalizeSkillRecord),
+            includedCount: indexData.s.length,
+            isLite: false
+        };
+    }
+
+    if (Array.isArray(indexData.skills)) {
+        return {
+            v: indexData.version || indexData.updated_at || '',
+            t: Number(indexData.total_count || indexData.skills.length),
+            s: indexData.skills.map(normalizeSkillRecord),
+            includedCount: Number(indexData.included_count || indexData.skills.length),
+            isLite: true
+        };
+    }
+
+    throw new Error('Unsupported search index schema');
+}
+
+async function loadSearchIndex() {
+    try {
+        return normalizeSearchIndex(await fetchJson(CONFIG.INDEX_URL));
+    } catch (error) {
+        console.warn(`Failed to load ${CONFIG.INDEX_URL}; falling back to ${CONFIG.LEGACY_INDEX_URL}:`, error);
+        return normalizeSearchIndex(await fetchJson(CONFIG.LEGACY_INDEX_URL));
+    }
+}
+
+function formatResultCount(count) {
+    const base = `${count.toLocaleString()} results`;
+    if (state.index?.isLite) {
+        return `${base} in highlighted index`;
+    }
+    return base;
+}
+
 // Initialize
 async function init() {
     try {
         // Load index and featured in parallel
         const [indexData, featuredData, categoriesData, pluginsData] = await Promise.all([
-            fetch(CONFIG.INDEX_URL).then(r => r.json()),
+            loadSearchIndex(),
             fetch(CONFIG.FEATURED_URL).then(r => r.json()).catch(() => ({ skills: [] })),
             fetch(CONFIG.CATEGORIES_URL).then(r => r.json()).catch(() => ({ categories: [] })),
             fetch(CONFIG.PLUGINS_URL).then(r => r.json()).catch(() => ({ plugins: [] }))
@@ -146,6 +228,9 @@ async function init() {
 
         // Update UI
         elements.totalCount.textContent = state.index.t.toLocaleString();
+        if (state.index.isLite && state.index.includedCount < state.index.t) {
+            elements.totalCount.title = `Searching ${state.index.includedCount.toLocaleString()} highlighted skills out of ${state.index.t.toLocaleString()} total`;
+        }
         elements.lastUpdated.textContent = `Updated: ${state.index.v}`;
 
         // Populate category filters
@@ -347,7 +432,7 @@ function renderCategoryChart() {
     chartContainer.innerHTML = sorted.map(([code, count]) => {
         const name = CATEGORY_NAMES[code] || code;
         const color = CATEGORY_COLORS[code] || '#576574';
-        const percentage = ((count / state.index.t) * 100).toFixed(1);
+        const percentage = ((count / state.index.s.length) * 100).toFixed(1);
         const barWidth = (count / maxCount) * 100;
 
         return `
@@ -480,11 +565,6 @@ function createPluginCard(plugin) {
         </div>
     `;
 }
-
-// Reverse category code lookup
-const CATEGORY_CODES_REVERSE = Object.fromEntries(
-    Object.entries(CATEGORY_NAMES).map(([code, name]) => [name.toLowerCase(), code])
-);
 
 // Copy text to clipboard
 function copyToClipboard(event, text) {
@@ -650,7 +730,7 @@ function search(query) {
     const searchTimeMs = (endTime - startTime).toFixed(1);
 
     // Update UI
-    elements.resultCount.textContent = `${results.length.toLocaleString()} results`;
+    elements.resultCount.textContent = formatResultCount(results.length);
     elements.searchTime.textContent = `${searchTimeMs}ms`;
 
     if (results.length === 0) {
@@ -1223,7 +1303,7 @@ function searchWithFiltersOnly() {
 
     document.querySelectorAll('.nav-tab').forEach(tab => tab.classList.remove('active'));
 
-    elements.resultCount.textContent = `${results.length.toLocaleString()} results`;
+    elements.resultCount.textContent = formatResultCount(results.length);
     elements.searchTime.textContent = `${searchTimeMs}ms`;
 
     if (results.length === 0) {

--- a/scripts/build_search_index.py
+++ b/scripts/build_search_index.py
@@ -46,8 +46,8 @@ CATEGORY_CODES = {
 # Known category directories (for scanning)
 KNOWN_CATEGORIES = set(CATEGORY_CODES.keys()) | {"data", "other"}
 
-# First-paint catalog index. Full search still uses search-index.json until
-# server-side search or sharded search details are introduced.
+# First-paint catalog index used by the static Pages app. Full search-index.json
+# remains available as the compatibility fallback.
 LITE_INDEX_LIMIT = 5000
 
 

--- a/scripts/sync_main_repo.sh
+++ b/scripts/sync_main_repo.sh
@@ -66,6 +66,11 @@ if [[ "$rebuild" -eq 1 ]]; then
     --compat-manifest-pointer
   python "$main_dir/scripts/build_registry_summary.py" --registry "$main_dir/registry.json" --plugins "$main_dir/sources/plugins.json" --output "$main_dir/registry_summary.json"
   python "$main_dir/scripts/build_search_index.py" --skills-dir "$main_dir/skills" --output "$main_dir/docs"
+  python "$main_dir/scripts/check_generated_file_sizes.py" \
+    --root "$main_dir" \
+    --include registry.json \
+    --include registry-shards \
+    --include docs
 fi
 
 echo "Generating third-party notices..."

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read_repo_file(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_pages_app_prefers_lite_index_with_full_index_fallback():
+    app_js = read_repo_file("docs/js/app.js")
+
+    assert "INDEX_URL: 'search-index-lite.json'" in app_js
+    assert "LEGACY_INDEX_URL: 'search-index.json'" in app_js
+    assert "function normalizeSearchIndex" in app_js
+    assert "function loadSearchIndex" in app_js
+    assert "in highlighted index" in app_js
+
+
+def test_publish_sync_runs_generated_size_guard_after_rebuild():
+    sync_script = read_repo_file("scripts/sync_main_repo.sh")
+
+    rebuild_pos = sync_script.index("scripts/build_search_index.py")
+    guard_pos = sync_script.index("scripts/check_generated_file_sizes.py")
+
+    assert guard_pos > rebuild_pos
+    assert "--include registry.json" in sync_script
+    assert "--include registry-shards" in sync_script
+    assert "--include docs" in sync_script
+
+
+def test_build_index_fails_closed_when_security_report_is_missing():
+    workflow = read_repo_file(".github/workflows/build-index.yml")
+
+    assert "allow_missing_security_report" in workflow
+    assert "core.setFailed(message)" in workflow
+    assert "security-report-missing.allowed" in workflow
+    assert "unzip -o security-report.zip -d docs || true" not in workflow
+    assert "test -f docs/security-report.json" in workflow
+
+
+def test_metadata_compliance_refuses_unexpected_zero_target_scan():
+    workflow = read_repo_file(".github/workflows/metadata-compliance.yml")
+
+    assert "allow_missing_data_repo" in workflow
+    assert "metadata-advisory-zero-targets" in workflow
+    assert "refusing to run metadata compliance with zero targets" in workflow
+    assert "exit 1" in workflow


### PR DESCRIPTION
## Summary
- load `search-index-lite.json` first in the static Pages app, with full-index fallback
- fail build-index by default when the latest security report is unavailable
- prevent metadata compliance from silently scanning zero data targets
- run generated artifact size checks during main publish rebuild

Fixes #66
Fixes #67
Fixes #68
Fixes #69

## Verification
- `git diff --check`
- `node --check docs/js/app.js`
- `bash -n scripts/sync_main_repo.sh`
- workflow YAML parse with PyYAML
- `python -m pytest -q` (212 passed)
