### PR TITLE
Shard signal index artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,14 @@ curl https://majiayu000.github.io/claude-skill-registry-core/search-shards/part-
 # Deduplicated catalog index with quality/security/install signals
 curl https://majiayu000.github.io/claude-skill-registry-core/search-index-lite.json
 curl https://majiayu000.github.io/claude-skill-registry-core/quality-index.json
+curl https://majiayu000.github.io/claude-skill-registry-core/quality-index-manifest.json
+curl https://majiayu000.github.io/claude-skill-registry-core/quality-shards/part-000.json
 curl https://majiayu000.github.io/claude-skill-registry-core/security-index.json
+curl https://majiayu000.github.io/claude-skill-registry-core/security-index-manifest.json
+curl https://majiayu000.github.io/claude-skill-registry-core/security-shards/part-000.json
 curl https://majiayu000.github.io/claude-skill-registry-core/ranking-index.json
+curl https://majiayu000.github.io/claude-skill-registry-core/ranking-index-manifest.json
+curl https://majiayu000.github.io/claude-skill-registry-core/ranking-shards/part-000.json
 
 # Lightweight registry summary (counts only)
 curl https://raw.githubusercontent.com/majiayu000/claude-skill-registry-core/main/registry_summary.json

--- a/scripts/build_search_index.py
+++ b/scripts/build_search_index.py
@@ -24,7 +24,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from index_artifacts import write_category_artifacts, write_search_artifacts
+from index_artifacts import write_category_artifacts, write_search_artifacts, write_signal_artifacts
 from plugin_index import build_plugins_index, load_plugins_from_registry, load_plugins_from_source
 from utils import extract_description, get_repo_suffix, load_metadata
 
@@ -523,51 +523,58 @@ def build_search_index(
     with gzip.open(search_index_lite_gz_path, "wt", encoding="utf-8") as f:
         json.dump(lite_index, f, ensure_ascii=False, separators=(",", ":"))
 
-    quality_index_path = output_dir / "quality-index.json"
-    with open(quality_index_path, "w", encoding="utf-8") as f:
-        json.dump(
-            {
-                "updated_at": utc_now_isoformat(),
-                "count": len(quality_records_by_id),
-                "records": list(quality_records_by_id.values()),
-            },
-            f,
-            ensure_ascii=False,
-            separators=(",", ":"),
-        )
-
-    security_index_path = output_dir / "security-index.json"
-    with open(security_index_path, "w", encoding="utf-8") as f:
-        json.dump(
-            {
-                "updated_at": utc_now_isoformat(),
-                "count": len(security_records_by_id),
-                "records": list(security_records_by_id.values()),
-            },
-            f,
-            ensure_ascii=False,
-            separators=(",", ":"),
-        )
-
-    ranking_index_path = output_dir / "ranking-index.json"
-    with open(ranking_index_path, "w", encoding="utf-8") as f:
-        json.dump(
-            {
-                "updated_at": utc_now_isoformat(),
-                "count": len(ranking_records),
-                "records": ranking_records,
-            },
-            f,
-            ensure_ascii=False,
-            separators=(",", ":"),
-        )
+    quality_artifacts = write_signal_artifacts(
+        list(quality_records_by_id.values()),
+        output_dir,
+        artifact_name="quality-index",
+        shard_dir_name="quality-shards",
+        record_schema="quality-v1",
+        shard_strategy="bounded-sequential-scan-order",
+        updated_at=utc_now_isoformat(),
+    )
+    security_artifacts = write_signal_artifacts(
+        list(security_records_by_id.values()),
+        output_dir,
+        artifact_name="security-index",
+        shard_dir_name="security-shards",
+        record_schema="security-v1",
+        shard_strategy="bounded-sequential-scan-order",
+        updated_at=utc_now_isoformat(),
+    )
+    ranking_artifacts = write_signal_artifacts(
+        ranking_records,
+        output_dir,
+        artifact_name="ranking-index",
+        shard_dir_name="ranking-shards",
+        record_schema="ranking-v1",
+        shard_strategy="bounded-sequential-score-desc",
+        updated_at=utc_now_isoformat(),
+    )
 
     logger.info(
         f"  search-index-lite.json: {search_index_lite_path.stat().st_size / 1024 / 1024:.2f} MB"
     )
-    logger.info(f"  quality-index.json: {quality_index_path.stat().st_size / 1024 / 1024:.2f} MB")
-    logger.info(f"  security-index.json: {security_index_path.stat().st_size / 1024 / 1024:.2f} MB")
-    logger.info(f"  ranking-index.json: {ranking_index_path.stat().st_size / 1024 / 1024:.2f} MB")
+    logger.info(
+        f"  quality-index.json pointer: {quality_artifacts.index_size_bytes / 1024 / 1024:.2f} MB"
+    )
+    logger.info(
+        f"  quality shards: {quality_artifacts.shard_count} "
+        f"(largest {quality_artifacts.largest_shard_bytes / 1024 / 1024:.2f} MB)"
+    )
+    logger.info(
+        f"  security-index.json pointer: {security_artifacts.index_size_bytes / 1024 / 1024:.2f} MB"
+    )
+    logger.info(
+        f"  security shards: {security_artifacts.shard_count} "
+        f"(largest {security_artifacts.largest_shard_bytes / 1024 / 1024:.2f} MB)"
+    )
+    logger.info(
+        f"  ranking-index.json pointer: {ranking_artifacts.index_size_bytes / 1024 / 1024:.2f} MB"
+    )
+    logger.info(
+        f"  ranking shards: {ranking_artifacts.shard_count} "
+        f"(largest {ranking_artifacts.largest_shard_bytes / 1024 / 1024:.2f} MB)"
+    )
 
     category_artifacts = write_category_artifacts(
         categories,
@@ -651,17 +658,40 @@ def build_search_index(
         "lite_index_included_count": len(lite_skills),
         "lite_index_size_bytes": search_index_lite_path.stat().st_size,
         "lite_index_gzip_size_bytes": search_index_lite_gz_path.stat().st_size,
-        "quality_index_size_bytes": quality_index_path.stat().st_size,
-        "security_index_size_bytes": security_index_path.stat().st_size,
-        "ranking_index_size_bytes": ranking_index_path.stat().st_size,
+        "quality_index_size_bytes": quality_artifacts.index_size_bytes,
+        "quality_index_gzip_size_bytes": quality_artifacts.index_size_gzip_bytes,
+        "quality_shard_count": quality_artifacts.shard_count,
+        "quality_largest_shard_bytes": quality_artifacts.largest_shard_bytes,
+        "quality_largest_shard_gzip_bytes": quality_artifacts.largest_shard_gzip_bytes,
+        "security_index_size_bytes": security_artifacts.index_size_bytes,
+        "security_index_gzip_size_bytes": security_artifacts.index_size_gzip_bytes,
+        "security_shard_count": security_artifacts.shard_count,
+        "security_largest_shard_bytes": security_artifacts.largest_shard_bytes,
+        "security_largest_shard_gzip_bytes": security_artifacts.largest_shard_gzip_bytes,
+        "ranking_index_size_bytes": ranking_artifacts.index_size_bytes,
+        "ranking_index_gzip_size_bytes": ranking_artifacts.index_size_gzip_bytes,
+        "ranking_shard_count": ranking_artifacts.shard_count,
+        "ranking_largest_shard_bytes": ranking_artifacts.largest_shard_bytes,
+        "ranking_largest_shard_gzip_bytes": ranking_artifacts.largest_shard_gzip_bytes,
         "largest_generated_file_bytes": max(
             search_artifacts.largest_shard_bytes,
+            search_artifacts.largest_shard_gzip_bytes,
             category_artifacts.largest_part_bytes,
+            category_artifacts.largest_part_gzip_bytes,
             search_index_lite_path.stat().st_size,
             search_index_lite_gz_path.stat().st_size,
-            quality_index_path.stat().st_size,
-            security_index_path.stat().st_size,
-            ranking_index_path.stat().st_size,
+            quality_artifacts.index_size_bytes,
+            quality_artifacts.index_size_gzip_bytes,
+            quality_artifacts.largest_shard_bytes,
+            quality_artifacts.largest_shard_gzip_bytes,
+            security_artifacts.index_size_bytes,
+            security_artifacts.index_size_gzip_bytes,
+            security_artifacts.largest_shard_bytes,
+            security_artifacts.largest_shard_gzip_bytes,
+            ranking_artifacts.index_size_bytes,
+            ranking_artifacts.index_size_gzip_bytes,
+            ranking_artifacts.largest_shard_bytes,
+            ranking_artifacts.largest_shard_gzip_bytes,
             (output_dir / "featured.json").stat().st_size,
         ),
     }

--- a/scripts/index_artifacts.py
+++ b/scripts/index_artifacts.py
@@ -32,6 +32,15 @@ class CategoryArtifactStats:
     largest_part_gzip_bytes: int
 
 
+@dataclass(frozen=True)
+class SignalArtifactStats:
+    shard_count: int
+    largest_shard_bytes: int
+    largest_shard_gzip_bytes: int
+    index_size_bytes: int
+    index_size_gzip_bytes: int
+
+
 def compact_json_bytes(payload: object) -> bytes:
     return json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
 
@@ -154,6 +163,80 @@ def write_search_artifacts(
     safe_write_gzip_json(index_gz_path, pointer)
 
     return SearchArtifactStats(
+        shard_count=part_count,
+        largest_shard_bytes=manifest["largest_shard_bytes"],
+        largest_shard_gzip_bytes=manifest["largest_shard_gzip_bytes"],
+        index_size_bytes=index_path.stat().st_size,
+        index_size_gzip_bytes=index_gz_path.stat().st_size,
+    )
+
+
+def write_signal_artifacts(
+    records: list[dict],
+    output_dir: Path,
+    *,
+    artifact_name: str,
+    shard_dir_name: str,
+    record_schema: str,
+    shard_strategy: str,
+    updated_at: str,
+    target_part_bytes: int = DEFAULT_PART_TARGET_BYTES,
+) -> SignalArtifactStats:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    shards_dir = output_dir / shard_dir_name
+    remove_generated_children(shards_dir)
+    shards_dir.mkdir(parents=True, exist_ok=True)
+
+    chunks = chunk_records(records, target_part_bytes)
+    part_count = len(chunks)
+    shard_entries: list[dict] = []
+
+    for idx, chunk in enumerate(chunks):
+        payload = {
+            "schema_version": 1,
+            "updated_at": updated_at,
+            "part": idx,
+            "part_count": part_count,
+            "count": len(chunk),
+            "records": chunk,
+        }
+        part_path = shards_dir / f"part-{idx:03d}.json"
+        gzip_path = shards_dir / f"part-{idx:03d}.json.gz"
+        safe_write_json(part_path, payload)
+        safe_write_gzip_json(gzip_path, payload)
+        shard_entries.append(build_part_entry(part_path, gzip_path, len(chunk), output_dir))
+
+    manifest_name = f"{artifact_name}-manifest.json"
+    manifest = {
+        "schema_version": 1,
+        "updated_at": updated_at,
+        "total_count": len(records),
+        "shard_strategy": shard_strategy,
+        "record_schema": record_schema,
+        "shard_count": part_count,
+        "largest_shard_bytes": max((entry["bytes"] for entry in shard_entries), default=0),
+        "largest_shard_gzip_bytes": max(
+            (entry["gzip_bytes"] for entry in shard_entries),
+            default=0,
+        ),
+        "shards": shard_entries,
+    }
+    safe_write_json(output_dir / manifest_name, manifest)
+
+    pointer = {
+        "schema_version": 1,
+        "updated_at": updated_at,
+        "count": len(records),
+        "deprecated_full_payload": True,
+        "manifest": manifest_name,
+        "message": f"Full {artifact_name} payload moved to {shard_dir_name}/*.json",
+    }
+    index_path = output_dir / f"{artifact_name}.json"
+    index_gz_path = output_dir / f"{artifact_name}.json.gz"
+    safe_write_json(index_path, pointer)
+    safe_write_gzip_json(index_gz_path, pointer)
+
+    return SignalArtifactStats(
         shard_count=part_count,
         largest_shard_bytes=manifest["largest_shard_bytes"],
         largest_shard_gzip_bytes=manifest["largest_shard_gzip_bytes"],

--- a/tests/test_plugin_contract.py
+++ b/tests/test_plugin_contract.py
@@ -90,9 +90,27 @@ def test_build_plugins_index_and_stats_use_plugin_keys(tmp_path):
             encoding="utf-8"
         )
     )
-    quality_data = json.loads((output_dir / "quality-index.json").read_text(encoding="utf-8"))
-    security_data = json.loads((output_dir / "security-index.json").read_text(encoding="utf-8"))
-    ranking_data = json.loads((output_dir / "ranking-index.json").read_text(encoding="utf-8"))
+    quality_pointer = json.loads((output_dir / "quality-index.json").read_text(encoding="utf-8"))
+    quality_manifest = json.loads(
+        (output_dir / "quality-index-manifest.json").read_text(encoding="utf-8")
+    )
+    quality_shard = json.loads(
+        (output_dir / quality_manifest["shards"][0]["path"]).read_text(encoding="utf-8")
+    )
+    security_pointer = json.loads((output_dir / "security-index.json").read_text(encoding="utf-8"))
+    security_manifest = json.loads(
+        (output_dir / "security-index-manifest.json").read_text(encoding="utf-8")
+    )
+    security_shard = json.loads(
+        (output_dir / security_manifest["shards"][0]["path"]).read_text(encoding="utf-8")
+    )
+    ranking_pointer = json.loads((output_dir / "ranking-index.json").read_text(encoding="utf-8"))
+    ranking_manifest = json.loads(
+        (output_dir / "ranking-index-manifest.json").read_text(encoding="utf-8")
+    )
+    ranking_shard = json.loads(
+        (output_dir / ranking_manifest["shards"][0]["path"]).read_text(encoding="utf-8")
+    )
 
     assert "plugins" in plugins_data
     assert "collections" not in plugins_data
@@ -110,6 +128,12 @@ def test_build_plugins_index_and_stats_use_plugin_keys(tmp_path):
     assert stats_data["lite_index_included_count"] == 1
     assert stats_data["search_shard_count"] == 1
     assert stats_data["category_shard_count"] == 1
+    assert stats_data["quality_shard_count"] == 1
+    assert stats_data["security_shard_count"] == 1
+    assert stats_data["ranking_shard_count"] == 1
+    assert stats_data["quality_largest_shard_bytes"] > 0
+    assert stats_data["security_largest_shard_bytes"] > 0
+    assert stats_data["ranking_largest_shard_bytes"] > 0
     assert stats_data["category_counts"] == [
         {"name": "development", "code": "dev", "count": 1}
     ]
@@ -134,10 +158,28 @@ def test_build_plugins_index_and_stats_use_plugin_keys(tmp_path):
     assert lite_data["skills"][0]["id"]
     assert lite_data["skills"][0]["quality_grade"] in {"S", "A", "B", "C", "unknown", "blocked"}
     assert lite_data["skills"][0]["security_status"] == "unknown"
-    assert quality_data["count"] == 1
-    assert security_data["count"] == 1
-    assert ranking_data["count"] == 1
-    assert ranking_data["records"][0]["recommended_score"] >= 0
+    assert quality_pointer["deprecated_full_payload"] is True
+    assert quality_pointer["manifest"] == "quality-index-manifest.json"
+    assert "records" not in quality_pointer
+    assert quality_manifest["record_schema"] == "quality-v1"
+    assert quality_manifest["shard_count"] == 1
+    assert sum(shard["count"] for shard in quality_manifest["shards"]) == 1
+    assert quality_shard["records"][0]["id"]
+    assert security_pointer["deprecated_full_payload"] is True
+    assert security_pointer["manifest"] == "security-index-manifest.json"
+    assert "records" not in security_pointer
+    assert security_manifest["record_schema"] == "security-v1"
+    assert security_manifest["shard_count"] == 1
+    assert sum(shard["count"] for shard in security_manifest["shards"]) == 1
+    assert security_shard["records"][0]["security_status"] == "unknown"
+    assert ranking_pointer["deprecated_full_payload"] is True
+    assert ranking_pointer["manifest"] == "ranking-index-manifest.json"
+    assert "records" not in ranking_pointer
+    assert ranking_manifest["record_schema"] == "ranking-v1"
+    assert ranking_manifest["shard_strategy"] == "bounded-sequential-score-desc"
+    assert ranking_manifest["shard_count"] == 1
+    assert sum(shard["count"] for shard in ranking_manifest["shards"]) == 1
+    assert ranking_shard["records"][0]["recommended_score"] >= 0
 
 
 def test_build_search_index_lite_dedupes_install_and_branch(tmp_path):


### PR DESCRIPTION
## Summary
- Add shared signal index artifact writer for quality/security/ranking outputs.
- Replace monolithic signal index payloads with small compatibility pointers, manifests, gzip variants, and bounded shards.
- Expose signal shard stats in stats.json and update README direct API examples.

Fixes #76

## Tests
- git diff --check
- python -m pytest -q tests/test_plugin_contract.py
- python -m pytest -q
- Full local data build to /tmp/csr-signal-index-6mev61 using ../claude-skill-registry-data
- python scripts/check_generated_file_sizes.py --root /tmp/csr-signal-index-6mev61 --include . --warn-mib 8 --fail-mib 9 --limit 12

## Full-data build result
- Indexed raw skills: 227,820
- Registry dedup count: 155,897
- quality-index.json pointer: 220 bytes, 6 shards, largest shard 8,388,616 bytes
- security-index.json pointer: 223 bytes, 4 shards, largest shard 8,388,629 bytes
- ranking-index.json pointer: 220 bytes, 5 shards, largest shard 8,388,660 bytes
- largest_generated_file_bytes: 8,388,750 bytes
