### PR TITLE
Fix depth normalization apply order

### DIFF
--- a/scripts/normalize_skill_depth.py
+++ b/scripts/normalize_skill_depth.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import shutil
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
@@ -158,8 +157,11 @@ def build_depth_plan(skills_dir: Path) -> dict[str, Any]:
 
 
 def apply_depth_plan(skills_dir: Path, plan: dict[str, Any]) -> None:
-    temp_moves: list[tuple[Path, Path, dict[str, Any]]] = []
-    for move in plan["moves"]:
+    moves = sorted(
+        plan["moves"],
+        key=lambda move: (-len(Path(move["source_path"]).parts), move["source_path"]),
+    )
+    for move in moves:
         source = skills_dir / move["source_path"]
         target = skills_dir / move["target_path"]
         if not source.exists():
@@ -167,14 +169,7 @@ def apply_depth_plan(skills_dir: Path, plan: dict[str, Any]) -> None:
         if target.exists():
             raise FileExistsError(f"Planned target already exists: {target}")
         target.parent.mkdir(parents=True, exist_ok=True)
-        temp = target.parent / f".tmp-depth-{short_hash(move['source_path'] + move['target_path'])}"
-        if temp.exists():
-            shutil.rmtree(temp)
-        source.rename(temp)
-        temp_moves.append((temp, target, move))
-
-    for temp, target, move in temp_moves:
-        temp.rename(target)
+        source.rename(target)
         meta = load_metadata(target)
         meta.setdefault("name", move["name"])
         meta["category"] = move["category"]

--- a/tests/test_normalize_skill_depth.py
+++ b/tests/test_normalize_skill_depth.py
@@ -97,3 +97,35 @@ def test_apply_depth_plan_preserves_existing_target_with_suffix(tmp_path):
     assert metadata["category"] == "security"
     assert metadata["dir_name"] == "auth-audit-acme-security-pack"
     assert not (skills_dir / "other" / "other" / "auth-audit").exists()
+
+
+def test_apply_depth_plan_moves_child_before_parent(tmp_path):
+    module = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "other/other/parent",
+        {
+            "name": "parent",
+            "category": "other",
+            "repo": "acme/parent",
+        },
+    )
+    _write_skill(
+        skills_dir,
+        "other/other/parent/child",
+        {
+            "name": "child",
+            "category": "other",
+            "repo": "acme/child",
+        },
+    )
+
+    plan = module.build_depth_plan(skills_dir)
+    assert plan["move_count"] == 2
+
+    module.apply_depth_plan(skills_dir, plan)
+
+    assert (skills_dir / "other" / "parent" / "SKILL.md").exists()
+    assert (skills_dir / "other" / "child" / "SKILL.md").exists()
+    assert not (skills_dir / "other" / "other" / "parent").exists()


### PR DESCRIPTION
## Summary

Fixes the depth normalization apply path for archives where one non-standard skill directory contains another nested `SKILL.md`.

Refs #84. Follow-up to #86.

## Changes

- Apply planned moves deepest-first so child skill directories are moved before parent directories.
- Replace the batch temp-directory phase with direct planned moves after target validation.
- Add a regression test for nested child-before-parent movement.

## Test plan

- `python -m pytest -q tests/test_normalize_skill_depth.py`
- `python -m ruff check scripts/normalize_skill_depth.py tests/test_normalize_skill_depth.py`
- `git diff --check`
- `python -m pytest -q`