### PR TITLE
Add nested layout normalization plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ The default audit uses metadata and paths for a fast full-archive pass; add
 `--include-frontmatter` when checking frontmatter/category drift.
 The audit also reports non-standard nested skill paths such as
 `category/category/skill/SKILL.md`.
+For those layout issues, use
+`python scripts/normalize_skill_depth.py --skills-dir skills --json` to review
+the exact move plan before applying it.
 
 Category counts are published in `categories/index.json`; full category payloads
 are available through `categories/<category>/manifest.json` and bounded

--- a/scripts/normalize_skill_depth.py
+++ b/scripts/normalize_skill_depth.py
@@ -3,118 +3,238 @@
 Normalize non-standard skill directory depths to:
   skills/<category>/<skill>/SKILL.md
 
-Moves any SKILL.md found outside the standard depth into the category root
-with a temporary unique name, then relies on normalize_skill_dirs.py for
-final naming.
+Default mode is a dry run. Use --json for a machine-readable migration report
+and --apply only after reviewing the planned destinations.
 """
+
+from __future__ import annotations
 
 import argparse
 import json
 import shutil
+from collections import defaultdict
 from pathlib import Path
+from typing import Any
 
+from category_taxonomy import resolve_category
 from utils import (
-    normalize_name,
-    normalize_category,
-    normalize_repo,
-    build_skill_key,
-    short_hash,
     build_legal_metadata,
+    build_skill_key,
+    get_repo_suffix,
     load_metadata,
+    normalize_category,
+    normalize_name,
+    normalize_repo,
+    short_hash,
     write_metadata,
 )
+
+LAYOUT_EXPECTED = "<category>/<skill>/SKILL.md"
+SKILLS_PREFIX_NAMES = {"skill", "skills"}
 
 
 def is_standard(rel_parts: tuple[str, ...]) -> bool:
     return len(rel_parts) == 3 and rel_parts[2] == "SKILL.md" and not rel_parts[0].startswith(".")
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Normalize non-standard skill depths")
-    parser.add_argument("--skills-dir", default="skills", help="Skills root directory")
-    parser.add_argument("--apply", action="store_true", help="Apply changes (default: dry-run)")
-    parser.add_argument("--max-passes", type=int, default=5, help="Max normalization passes")
+def iter_nonstandard_skill_dirs(skills_dir: Path):
+    for skill_md in sorted(skills_dir.rglob("SKILL.md")):
+        rel = skill_md.relative_to(skills_dir)
+        if any(part.startswith(".") for part in rel.parts):
+            continue
+        if not is_standard(rel.parts):
+            yield skill_md.parent, rel
 
-    args = parser.parse_args()
-    skills_dir = Path(args.skills_dir)
-    if not skills_dir.exists():
-        raise SystemExit(f"Skills directory not found: {skills_dir}")
 
-    for pass_num in range(1, args.max_passes + 1):
-        moves = []
-        seen_dirs = set()
+def infer_category(rel_parts: tuple[str, ...], meta: dict[str, Any]) -> str:
+    raw_category = meta.get("category") if isinstance(meta.get("category"), str) else ""
+    if raw_category:
+        return normalize_category(raw_category)
 
-        for skill_md in skills_dir.rglob("SKILL.md"):
-            rel = skill_md.relative_to(skills_dir)
-            if is_standard(rel.parts):
+    if rel_parts and rel_parts[0] in SKILLS_PREFIX_NAMES and len(rel_parts) > 1:
+        return normalize_category(rel_parts[1])
+
+    first_part = rel_parts[0] if rel_parts else "other"
+    category = normalize_category(first_part)
+    if category.startswith("."):
+        return "other"
+    return category or "other"
+
+
+def existing_category_state(skills_dir: Path) -> dict[str, dict[str, set[str]]]:
+    state: dict[str, dict[str, set[str]]] = defaultdict(lambda: {"names": set(), "keys": set()})
+    for category_dir in sorted(skills_dir.iterdir()):
+        if not category_dir.is_dir() or category_dir.name.startswith("."):
+            continue
+        category = normalize_category(category_dir.name)
+        for skill_dir in sorted(category_dir.iterdir()):
+            if not skill_dir.is_dir() or not (skill_dir / "SKILL.md").exists():
                 continue
-
-            skill_dir = skill_md.parent
-            if skill_dir in seen_dirs:
-                continue
-            seen_dirs.add(skill_dir)
-
             meta = load_metadata(skill_dir)
-            raw_category = meta.get("category", "")
-            if raw_category:
-                category = normalize_category(raw_category) or "other"
-            else:
-                category = normalize_category(rel.parts[0] if rel.parts else "other") or "other"
-                if category.startswith("."):
-                    category = "other"
-
             name = normalize_name(meta.get("name") or skill_dir.name)
             repo = normalize_repo(meta.get("repo", ""))
             path = meta.get("github_path") or meta.get("path") or ""
             key = build_skill_key(repo, path, name=name, category=category)
+            state[category]["names"].add(skill_dir.name.lower())
+            if key:
+                state[category]["keys"].add(key)
+    return state
 
-            temp_base = f"{name}-{short_hash(key or name)}-depth"
-            target_dir = skills_dir / category / temp_base
-            counter = 2
-            while target_dir.exists():
-                target_dir = skills_dir / category / f"{temp_base}-{counter}"
-                counter += 1
 
-            moves.append((skill_dir, target_dir, meta, category, name))
+def unique_dir_name(
+    *,
+    category_state: dict[str, set[str]],
+    base_name: str,
+    repo: str,
+    key: str,
+) -> str:
+    base = normalize_name(base_name)
+    if base.lower() not in category_state["names"]:
+        category_state["names"].add(base.lower())
+        if key:
+            category_state["keys"].add(key)
+        return base
 
-        print(f"Pass {pass_num}: Non-standard SKILL.md dirs found: {len(moves)}")
-        if not args.apply:
-            for src, dest, _, _, _ in moves[:20]:
-                print(f"  {src.relative_to(skills_dir)} -> {dest.relative_to(skills_dir)}")
-            if len(moves) > 20:
-                print("  ...")
-            return
+    suffix = get_repo_suffix(repo)
+    if suffix and not base.endswith(f"-{suffix}"):
+        candidate_base = f"{base}-{suffix}"
+    else:
+        candidate_base = f"{base}-{short_hash(key or base)}"
 
-        if not moves:
-            break
+    candidate = candidate_base
+    counter = 2
+    while candidate.lower() in category_state["names"]:
+        candidate = f"{candidate_base}-{counter}"
+        counter += 1
 
-        for src, dest, meta, category, name in moves:
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            if dest.exists():
-                continue
-            shutil.move(str(src), str(dest))
+    category_state["names"].add(candidate.lower())
+    if key:
+        category_state["keys"].add(key)
+    return candidate
 
-            if not meta:
-                meta = {}
-            meta.setdefault("name", name)
-            meta["category"] = category
-            meta["dir_name"] = dest.name
-            legal_meta = build_legal_metadata(
-                repo=normalize_repo(meta.get("repo", "")),
-                path=meta.get("github_path") or meta.get("path") or "",
-                branch=meta.get("github_branch") or meta.get("branch") or "main",
-                source_url=meta.get("source_url", ""),
-                author=meta.get("author", ""),
-                license_name=meta.get("license", ""),
-                copyright_text=meta.get("copyright", ""),
-                permission_note=meta.get("permission_note", ""),
-                distribution=meta.get("distribution", ""),
-            )
-            meta.update(legal_meta)
-            write_metadata(dest, meta)
 
-    print("Depth normalization complete.")
+def build_depth_plan(skills_dir: Path) -> dict[str, Any]:
+    state = existing_category_state(skills_dir)
+    moves: list[dict[str, Any]] = []
+
+    for skill_dir, rel in iter_nonstandard_skill_dirs(skills_dir):
+        meta = load_metadata(skill_dir)
+        category = infer_category(rel.parts, meta)
+        category = resolve_category(category, allow_unknown=True)
+        name = normalize_name(meta.get("name") or skill_dir.name)
+        repo = normalize_repo(meta.get("repo", ""))
+        path = meta.get("github_path") or meta.get("path") or ""
+        key = build_skill_key(repo, path, name=name, category=category)
+        category_state = state[category]
+        target_name = unique_dir_name(
+            category_state=category_state,
+            base_name=name,
+            repo=repo,
+            key=key or str(rel),
+        )
+        target_rel = Path(category) / target_name
+        moves.append(
+            {
+                "source_path": str(skill_dir.relative_to(skills_dir)),
+                "source_skill": str(rel),
+                "target_path": str(target_rel),
+                "target_skill": str(target_rel / "SKILL.md"),
+                "category": category,
+                "name": name,
+                "repo": repo,
+                "key": key,
+                "metadata_category": meta.get("category", ""),
+                "layout_depth": len(rel.parts),
+                "expected_layout": LAYOUT_EXPECTED,
+            }
+        )
+
+    return {
+        "skills_dir": str(skills_dir),
+        "expected_layout": LAYOUT_EXPECTED,
+        "move_count": len(moves),
+        "moves": moves,
+    }
+
+
+def apply_depth_plan(skills_dir: Path, plan: dict[str, Any]) -> None:
+    temp_moves: list[tuple[Path, Path, dict[str, Any]]] = []
+    for move in plan["moves"]:
+        source = skills_dir / move["source_path"]
+        target = skills_dir / move["target_path"]
+        if not source.exists():
+            raise FileNotFoundError(f"Planned source does not exist: {source}")
+        if target.exists():
+            raise FileExistsError(f"Planned target already exists: {target}")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        temp = target.parent / f".tmp-depth-{short_hash(move['source_path'] + move['target_path'])}"
+        if temp.exists():
+            shutil.rmtree(temp)
+        source.rename(temp)
+        temp_moves.append((temp, target, move))
+
+    for temp, target, move in temp_moves:
+        temp.rename(target)
+        meta = load_metadata(target)
+        meta.setdefault("name", move["name"])
+        meta["category"] = move["category"]
+        meta["dir_name"] = target.name
+        legal_meta = build_legal_metadata(
+            repo=normalize_repo(meta.get("repo", "")),
+            path=meta.get("github_path") or meta.get("path") or "",
+            branch=meta.get("github_branch") or meta.get("branch") or "main",
+            source_url=meta.get("source_url", ""),
+            author=meta.get("author", ""),
+            license_name=meta.get("license", ""),
+            copyright_text=meta.get("copyright", ""),
+            permission_note=meta.get("permission_note", ""),
+            distribution=meta.get("distribution", ""),
+        )
+        meta.update(legal_meta)
+        write_metadata(target, meta)
+
+
+def print_text_report(plan: dict[str, Any], *, limit: int) -> None:
+    print(f"Non-standard SKILL.md dirs found: {plan['move_count']}")
+    for move in plan["moves"][:limit]:
+        print(f"  {move['source_path']} -> {move['target_path']}")
+    if plan["move_count"] > limit:
+        print("  ...")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Normalize non-standard skill depths")
+    parser.add_argument("--skills-dir", default="skills", help="Skills root directory")
+    parser.add_argument("--apply", action="store_true", help="Apply changes (default: dry-run)")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON report")
+    parser.add_argument("--output", type=Path, help="Write the JSON report to a file")
+    parser.add_argument("--limit", type=int, default=20, help="Text preview limit")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    skills_dir = Path(args.skills_dir)
+    if not skills_dir.exists():
+        raise SystemExit(f"Skills directory not found: {skills_dir}")
+
+    plan = build_depth_plan(skills_dir)
+    if args.apply:
+        apply_depth_plan(skills_dir, plan)
+
+    if args.json or args.output:
+        payload = json.dumps(plan, indent=2, ensure_ascii=False)
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(payload + "\n", encoding="utf-8")
+        if args.json:
+            print(payload)
+    else:
+        print_text_report(plan, limit=args.limit)
+        if args.apply:
+            print("Depth normalization complete.")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/test_normalize_skill_depth.py
+++ b/tests/test_normalize_skill_depth.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    return importlib.import_module("normalize_skill_depth")
+
+
+def _write_skill(root: Path, rel_dir: str, metadata: dict) -> Path:
+    skill_dir = root / rel_dir
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: demo\n---\n", encoding="utf-8")
+    (skill_dir / "metadata.json").write_text(
+        json.dumps(metadata, indent=2),
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def test_depth_plan_uses_metadata_category_for_nested_skill(tmp_path):
+    module = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "other/other/auth-audit",
+        {
+            "name": "auth-audit",
+            "category": "security",
+            "repo": "acme/security-pack",
+            "path": "skills/auth-audit",
+        },
+    )
+
+    plan = module.build_depth_plan(skills_dir)
+    assert plan["move_count"] == 1
+    assert plan["moves"][0]["source_path"] == "other/other/auth-audit"
+    assert plan["moves"][0]["target_path"] == "security/auth-audit"
+    assert plan["moves"][0]["expected_layout"] == "<category>/<skill>/SKILL.md"
+
+
+def test_depth_plan_uses_category_after_skills_prefix(tmp_path):
+    module = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "skills/documents/doc-helper",
+        {
+            "name": "doc-helper",
+            "repo": "acme/docs",
+            "path": "skills/doc-helper",
+        },
+    )
+
+    plan = module.build_depth_plan(skills_dir)
+    assert plan["move_count"] == 1
+    assert plan["moves"][0]["target_path"] == "documents/doc-helper"
+
+
+def test_apply_depth_plan_preserves_existing_target_with_suffix(tmp_path):
+    module = _load_module()
+    skills_dir = tmp_path / "skills"
+    existing = _write_skill(
+        skills_dir,
+        "security/auth-audit",
+        {
+            "name": "auth-audit",
+            "category": "security",
+            "repo": "acme/existing",
+        },
+    )
+    _write_skill(
+        skills_dir,
+        "other/other/auth-audit",
+        {
+            "name": "auth-audit",
+            "category": "security",
+            "repo": "acme/security-pack",
+        },
+    )
+
+    plan = module.build_depth_plan(skills_dir)
+    assert plan["moves"][0]["target_path"] == "security/auth-audit-acme-security-pack"
+
+    module.apply_depth_plan(skills_dir, plan)
+
+    assert (existing / "SKILL.md").exists()
+    target = skills_dir / "security" / "auth-audit-acme-security-pack"
+    assert (target / "SKILL.md").exists()
+    metadata = json.loads((target / "metadata.json").read_text(encoding="utf-8"))
+    assert metadata["category"] == "security"
+    assert metadata["dir_name"] == "auth-audit-acme-security-pack"
+    assert not (skills_dir / "other" / "other" / "auth-audit").exists()


### PR DESCRIPTION
## Summary

Adds a reviewable, machine-readable plan/apply path for normalizing nested skill archive directories before taxonomy migration.

Refs #84.

## Changes

- Reworks `scripts/normalize_skill_depth.py` into a deterministic dry-run/apply workflow.
- Adds `--json` and `--output` so every nested path and proposed destination can be reviewed before applying.
- Infers target category from metadata first, then `skills/<category>/...`, then the first path segment.
- Preserves existing targets by assigning deterministic repo/hash suffixes instead of overwriting or deleting.
- Updates metadata after apply and documents the workflow.

## Local dry-run signal

Against local `claude-skill-registry-data`:

- planned moves: 52,966
- first move: `other/other/0-autoresearch-skill -> other/0-autoresearch-skill`
- conflict example: `other/other/00-meta-chain-flow-150 -> other/00-meta-chain-flow-150-mykhailodmytriakha-my-preacher-helper-2`

## Test plan

- `python -m pytest -q tests/test_normalize_skill_depth.py tests/test_audit_category_quality.py tests/test_utils.py`
- `python -m ruff check scripts/normalize_skill_depth.py tests/test_normalize_skill_depth.py`
- `git diff --check`
- `python scripts/normalize_skill_depth.py --skills-dir /Users/lifcc/Desktop/code/AI/tools/claude-skill-registry-data --json --output /tmp/nested-layout-plan.json`
- `python -m pytest -q`