### PR TITLE
Add canonical taxonomy audit rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,10 +188,19 @@ The merged `claude-skill-registry` publish artifact additionally contains
 
 ## Categories
 
+Canonical category slugs, aliases, short codes, and heuristic keywords live in
+`taxonomy/categories.yaml`. Pipeline scripts read that file instead of keeping
+their own category lists. To review category quality across the archive before
+moving anything, run `python scripts/audit_category_quality.py --skills-dir skills`.
+The default audit uses metadata and paths for a fast full-archive pass; add
+`--include-frontmatter` when checking frontmatter/category drift.
+The audit also reports non-standard nested skill paths such as
+`category/category/skill/SKILL.md`.
+
 Category counts are published in `categories/index.json`; full category payloads
 are available through `categories/<category>/manifest.json` and bounded
 `part-*.json` files. The legacy `categories/<category>.json` URL is now a small
-compatibility pointer. Here are the standard codes:
+compatibility pointer. Common category codes include:
 
 | Category | Code | Description |
 |----------|------|-------------|

--- a/schema/skill.schema.json
+++ b/schema/skill.schema.json
@@ -43,12 +43,8 @@
     },
     "category": {
       "type": "string",
-      "enum": [
-        "development", "testing", "data", "design",
-        "documents", "productivity", "devops", "security",
-        "marketing", "product", "communication", "creative"
-      ],
-      "description": "Primary category"
+      "pattern": "^[a-z0-9][a-z0-9-]{0,63}$",
+      "description": "Primary category slug; canonical values and aliases are defined in taxonomy/categories.yaml"
     },
     "model": {
       "type": "string",

--- a/scripts/audit_category_quality.py
+++ b/scripts/audit_category_quality.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Audit category quality across a skill archive."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from category_taxonomy import (
+    UnknownCategoryError,
+    category_aliases,
+    category_keywords,
+    category_slug,
+    resolve_category,
+)
+from utils import extract_frontmatter, load_metadata
+
+
+def iter_skill_dirs(skills_dir: Path):
+    for dirpath, dirnames, filenames in os.walk(skills_dir):
+        dirnames[:] = sorted(name for name in dirnames if not name.startswith("."))
+        if "SKILL.md" not in filenames:
+            continue
+        skill_file = Path(dirpath) / "SKILL.md"
+        rel = skill_file.relative_to(skills_dir)
+        if any(part.startswith(".") for part in rel.parts):
+            continue
+        yield skill_file.parent, rel
+
+
+def normalized_haystack(text: str) -> str:
+    return f" {category_slug(text).replace('-', ' ')} "
+
+
+def keyword_hits(haystack: str, keywords: list[str]) -> list[str]:
+    hits: list[str] = []
+    for keyword in keywords:
+        needle = f" {category_slug(keyword).replace('-', ' ')} "
+        if needle in haystack:
+            hits.append(keyword)
+    return hits
+
+
+def score_categories(text: str, keyword_map: dict[str, list[str]]) -> dict[str, list[str]]:
+    scores: dict[str, list[str]] = {}
+    haystack = normalized_haystack(text)
+    for category, keywords in keyword_map.items():
+        hits = keyword_hits(haystack, keywords)
+        if hits:
+            scores[category] = hits
+    return scores
+
+
+def read_text_prefix(path: Path, max_chars: int = 8192) -> str:
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        return handle.read(max_chars)
+
+
+def best_suggestion(
+    current_category: str,
+    text: str,
+    keyword_map: dict[str, list[str]],
+    *,
+    min_score: int,
+    min_delta: int,
+) -> dict[str, Any] | None:
+    scores = score_categories(text, keyword_map)
+    if not scores:
+        return None
+
+    ranked = sorted(scores.items(), key=lambda item: (-len(item[1]), item[0]))
+    suggested_category, hits = ranked[0]
+    current_score = len(scores.get(current_category, []))
+    suggested_score = len(hits)
+    if suggested_category == current_category:
+        return None
+    if suggested_score < min_score:
+        return None
+    if current_category != "other" and suggested_score - current_score < min_delta:
+        return None
+
+    reason = f"matched {suggested_score} {suggested_category} keyword(s)"
+    if current_score:
+        reason += f" versus {current_score} current-category keyword(s)"
+
+    return {
+        "suggested_category": suggested_category,
+        "score": suggested_score,
+        "current_score": current_score,
+        "signals": hits,
+        "reason": reason,
+    }
+
+
+def compact_examples(items: list[dict[str, Any]], limit: int) -> list[dict[str, Any]]:
+    return items[: max(limit, 0)]
+
+
+def build_report(
+    skills_dir: Path,
+    *,
+    include_frontmatter: bool = False,
+    content_chars: int = 0,
+    min_score: int = 2,
+    min_delta: int = 2,
+    small_category_threshold: int = 10,
+    limit_candidates: int = 100,
+    limit_examples: int = 20,
+) -> dict[str, Any]:
+    aliases = category_aliases()
+    keyword_map = category_keywords()
+    category_counts: Counter[str] = Counter()
+    unknown_counts: Counter[str] = Counter()
+    alias_usages: list[dict[str, Any]] = []
+    category_conflicts: list[dict[str, Any]] = []
+    layout_issues: list[dict[str, Any]] = []
+    candidates: list[dict[str, Any]] = []
+    total_skills = 0
+    standard_layout_skills = 0
+
+    for skill_dir, rel in iter_skill_dirs(skills_dir):
+        total_skills += 1
+        if len(rel.parts) == 3:
+            standard_layout_skills += 1
+        else:
+            layout_issues.append(
+                {
+                    "path": str(rel),
+                    "expected": "<category>/<skill>/SKILL.md",
+                    "depth": len(rel.parts),
+                }
+            )
+        content = ""
+        frontmatter: dict[str, Any] = {}
+        if include_frontmatter or content_chars > 0:
+            content = read_text_prefix(skill_dir / "SKILL.md", max_chars=max(content_chars, 8192))
+            frontmatter = extract_frontmatter(content)
+        metadata = load_metadata(skill_dir)
+
+        dir_category = rel.parts[0] if rel.parts else "other"
+        raw_sources = {
+            "directory": dir_category,
+            "metadata": metadata.get("category") if isinstance(metadata.get("category"), str) else "",
+            "frontmatter": frontmatter.get("category") if isinstance(frontmatter.get("category"), str) else "",
+        }
+        declared_category = raw_sources["metadata"] or raw_sources["frontmatter"] or raw_sources["directory"]
+        current_category = resolve_category(declared_category, allow_unknown=True)
+        category_counts[current_category] += 1
+
+        if current_category not in keyword_map and current_category not in {"other"}:
+            try:
+                resolve_category(current_category)
+            except UnknownCategoryError:
+                unknown_counts[current_category] += 1
+
+        resolved_sources = {
+            source: resolve_category(value, allow_unknown=True)
+            for source, value in raw_sources.items()
+            if value
+        }
+        if len(set(resolved_sources.values())) > 1:
+            category_conflicts.append(
+                {
+                    "path": str(rel),
+                    "name": metadata.get("name") or frontmatter.get("name") or skill_dir.name,
+                    "resolved_sources": resolved_sources,
+                    "raw_sources": {k: v for k, v in raw_sources.items() if v},
+                }
+            )
+
+        for source, value in raw_sources.items():
+            alias_slug = category_slug(value)
+            if alias_slug in aliases:
+                alias_usages.append(
+                    {
+                        "path": str(rel),
+                        "source": source,
+                        "alias": alias_slug,
+                        "canonical_category": aliases[alias_slug],
+                    }
+                )
+
+        tags = metadata.get("tags") or frontmatter.get("tags") or []
+        if isinstance(tags, list):
+            tag_text = " ".join(str(tag) for tag in tags)
+        else:
+            tag_text = str(tags)
+        text = " ".join(
+            [
+                str(metadata.get("name") or frontmatter.get("name") or skill_dir.name),
+                str(metadata.get("description") or frontmatter.get("description") or ""),
+                tag_text,
+                str(rel),
+                content[:content_chars],
+            ]
+        )
+        suggestion = best_suggestion(
+            current_category,
+            text,
+            keyword_map,
+            min_score=min_score,
+            min_delta=min_delta,
+        )
+        if suggestion:
+            candidates.append(
+                {
+                    "path": str(rel),
+                    "name": metadata.get("name") or frontmatter.get("name") or skill_dir.name,
+                    "current_category": current_category,
+                    **suggestion,
+                }
+            )
+
+    candidates.sort(key=lambda item: (-item["score"], item["current_category"], item["path"]))
+    nonzero_counts = dict(sorted(category_counts.items()))
+    small_categories = [
+        {"category": category, "count": count}
+        for category, count in sorted(category_counts.items(), key=lambda item: (item[1], item[0]))
+        if 0 < count <= small_category_threshold
+    ]
+    large_categories = [
+        {"category": category, "count": count}
+        for category, count in sorted(category_counts.items(), key=lambda item: (-item[1], item[0]))[:10]
+    ]
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "skills_dir": str(skills_dir),
+        "total_skills": total_skills,
+        "standard_layout_skill_count": standard_layout_skills,
+        "layout_issue_count": len(layout_issues),
+        "layout_issues": compact_examples(layout_issues, limit_examples),
+        "category_count": len(nonzero_counts),
+        "category_counts": nonzero_counts,
+        "large_categories": large_categories,
+        "small_categories": small_categories,
+        "unknown_categories": [
+            {"category": category, "count": count}
+            for category, count in sorted(unknown_counts.items())
+        ],
+        "alias_usages": compact_examples(alias_usages, limit_examples),
+        "alias_usage_count": len(alias_usages),
+        "category_conflicts": compact_examples(category_conflicts, limit_examples),
+        "category_conflict_count": len(category_conflicts),
+        "candidate_reclassifications": compact_examples(candidates, limit_candidates),
+        "candidate_reclassification_count": len(candidates),
+        "notes": [
+            "Candidates are heuristic review targets, not automatic migrations.",
+            "The audit scores every category, including non-other categories.",
+            "Default mode uses metadata and paths for speed; pass --include-frontmatter or --content-chars for deeper scans.",
+            "Layout issues catch nested paths such as category/category/skill/SKILL.md.",
+        ],
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--skills-dir", type=Path, default=Path("skills"))
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--include-frontmatter", action="store_true")
+    parser.add_argument("--content-chars", type=int, default=0)
+    parser.add_argument("--min-score", type=int, default=2)
+    parser.add_argument("--min-delta", type=int, default=2)
+    parser.add_argument("--small-category-threshold", type=int, default=10)
+    parser.add_argument("--limit-candidates", type=int, default=100)
+    parser.add_argument("--limit-examples", type=int, default=20)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = build_report(
+        args.skills_dir,
+        include_frontmatter=args.include_frontmatter,
+        content_chars=args.content_chars,
+        min_score=args.min_score,
+        min_delta=args.min_delta,
+        small_category_threshold=args.small_category_threshold,
+        limit_candidates=args.limit_candidates,
+        limit_examples=args.limit_examples,
+    )
+    payload = json.dumps(report, indent=2, ensure_ascii=False)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload + "\n", encoding="utf-8")
+    else:
+        print(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_search_index.py
+++ b/scripts/build_search_index.py
@@ -24,31 +24,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from category_taxonomy import get_category_code, resolve_category
 from index_artifacts import write_category_artifacts, write_search_artifacts, write_signal_artifacts
 from plugin_index import build_plugins_index, load_plugins_from_registry, load_plugins_from_source
 from utils import extract_description, get_repo_suffix, load_metadata
 
 logging.basicConfig(level=logging.INFO, format='%(message)s')
 logger = logging.getLogger(__name__)
-
-# Category short codes
-CATEGORY_CODES = {
-    "development": "dev",
-    "devops": "ops",
-    "security": "sec",
-    "documents": "doc",
-    "design": "des",
-    "testing": "tst",
-    "product": "prd",
-    "marketing": "mkt",
-    "productivity": "pro",
-    "data": "dat",
-    "official": "off",
-    "other": "oth",
-}
-
-# Known category directories (for scanning)
-KNOWN_CATEGORIES = set(CATEGORY_CODES.keys()) | {"data", "other"}
 
 # First-paint catalog index used by the static Pages app. Full search shards
 # remain available through search-index.json as a compatibility pointer.
@@ -70,13 +52,6 @@ def truncate_text(text: Any, max_length: int) -> str:
     if len(text) <= max_length:
         return text
     return text[:max_length - 3] + "..."
-
-
-def get_category_code(category: str) -> str:
-    """Get short code for category."""
-    if not category:
-        return "oth"
-    return CATEGORY_CODES.get(category.lower(), "oth")
 
 
 def get_stable_id(install: str, branch: str) -> str:
@@ -213,8 +188,10 @@ def scan_skills_v2(skills_dir: Path) -> List[Dict]:
         if not description:
             description = f"Skill: {name}"
 
-        # Get category
-        category = metadata.get("category", category_name)
+        # Get category through the canonical taxonomy. Unknown categories are
+        # preserved as explicit slugs so they remain auditable instead of
+        # silently collapsing into "other".
+        category = resolve_category(metadata.get("category", category_name), allow_unknown=True)
 
         # Build install path
         repo = metadata.get("repo", "")
@@ -331,7 +308,7 @@ def build_search_index(
     for skill in skills:
         name = skill.get('name', '')
         description = skill.get('description', '')
-        category = skill.get('category', 'other')
+        category = resolve_category(skill.get('category', 'other'), allow_unknown=True)
         tags = skill.get('tags', [])
         stars = skill.get('stars', 0)
         repo = skill.get('repo', '')

--- a/scripts/category_taxonomy.py
+++ b/scripts/category_taxonomy.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Canonical category taxonomy helpers for registry pipeline scripts."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_TAXONOMY_PATH = ROOT / "taxonomy" / "categories.yaml"
+
+
+class UnknownCategoryError(ValueError):
+    """Raised when a category is not declared by the canonical taxonomy."""
+
+
+@dataclass(frozen=True)
+class CategoryDefinition:
+    slug: str
+    code: str
+    display_name: str
+    aliases: tuple[str, ...]
+    keywords: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CategoryTaxonomy:
+    schema_version: int
+    default_category: str
+    categories: dict[str, CategoryDefinition]
+    aliases: dict[str, str]
+
+    def resolve(self, raw_category: str | None, *, allow_unknown: bool = False) -> str:
+        slug = category_slug(raw_category or self.default_category)
+        if not slug:
+            return self.default_category
+        if slug in self.categories:
+            return slug
+        if slug in self.aliases:
+            return self.aliases[slug]
+        if allow_unknown:
+            return slug
+        raise UnknownCategoryError(f"Unknown category: {raw_category!r}")
+
+    def code_for(self, raw_category: str | None) -> str:
+        slug = self.resolve(raw_category, allow_unknown=True)
+        definition = self.categories.get(slug)
+        return definition.code if definition else slug
+
+    def is_known(self, raw_category: str | None) -> bool:
+        slug = category_slug(raw_category or "")
+        return slug in self.categories
+
+    def alias_target(self, raw_category: str | None) -> str | None:
+        slug = category_slug(raw_category or "")
+        return self.aliases.get(slug)
+
+    def keyword_map(self) -> dict[str, list[str]]:
+        return {
+            slug: list(definition.keywords)
+            for slug, definition in self.categories.items()
+            if definition.keywords
+        }
+
+
+def category_slug(raw_category: str | None) -> str:
+    text = str(raw_category or "").strip().lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", text)
+    slug = re.sub(r"-+", "-", slug).strip("-")
+    return slug
+
+
+def _as_string_list(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise ValueError("taxonomy aliases/keywords must be lists")
+    return tuple(category_slug(item) for item in value if category_slug(item))
+
+
+def load_taxonomy(path: Path = DEFAULT_TAXONOMY_PATH) -> CategoryTaxonomy:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("taxonomy file must contain an object")
+
+    default_category = category_slug(payload.get("default_category", "other")) or "other"
+    categories_raw = payload.get("categories")
+    if not isinstance(categories_raw, list) or not categories_raw:
+        raise ValueError("taxonomy must declare at least one category")
+
+    categories: dict[str, CategoryDefinition] = {}
+    aliases: dict[str, str] = {}
+    codes: dict[str, str] = {}
+
+    for entry in categories_raw:
+        if not isinstance(entry, dict):
+            raise ValueError("taxonomy category entries must be objects")
+        slug = category_slug(entry.get("slug"))
+        if not slug:
+            raise ValueError("taxonomy category missing slug")
+        if slug in categories:
+            raise ValueError(f"duplicate taxonomy category slug: {slug}")
+        if slug in aliases:
+            raise ValueError(f"taxonomy category {slug!r} conflicts with an alias")
+        code = category_slug(entry.get("code") or slug)
+        if code in codes:
+            raise ValueError(
+                f"taxonomy code {code!r} maps to both {codes[code]!r} and {slug!r}"
+            )
+        codes[code] = slug
+        display_name = str(entry.get("display_name") or slug.replace("-", " ").title())
+        category_aliases = _as_string_list(entry.get("aliases"))
+        keywords = _as_string_list(entry.get("keywords"))
+        categories[slug] = CategoryDefinition(
+            slug=slug,
+            code=code,
+            display_name=display_name,
+            aliases=category_aliases,
+            keywords=keywords,
+        )
+        for alias in category_aliases:
+            if alias in categories:
+                raise ValueError(f"taxonomy alias {alias!r} conflicts with a category slug")
+            existing = aliases.get(alias)
+            if existing and existing != slug:
+                raise ValueError(f"taxonomy alias {alias!r} maps to both {existing!r} and {slug!r}")
+            aliases[alias] = slug
+
+    if default_category not in categories:
+        raise ValueError(f"default category {default_category!r} is not declared")
+
+    return CategoryTaxonomy(
+        schema_version=int(payload.get("schema_version", 1)),
+        default_category=default_category,
+        categories=categories,
+        aliases=aliases,
+    )
+
+
+@lru_cache(maxsize=1)
+def get_taxonomy() -> CategoryTaxonomy:
+    return load_taxonomy()
+
+
+def known_categories() -> frozenset[str]:
+    return frozenset(get_taxonomy().categories)
+
+
+def category_aliases() -> dict[str, str]:
+    return dict(get_taxonomy().aliases)
+
+
+def resolve_category(raw_category: str | None, *, allow_unknown: bool = False) -> str:
+    return get_taxonomy().resolve(raw_category, allow_unknown=allow_unknown)
+
+
+def get_category_code(raw_category: str | None) -> str:
+    return get_taxonomy().code_for(raw_category)
+
+
+def category_keywords() -> dict[str, list[str]]:
+    return get_taxonomy().keyword_map()

--- a/scripts/clone_and_import.py
+++ b/scripts/clone_and_import.py
@@ -4,23 +4,21 @@ Clone and Import Skills - No GitHub API needed!
 Clones awesome-claude-skills repos and imports SKILL.md files.
 """
 
-import os
 import json
-import shutil
-import subprocess
-import tempfile
-from pathlib import Path
-from datetime import datetime
 import logging
+import subprocess
+from datetime import datetime
+from pathlib import Path
 
 from utils import (
-    normalize_name,
-    ensure_unique_dir,
-    build_skill_key,
-    normalize_repo,
     build_legal_metadata,
+    build_skill_key,
+    ensure_unique_dir,
     extract_frontmatter,
     guess_category,
+    normalize_category,
+    normalize_name,
+    normalize_repo,
 )
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(message)s')
@@ -140,7 +138,7 @@ def import_skill(skill_file: Path, skills_dir: Path, repo_slug: str, stats: dict
         return False
 
     # Determine category
-    category = normalize_name(metadata.get("category", ""))
+    category = normalize_category(metadata.get("category", ""))
     if not category or category == "unknown":
         category = guess_category(str(skill_file) + " " + content[:1000])
 

--- a/scripts/download_v2.py
+++ b/scripts/download_v2.py
@@ -37,6 +37,7 @@ from utils import (
     ensure_unique_dir,
     get_repo_suffix,
     iter_source_skills,
+    normalize_category,
     normalize_name,
     short_hash,
 )
@@ -313,7 +314,7 @@ async def download_skill(
     repo = repo.rstrip("/")
 
     # Get directory name (handles conflicts)
-    category_normalized = normalize_name(category) or "other"
+    category_normalized = normalize_category(category) or "other"
     dir_name = registry.get_dir_name(name, repo, category_normalized, stars)
 
     key = build_skill_key(repo, path, name=name, category=category_normalized)

--- a/scripts/sync_pipeline_support.py
+++ b/scripts/sync_pipeline_support.py
@@ -22,8 +22,6 @@ Environment:
     GITHUB_TOKEN - GitHub personal access token for higher rate limits
 """
 
-import argparse
-import asyncio
 import hashlib
 import json
 import logging
@@ -31,10 +29,8 @@ import os
 import shutil
 import subprocess
 import sys
-import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path, PurePosixPath
-from urllib.parse import quote
 
 # Add parent to path for imports
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -42,24 +38,15 @@ ROOT_DIR = SCRIPT_DIR.parent
 sys.path.insert(0, str(ROOT_DIR))
 sys.path.insert(0, str(SCRIPT_DIR))
 
-from discover_by_topic import GitHubTopicDiscovery
-from security_blocklist import blocked_metadata_source, load_security_blocklist
+from security_blocklist import blocked_metadata_source
 from utils import (
-    build_legal_metadata,
     build_skill_key,
-    ensure_unique_dir,
-    iter_source_skills,
-    normalize_name,
+    normalize_category,
 )
-
-from crawler.skillsmp_sync import SkillsMPSync
 
 
 def sanitize_category(category: str) -> str:
-    category = (category or "other").strip()
-    if not category:
-        category = "other"
-    return category.replace("/", "-").replace("\\", "-").replace(":", "-")
+    return normalize_category(category or "other")
 
 
 def skill_key(skill: dict) -> str:
@@ -70,7 +57,7 @@ def skill_key(skill: dict) -> str:
     if repo:
         return repo
     name = skill.get("name") or ""
-    category = skill.get("category") or "other"
+    category = sanitize_category(skill.get("category") or "other")
     return f"{category}:{name}"
 
 logging.basicConfig(

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import yaml
+from category_taxonomy import category_keywords, resolve_category
 
 logger = logging.getLogger(__name__)
 
@@ -221,11 +222,11 @@ def normalize_name(name: str) -> str:
 def normalize_category(category: str) -> str:
     """
     Normalize category name for directory creation.
-    Same as normalize_name but with 32 char limit.
+    Resolve declared aliases through the canonical taxonomy, then normalize.
     """
     if not category:
         return "other"
-    name = re.sub(r"[^a-z0-9]+", "-", category.lower())
+    name = resolve_category(category, allow_unknown=True)
     name = re.sub(r"-+", "-", name).strip("-")
     return name[:32] if name else "other"
 
@@ -373,82 +374,7 @@ def ensure_unique_dir(parent: Path, base_name: str, key: str = "", repo: str = "
 # ---------------------------------------------------------------------------
 
 # Category keywords used across multiple scripts for auto-detection.
-CATEGORY_KEYWORDS = {
-    "development": [
-        "dev",
-        "code",
-        "programming",
-        "api",
-        "sdk",
-        "framework",
-        "build",
-        "software",
-        "compile",
-        "debug",
-        "refactor",
-    ],
-    "testing": [
-        "test",
-        "qa",
-        "quality",
-        "tdd",
-        "jest",
-        "pytest",
-        "unittest",
-        "integration",
-        "e2e",
-        "playwright",
-        "cypress",
-    ],
-    "devops": ["devops", "ci", "cd", "docker", "kubernetes", "deploy", "infra", "infrastructure"],
-    "security": [
-        "security",
-        "auth",
-        "crypto",
-        "vulnerability",
-        "audit",
-        "owasp",
-        "pentest",
-        "fuzzing",
-    ],
-    "documents": [
-        "doc",
-        "pdf",
-        "word",
-        "excel",
-        "pptx",
-        "xlsx",
-        "docx",
-        "markdown",
-        "documentation",
-    ],
-    "data": [
-        "data",
-        "analytics",
-        "sql",
-        "database",
-        "etl",
-        "pipeline",
-        "ml",
-        "ai",
-        "machine-learning",
-        "visualization",
-    ],
-    "design": [
-        "design",
-        "ui",
-        "ux",
-        "css",
-        "frontend",
-        "component",
-        "tailwind",
-        "figma",
-        "animation",
-    ],
-    "productivity": ["productivity", "automation", "workflow", "task", "planning", "memory"],
-    "product": ["product", "prd", "roadmap", "feature", "backlog", "user-research", "metrics"],
-    "marketing": ["marketing", "seo", "content", "social", "campaign", "brand"],
-}
+CATEGORY_KEYWORDS = category_keywords()
 
 
 def extract_frontmatter(content: str) -> dict:

--- a/scripts/validate_sources.py
+++ b/scripts/validate_sources.py
@@ -26,26 +26,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable
 
-# -- Constants kept in sync with schema/skill.schema.json + README ---------
+from category_taxonomy import category_aliases, category_slug, known_categories
 
-VALID_CATEGORIES: frozenset[str] = frozenset(
-    {
-        "development",
-        "testing",
-        "data",
-        "design",
-        "documents",
-        "productivity",
-        "devops",
-        "security",
-        "marketing",
-        "product",
-        "communication",
-        "creative",
-        "official",
-        "other",
-    }
-)
+# -- Canonical category rules -------------------------------------------------
+
+VALID_CATEGORIES: frozenset[str] = known_categories()
+CATEGORY_ALIASES: dict[str, str] = category_aliases()
 
 REPO_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
@@ -229,7 +215,19 @@ def validate_skill_entry(
         report.add(
             Issue(file, "error", "E_CATEGORY_TYPE", "category must be a string", location)
         )
-    elif category not in VALID_CATEGORIES:
+    elif category_slug(category) in CATEGORY_ALIASES:
+        target = CATEGORY_ALIASES[category_slug(category)]
+        report.add(
+            Issue(
+                file,
+                "warning",
+                "W_CATEGORY_ALIAS",
+                f"category '{category}' is an alias for canonical category "
+                f"'{target}'",
+                location,
+            )
+        )
+    elif category_slug(category) not in VALID_CATEGORIES:
         report.add(
             Issue(
                 file,

--- a/taxonomy/categories.yaml
+++ b/taxonomy/categories.yaml
@@ -1,0 +1,268 @@
+schema_version: 1
+default_category: other
+categories:
+  - slug: adb-meta-automation
+    code: adb-meta-automation
+    display_name: ADB Meta Automation
+  - slug: agent
+    code: agent
+    display_name: Agent
+  - slug: agent-coordination
+    code: agent-coordination
+    display_name: Agent Coordination
+  - slug: ai-llm
+    code: ai-llm
+    display_name: AI / LLM
+    keywords: [ai, llm, language-model, prompt, prompting]
+  - slug: ai-ml
+    code: ai-ml
+    display_name: AI / ML
+    aliases: [machine-learning]
+    keywords: [ai, ml, machine-learning, model, training]
+  - slug: analysis
+    code: analysis
+    display_name: Analysis
+    keywords: [analysis, analyze, insights]
+  - slug: analysis-methods
+    code: analysis-methods
+    display_name: Analysis Methods
+  - slug: api
+    code: api
+    display_name: API
+    keywords: [api, sdk, endpoint, openapi]
+  - slug: applied
+    code: applied
+    display_name: Applied
+  - slug: artifact-generation
+    code: artifact-generation
+    display_name: Artifact Generation
+  - slug: bash
+    code: bash
+    display_name: Bash
+    keywords: [bash, shell, script, cli]
+  - slug: business
+    code: business
+    display_name: Business
+    keywords: [business, operations, strategy]
+  - slug: business-monetization
+    code: business-monetization
+    display_name: Business Monetization
+  - slug: business-productivity
+    code: business-productivity
+    display_name: Business Productivity
+  - slug: c-level
+    code: c-level
+    display_name: C-Level
+  - slug: communication
+    code: communication
+    display_name: Communication
+    keywords: [communication, messaging, email, chat]
+  - slug: context-management
+    code: context-management
+    display_name: Context Management
+  - slug: core
+    code: core
+    display_name: Core
+  - slug: creative
+    code: creative
+    display_name: Creative
+    keywords: [creative, ideation, story, writing]
+  - slug: data
+    code: dat
+    display_name: Data
+    keywords: [data, analytics, sql, database, etl, pipeline, visualization]
+  - slug: data-access
+    code: data-access
+    display_name: Data Access
+  - slug: design
+    code: des
+    display_name: Design
+    keywords: [design, ui, ux, css, frontend, component, tailwind, figma, animation]
+  - slug: design-principles
+    code: design-principles
+    display_name: Design Principles
+  - slug: development
+    code: dev
+    display_name: Development
+    aliases: [dev, engineering, software-engineering, programming]
+    keywords: [dev, code, programming, framework, build, software, compile, debug, refactor]
+  - slug: development-code
+    code: development-code
+    display_name: Development Code
+  - slug: development-tools
+    code: development-tools
+    display_name: Development Tools
+  - slug: devops
+    code: ops
+    display_name: DevOps
+    keywords: [devops, ci, cd, docker, kubernetes, deploy, infra, infrastructure]
+  - slug: docs
+    code: docs
+    display_name: Docs
+  - slug: document-processing
+    code: document-processing
+    display_name: Document Processing
+  - slug: documents
+    code: doc
+    display_name: Documents
+    aliases: [documentation]
+    keywords: [doc, docs, pdf, word, excel, pptx, xlsx, docx, markdown, documentation]
+  - slug: domains
+    code: domains
+    display_name: Domains
+  - slug: examples
+    code: examples
+    display_name: Examples
+  - slug: extended
+    code: extended
+    display_name: Extended
+  - slug: forensics
+    code: forensics
+    display_name: Forensics
+  - slug: foundation
+    code: foundation
+    display_name: Foundation
+  - slug: framework
+    code: framework
+    display_name: Framework
+  - slug: gaming
+    code: gaming
+    display_name: Gaming
+  - slug: generation
+    code: generation
+    display_name: Generation
+  - slug: github-integration
+    code: github-integration
+    display_name: GitHub Integration
+  - slug: github-skills
+    code: github-skills
+    display_name: GitHub Skills
+  - slug: integration
+    code: integration
+    display_name: Integration
+  - slug: language
+    code: language
+    display_name: Language
+  - slug: local-ai-infrastructure
+    code: local-ai-infrastructure
+    display_name: Local AI Infrastructure
+  - slug: marketing
+    code: mkt
+    display_name: Marketing
+    keywords: [marketing, seo, content, social, campaign, brand]
+  - slug: messaging
+    code: messaging
+    display_name: Messaging
+    keywords: [messaging, message, email, chat, slack]
+  - slug: meta
+    code: meta
+    display_name: Meta
+  - slug: orchestration
+    code: orchestration
+    display_name: Orchestration
+    keywords: [orchestration, orchestrator, coordination, multi-agent]
+  - slug: official
+    code: off
+    display_name: Official
+  - slug: other
+    code: oth
+    display_name: Other
+  - slug: performance
+    code: performance
+    display_name: Performance
+    keywords: [performance, optimize, latency, speed, benchmark]
+  - slug: personal-development
+    code: personal-development
+    display_name: Personal Development
+  - slug: planning
+    code: planning
+    display_name: Planning
+    keywords: [planning, plan, roadmap]
+  - slug: platform
+    code: platform
+    display_name: Platform
+  - slug: product
+    code: prd
+    display_name: Product
+    keywords: [product, prd, roadmap, feature, backlog, user-research, metrics]
+  - slug: productivity
+    code: pro
+    display_name: Productivity
+    keywords: [productivity, automation, workflow, task, planning, memory]
+  - slug: programming-languages
+    code: programming-languages
+    display_name: Programming Languages
+  - slug: project
+    code: project
+    display_name: Project
+  - slug: quality
+    code: quality
+    display_name: Quality
+    keywords: [quality, lint, review, validate]
+  - slug: research-analysis
+    code: research-analysis
+    display_name: Research Analysis
+  - slug: security
+    code: sec
+    display_name: Security
+    keywords: [security, auth, crypto, vulnerability, audit, owasp, pentest, fuzzing]
+  - slug: security-compliance
+    code: security-compliance
+    display_name: Security Compliance
+  - slug: security-operations
+    code: security-operations
+    display_name: Security Operations
+  - slug: skills
+    code: skills
+    display_name: Skills
+  - slug: specialized
+    code: specialized
+    display_name: Specialized
+  - slug: specialized-testing
+    code: specialized-testing
+    display_name: Specialized Testing
+  - slug: story-analysis
+    code: story-analysis
+    display_name: Story Analysis
+  - slug: string
+    code: string
+    display_name: String
+  - slug: system
+    code: system
+    display_name: System
+  - slug: technical-integration
+    code: technical-integration
+    display_name: Technical Integration
+  - slug: template
+    code: template
+    display_name: Template
+  - slug: test
+    code: test
+    display_name: Test
+  - slug: testing
+    code: tst
+    display_name: Testing
+    keywords: [test, qa, tdd, jest, pytest, unittest, integration, e2e, playwright, cypress]
+  - slug: testing-methodologies
+    code: testing-methodologies
+    display_name: Testing Methodologies
+  - slug: travel
+    code: travel
+    display_name: Travel
+  - slug: utility
+    code: utility
+    display_name: Utility
+  - slug: war-room
+    code: war-room
+    display_name: War Room
+  - slug: wix-extensions
+    code: wix-extensions
+    display_name: Wix Extensions
+  - slug: workflow
+    code: workflow
+    display_name: Workflow
+    keywords: [workflow, process, automation, pipeline]
+  - slug: writing
+    code: writing
+    display_name: Writing
+    keywords: [writing, writer, copy, blog, article]

--- a/tests/test_audit_category_quality.py
+++ b/tests/test_audit_category_quality.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    return importlib.import_module("audit_category_quality")
+
+
+def _write_skill(root: Path, category: str, name: str, metadata: dict, body: str) -> None:
+    skill_dir = root / category / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "metadata.json").write_text(
+        json.dumps(metadata, indent=2),
+        encoding="utf-8",
+    )
+    (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
+
+
+def test_audit_finds_candidates_outside_other(tmp_path):
+    audit = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "development",
+        "auth-audit",
+        {
+            "name": "auth-audit",
+            "category": "development",
+            "description": "Security auth vulnerability OWASP audit workflow.",
+            "tags": ["security", "auth", "owasp"],
+        },
+        "---\nname: auth-audit\n---\n\nSecurity auth vulnerability OWASP audit workflow.",
+    )
+    _write_skill(
+        skills_dir,
+        "other",
+        "design-system",
+        {
+            "name": "design-system",
+            "category": "other",
+            "description": "Figma UI UX CSS component design workflow.",
+            "tags": ["figma", "ui", "ux"],
+        },
+        "---\nname: design-system\n---\n\nFigma UI UX CSS component design workflow.",
+    )
+
+    report = audit.build_report(skills_dir, min_score=2, min_delta=2)
+    candidates = {
+        item["path"]: item
+        for item in report["candidate_reclassifications"]
+    }
+    assert candidates["development/auth-audit/SKILL.md"]["suggested_category"] == "security"
+    assert candidates["other/design-system/SKILL.md"]["suggested_category"] == "design"
+    assert report["candidate_reclassification_count"] == 2
+
+
+def test_audit_reports_alias_usage_and_source_conflict(tmp_path):
+    audit = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "engineering",
+        "doc-helper",
+        {
+            "name": "doc-helper",
+            "category": "engineering",
+            "description": "Convert PDF DOCX to markdown.",
+        },
+        "---\nname: doc-helper\ncategory: documents\n---\n\nConvert PDF DOCX to markdown.",
+    )
+
+    report = audit.build_report(skills_dir, include_frontmatter=True)
+    assert report["alias_usage_count"] == 2
+    assert report["alias_usages"][0]["canonical_category"] == "development"
+    assert report["category_conflict_count"] == 1
+    assert report["category_conflicts"][0]["resolved_sources"]["frontmatter"] == "documents"
+
+
+def test_audit_reports_nonstandard_nested_layout(tmp_path):
+    audit = _load_module()
+    skills_dir = tmp_path / "skills"
+    nested_dir = skills_dir / "other" / "other" / "nested-skill"
+    nested_dir.mkdir(parents=True)
+    (nested_dir / "metadata.json").write_text(
+        json.dumps({"name": "nested-skill", "category": "other"}),
+        encoding="utf-8",
+    )
+    (nested_dir / "SKILL.md").write_text("---\nname: nested-skill\n---\n", encoding="utf-8")
+
+    report = audit.build_report(skills_dir)
+    assert report["total_skills"] == 1
+    assert report["standard_layout_skill_count"] == 0
+    assert report["layout_issue_count"] == 1
+    assert report["layout_issues"][0]["path"] == "other/other/nested-skill/SKILL.md"

--- a/tests/test_category_taxonomy.py
+++ b/tests/test_category_taxonomy.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    return importlib.import_module("category_taxonomy")
+
+
+def test_taxonomy_loads_current_category_set():
+    taxonomy = _load_module()
+    loaded = taxonomy.load_taxonomy()
+    assert loaded.default_category == "other"
+    assert "development" in loaded.categories
+    assert "other" in loaded.categories
+    assert len(loaded.categories) >= 77
+
+
+def test_taxonomy_resolves_aliases_and_codes():
+    taxonomy = _load_module()
+    assert taxonomy.resolve_category("Engineering") == "development"
+    assert taxonomy.get_category_code("development") == "dev"
+    assert taxonomy.get_category_code("unknown-new-bucket") == "unknown-new-bucket"
+
+
+def test_taxonomy_rejects_alias_category_conflict(tmp_path):
+    taxonomy = _load_module()
+    taxonomy_file = tmp_path / "categories.yaml"
+    taxonomy_file.write_text(
+        """
+schema_version: 1
+default_category: other
+categories:
+  - slug: other
+    code: oth
+    aliases: [dev]
+  - slug: dev
+    code: dev
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="conflicts with an alias"):
+        taxonomy.load_taxonomy(taxonomy_file)
+
+
+def test_taxonomy_rejects_duplicate_codes(tmp_path):
+    taxonomy = _load_module()
+    taxonomy_file = tmp_path / "categories.yaml"
+    taxonomy_file.write_text(
+        """
+schema_version: 1
+default_category: other
+categories:
+  - slug: other
+    code: oth
+  - slug: development
+    code: oth
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="maps to both"):
+        taxonomy.load_taxonomy(taxonomy_file)

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -20,6 +20,19 @@ def load_module():
     return module
 
 
+def load_support_module():
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    module_path = scripts_dir / "sync_pipeline_support.py"
+    spec = importlib.util.spec_from_file_location("sync_pipeline_support_module", module_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
 class FakeResponse:
     def __init__(self, status, *, text="", json_payload=None, body=b""):
         self.status = status
@@ -921,6 +934,13 @@ def test_filter_pending_skills_prefilters_no_repo_and_cooldown():
     reasons = [reason for _, reason in skipped_rows]
     assert "no_repo_prefilter" in reasons
     assert "cooldown_not_found" in reasons
+
+
+def test_sync_pipeline_category_sanitization_uses_taxonomy_aliases():
+    module = load_support_module()
+    assert module.sanitize_category("dev") == "development"
+    assert module.sanitize_category("Engineering") == "development"
+    assert module.skill_key({"name": "demo", "category": "dev"}) == "development:demo"
 
 
 def test_negative_cache_helpers_prune_and_cooldown():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -286,6 +286,11 @@ def test_normalize_category_empty(utils):
     assert utils.normalize_category(None) == "other"
 
 
+def test_normalize_category_resolves_declared_aliases(utils):
+    assert utils.normalize_category("Engineering") == "development"
+    assert utils.normalize_category("dev") == "development"
+
+
 # ---------------------------------------------------------------------------
 # Repo suffix and dir-name builder (AGENTS.md case-conflict policy)
 # ---------------------------------------------------------------------------

--- a/tests/test_validate_sources.py
+++ b/tests/test_validate_sources.py
@@ -330,7 +330,7 @@ def test_unknown_category_is_warning_not_error(vs, sources, capsys):
                     "name": "demo",
                     "repo": "owner/repo",
                     "description": "Long enough description here.",
-                    "category": "engineering",  # not in canonical set
+                    "category": "moonbase",
                 }
             ],
         },
@@ -339,6 +339,29 @@ def test_unknown_category_is_warning_not_error(vs, sources, capsys):
     out = capsys.readouterr().out
     assert rc == 0
     assert "W_CATEGORY_UNKNOWN" in out
+
+
+def test_alias_category_is_warning_not_error(vs, sources, capsys):
+    _write(
+        sources / "community.json",
+        {
+            "name": "Community",
+            "description": "x",
+            "skills": [
+                {
+                    "name": "demo",
+                    "repo": "owner/repo",
+                    "description": "Long enough description here.",
+                    "category": "engineering",
+                }
+            ],
+        },
+    )
+    rc = vs.main(["--sources-dir", str(sources)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "W_CATEGORY_ALIAS" in out
+    assert "development" in out
 
 
 def test_strict_promotes_warning_to_failure(vs, sources, capsys):
@@ -352,7 +375,7 @@ def test_strict_promotes_warning_to_failure(vs, sources, capsys):
                     "name": "demo",
                     "repo": "owner/repo",
                     "description": "Long enough description here.",
-                    "category": "engineering",
+                    "category": "moonbase",
                 }
             ],
         },


### PR DESCRIPTION
## Summary

Adds a core-owned category taxonomy and audit path so category rules are enforced from one source of truth instead of scattered hardcoded lists.

Refs #78. Refs #83. Follow-up data layout migration is tracked in #84.

## Changes

- Add `taxonomy/categories.yaml` plus `scripts/category_taxonomy.py` for canonical slugs, aliases, short codes, and keyword signals.
- Switch source validation, search-index category codes, utility guessing, download/import/sync category normalization, and the skill schema to the shared taxonomy.
- Add `scripts/audit_category_quality.py` to report category counts, alias use, source conflicts, non-standard nested layouts, and heuristic reclassification candidates across every category, not only `other`.
- Document the taxonomy/audit workflow and add regression tests.

## Local audit signal

A full local audit against `claude-skill-registry-data` found:

- total `SKILL.md`: 227,820
- standard `<category>/<skill>/SKILL.md`: 174,854
- nested/non-standard layout paths: 52,966
- heuristic reclassification candidates: 6,689
- examples include `data/devops-patterns -> devops`, `data/dotnet-cicd-patterns -> devops`, and `development/frontend-testing -> testing`

## Test plan

- `python -m pytest -q tests/test_utils.py tests/test_sync_and_download.py tests/test_download_v2.py tests/test_audit_category_quality.py tests/test_category_taxonomy.py tests/test_validate_sources.py tests/test_plugin_contract.py`
- `python -m ruff check scripts/category_taxonomy.py scripts/audit_category_quality.py scripts/build_search_index.py scripts/utils.py scripts/validate_sources.py scripts/sync_pipeline_support.py scripts/download_v2.py scripts/clone_and_import.py tests/test_category_taxonomy.py tests/test_audit_category_quality.py tests/test_validate_sources.py tests/test_utils.py tests/test_sync_and_download.py`
- `git diff --check`
- `python -m pytest -q`
- `/usr/bin/time -p python scripts/audit_category_quality.py --skills-dir /Users/lifcc/Desktop/code/AI/tools/claude-skill-registry-data --limit-candidates 5 --limit-examples 5`