### PR TITLE
Add taxonomy v2 governance and migration planning

### DIFF
--- a/.github/workflows/build-index.yml
+++ b/.github/workflows/build-index.yml
@@ -140,6 +140,9 @@ jobs:
             --include docs \
             --limit 12
 
+      - name: Check category artifacts remain sharded
+        run: python scripts/check_category_artifacts.py --categories-dir docs/categories
+
       - name: Setup Pages
         uses: actions/configure-pages@v6
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -5,7 +5,9 @@ on:
     paths:
       - 'crawler/**'
       - 'scripts/**'
+      - 'taxonomy/**'
       - 'tests/**'
+      - 'docs/plan/**'
       - 'pyproject.toml'
       - 'requirements.txt'
       - '.github/workflows/python-tests.yml'
@@ -14,7 +16,9 @@ on:
     paths:
       - 'crawler/**'
       - 'scripts/**'
+      - 'taxonomy/**'
       - 'tests/**'
+      - 'docs/plan/**'
       - 'pyproject.toml'
       - 'requirements.txt'
       - '.github/workflows/python-tests.yml'
@@ -42,3 +46,6 @@ jobs:
 
       - name: Run full pytest suite with coverage gate
         run: python -m pytest -q --cov-fail-under=50
+
+      - name: Validate taxonomy governance
+        run: python scripts/check_taxonomy_governance.py

--- a/README.md
+++ b/README.md
@@ -188,10 +188,12 @@ The merged `claude-skill-registry` publish artifact additionally contains
 
 ## Categories
 
-Canonical category slugs, aliases, short codes, and heuristic keywords live in
-`taxonomy/categories.yaml`. Pipeline scripts read that file instead of keeping
-their own category lists. To review category quality across the archive before
-moving anything, run `python scripts/audit_category_quality.py --skills-dir skills`.
+Canonical category slugs, aliases, short codes, governance status, and
+heuristic keywords live in `taxonomy/categories.yaml`. Pipeline scripts read
+that file instead of keeping their own category lists. Validate the taxonomy
+itself with `python scripts/check_taxonomy_governance.py`. To review category
+quality across the archive before moving anything, run
+`python scripts/audit_category_quality.py --skills-dir skills`.
 The default audit uses metadata and paths for a fast full-archive pass; add
 `--include-frontmatter` when checking frontmatter/category drift.
 The audit also reports non-standard nested skill paths such as
@@ -199,11 +201,18 @@ The audit also reports non-standard nested skill paths such as
 For those layout issues, use
 `python scripts/normalize_skill_depth.py --skills-dir skills --json` to review
 the exact move plan before applying it.
+For semantic reclassification, generate a review-only migration plan with
+`python scripts/plan_category_migration.py --skills-dir skills --output category-migration-plan.json`.
+The plan records action, confidence, source categories, target category, keyword
+signals, and reason for every proposed change; it does not move files.
 
 Category counts are published in `categories/index.json`; full category payloads
 are available through `categories/<category>/manifest.json` and bounded
 `part-*.json` files. The legacy `categories/<category>.json` URL is now a small
-compatibility pointer. Common category codes include:
+compatibility pointer. The publish path runs
+`python scripts/check_category_artifacts.py --categories-dir docs/categories` so
+legacy category files cannot silently grow back into large full-payload JSON.
+Common category codes include:
 
 | Category | Code | Description |
 |----------|------|-------------|

--- a/docs/plan/taxonomy-v2-governance-spec.md
+++ b/docs/plan/taxonomy-v2-governance-spec.md
@@ -1,0 +1,137 @@
+# Taxonomy v2 Governance and Migration Spec
+
+## Problem
+
+The archive now has a clean two-level layout, but semantic category quality is
+still uneven. The first post-layout audit found 229,302 standard-layout skills,
+76 categories, 131,935 skills in `other`, and 6,766 reviewable reclassification
+candidates. Category names also mix stable user-facing buckets with historical
+or import-derived buckets such as `test`, `docs`, `specialized-testing`, and
+`utility`.
+
+The next step must not be a blind bulk move. Category changes affect published
+URLs, search filters, install discovery, and downstream consumers. Every
+category change needs a reproducible reason and a review path.
+
+## Goals
+
+- Make `taxonomy/categories.yaml` the versioned source of truth for category
+  names, aliases, status, parent relationships, and deprecation targets.
+- Keep generated classification suggestions deterministic and reviewable.
+- Separate category-name governance from per-skill reclassification.
+- Prevent regressions where legacy category compatibility files grow back into
+  large full-payload JSON.
+- Leave the data archive untouched until a migration plan is reviewed.
+
+## Non-Goals
+
+- Do not automatically apply the 6,766 heuristic candidates.
+- Do not directly edit generated files in the merged main artifact.
+- Do not delete skills to resolve category or directory conflicts.
+- Do not require historical metadata compliance cleanup as part of this work.
+
+## Taxonomy v2 Schema
+
+`taxonomy/categories.yaml` uses `schema_version: 2`.
+
+Each category keeps the existing fields:
+
+- `slug`: stable canonical identifier.
+- `code`: compact search-index code.
+- `display_name`: user-facing label.
+- `aliases`: accepted inbound names that resolve to the canonical slug.
+- `keywords`: deterministic text signals used for audit scoring.
+
+Taxonomy v2 adds governance fields:
+
+- `status`: `active`, `review`, or `deprecated`. Missing status defaults to
+  `active`.
+- `description`: user-facing inclusion rule.
+- `parent`: optional parent category for review and reporting.
+- `migrate_to`: required when `status: deprecated`; points to an active or
+  review category.
+
+Status meaning:
+
+- `active`: stable enough for new skills.
+- `review`: allowed but suspicious, broad, or still under naming review.
+- `deprecated`: existing archive entries may remain temporarily, but migration
+  plans should propose `migrate_to`.
+
+## Migration Plan Contract
+
+`scripts/plan_category_migration.py` emits JSON with:
+
+- `schema_version`
+- `generated_at`
+- `skills_dir`
+- `policy`
+- `summary`
+- `changes`
+- `notes`
+
+Each change contains:
+
+- `action`: `taxonomy_deprecation`, `normalize_alias`,
+  `resolve_source_conflict`, or `heuristic_reclassify`.
+- `confidence`: `high`, `medium`, or `low`.
+- `review_required`: boolean.
+- `path`, `name`, `current_category`, `proposed_category`.
+- `target_path_preview`: non-authoritative preview for human review.
+- `raw_sources`: directory/metadata/frontmatter values.
+- `resolved_sources`: taxonomy-normalized source values.
+- `score`, `current_score`, `signals`, and `reason` where applicable.
+
+The plan is review-only. A later apply tool must recompute collision-safe
+targets using the same deterministic directory rules as the existing archive
+normalizers.
+
+## Confidence Rules
+
+- `high`: declared taxonomy deprecation, or heuristic score at least 4 with a
+  strong delta, or `other` to a strong keyword target.
+- `medium`: clear target, but not enough evidence for high confidence.
+- `low`: weak signal or conflicting category sources.
+
+High confidence does not mean auto-apply. It means the item is suitable for a
+small reviewed migration batch.
+
+## Governance Gates
+
+Taxonomy gate:
+
+- `scripts/check_taxonomy_governance.py` fails on schema and relationship
+  errors.
+- It warns on broad active names, missing descriptions, long compact codes, and
+  deprecated categories that still attract keywords.
+- CI runs the gate in the Python test workflow.
+
+Category artifact gate:
+
+- `scripts/check_category_artifacts.py` verifies every
+  `docs/categories/<category>.json` compatibility file is a small pointer.
+- It fails if a pointer contains `skills`, lacks `deprecated_full_payload`, lacks
+  a manifest reference, references a missing manifest, or exceeds the pointer
+  size limit.
+- Build and publish paths run the gate after search/category index generation.
+
+## Operating Flow
+
+1. Update taxonomy status/name semantics in core.
+2. Run taxonomy governance validation.
+3. Generate a review-only migration plan against the data archive.
+4. Review by action, confidence, and category pair.
+5. Apply only small, high-confidence batches in data PRs.
+6. Publish main from pinned core/data refs.
+7. Re-run audit and compare `other` share, category conflicts, and plan deltas.
+
+## Acceptance Criteria
+
+- Current taxonomy loads as schema v2 and has no governance errors.
+- Deprecated categories can produce migration targets without changing current
+  resolution behavior.
+- A migration plan can be generated without modifying the archive.
+- The plan reports deprecations, aliases, source conflicts, heuristic
+  reclassifications, confidence bands, and category pair counts.
+- Generated category artifacts are guarded so legacy category JSON files remain
+  pointer-only.

--- a/scripts/category_taxonomy.py
+++ b/scripts/category_taxonomy.py
@@ -26,6 +26,10 @@ class CategoryDefinition:
     display_name: str
     aliases: tuple[str, ...]
     keywords: tuple[str, ...]
+    status: str = "active"
+    description: str = ""
+    parent: str = ""
+    migrate_to: str = ""
 
 
 @dataclass(frozen=True)
@@ -67,6 +71,13 @@ class CategoryTaxonomy:
             if definition.keywords
         }
 
+    def migration_target(self, raw_category: str | None) -> str | None:
+        slug = self.resolve(raw_category, allow_unknown=True)
+        definition = self.categories.get(slug)
+        if not definition:
+            return None
+        return definition.migrate_to or None
+
 
 def category_slug(raw_category: str | None) -> str:
     text = str(raw_category or "").strip().lower()
@@ -81,6 +92,12 @@ def _as_string_list(value: Any) -> tuple[str, ...]:
     if not isinstance(value, list):
         raise ValueError("taxonomy aliases/keywords must be lists")
     return tuple(category_slug(item) for item in value if category_slug(item))
+
+
+def _as_optional_slug(value: Any) -> str:
+    if value is None:
+        return ""
+    return category_slug(value)
 
 
 def load_taxonomy(path: Path = DEFAULT_TAXONOMY_PATH) -> CategoryTaxonomy:
@@ -116,12 +133,24 @@ def load_taxonomy(path: Path = DEFAULT_TAXONOMY_PATH) -> CategoryTaxonomy:
         display_name = str(entry.get("display_name") or slug.replace("-", " ").title())
         category_aliases = _as_string_list(entry.get("aliases"))
         keywords = _as_string_list(entry.get("keywords"))
+        status = category_slug(entry.get("status") or "active")
+        if status not in {"active", "review", "deprecated"}:
+            raise ValueError(
+                f"taxonomy category {slug!r} has invalid status {status!r}"
+            )
+        description = str(entry.get("description") or "").strip()
+        parent = _as_optional_slug(entry.get("parent"))
+        migrate_to = _as_optional_slug(entry.get("migrate_to"))
         categories[slug] = CategoryDefinition(
             slug=slug,
             code=code,
             display_name=display_name,
             aliases=category_aliases,
             keywords=keywords,
+            status=status,
+            description=description,
+            parent=parent,
+            migrate_to=migrate_to,
         )
         for alias in category_aliases:
             if alias in categories:
@@ -133,6 +162,42 @@ def load_taxonomy(path: Path = DEFAULT_TAXONOMY_PATH) -> CategoryTaxonomy:
 
     if default_category not in categories:
         raise ValueError(f"default category {default_category!r} is not declared")
+    if categories[default_category].status == "deprecated":
+        raise ValueError("default category must not be deprecated")
+
+    for slug, definition in categories.items():
+        if definition.parent:
+            parent_definition = categories.get(definition.parent)
+            if parent_definition is None:
+                raise ValueError(
+                    f"taxonomy category {slug!r} has unknown parent "
+                    f"{definition.parent!r}"
+                )
+            if parent_definition.status == "deprecated":
+                raise ValueError(
+                    f"taxonomy category {slug!r} has deprecated parent "
+                    f"{definition.parent!r}"
+                )
+        if definition.migrate_to:
+            target = categories.get(definition.migrate_to)
+            if target is None:
+                raise ValueError(
+                    f"taxonomy category {slug!r} has unknown migrate_to "
+                    f"{definition.migrate_to!r}"
+                )
+            if definition.migrate_to == slug:
+                raise ValueError(
+                    f"taxonomy category {slug!r} must not migrate to itself"
+                )
+            if target.status == "deprecated":
+                raise ValueError(
+                    f"taxonomy category {slug!r} migrates to deprecated target "
+                    f"{definition.migrate_to!r}"
+                )
+        if definition.status == "deprecated" and not definition.migrate_to:
+            raise ValueError(
+                f"deprecated taxonomy category {slug!r} must declare migrate_to"
+            )
 
     return CategoryTaxonomy(
         schema_version=int(payload.get("schema_version", 1)),
@@ -165,3 +230,7 @@ def get_category_code(raw_category: str | None) -> str:
 
 def category_keywords() -> dict[str, list[str]]:
     return get_taxonomy().keyword_map()
+
+
+def category_migration_target(raw_category: str | None) -> str | None:
+    return get_taxonomy().migration_target(raw_category)

--- a/scripts/check_category_artifacts.py
+++ b/scripts/check_category_artifacts.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Verify generated category artifacts stay sharded and pointer-only."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_POINTER_MAX_BYTES = 16 * 1024
+DEFAULT_PART_MAX_BYTES = 10 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class ArtifactIssue:
+    severity: str
+    code: str
+    path: str
+    message: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "severity": self.severity,
+            "code": self.code,
+            "path": self.path,
+            "message": self.message,
+        }
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _relative(path: Path, root: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def build_report(
+    categories_dir: Path,
+    *,
+    pointer_max_bytes: int = DEFAULT_POINTER_MAX_BYTES,
+    part_max_bytes: int = DEFAULT_PART_MAX_BYTES,
+) -> dict[str, Any]:
+    issues: list[ArtifactIssue] = []
+    pointer_count = 0
+    part_count = 0
+    largest_pointer_bytes = 0
+    largest_part_bytes = 0
+
+    if not categories_dir.exists():
+        issues.append(
+            ArtifactIssue(
+                severity="error",
+                code="missing-categories-dir",
+                path=str(categories_dir),
+                message="categories directory does not exist",
+            )
+        )
+    else:
+        for pointer_path in sorted(categories_dir.glob("*.json")):
+            if pointer_path.name == "index.json":
+                continue
+            pointer_count += 1
+            pointer_size = pointer_path.stat().st_size
+            largest_pointer_bytes = max(largest_pointer_bytes, pointer_size)
+            rel_path = _relative(pointer_path, categories_dir.parent)
+            if pointer_size > pointer_max_bytes:
+                issues.append(
+                    ArtifactIssue(
+                        severity="error",
+                        code="category-pointer-too-large",
+                        path=rel_path,
+                        message=(
+                            f"category compatibility pointer is {pointer_size} bytes; "
+                            f"expected <= {pointer_max_bytes}"
+                        ),
+                    )
+                )
+
+            payload = load_json(pointer_path)
+            if not isinstance(payload, dict):
+                issues.append(
+                    ArtifactIssue(
+                        severity="error",
+                        code="category-pointer-shape",
+                        path=rel_path,
+                        message="category pointer must be a JSON object",
+                    )
+                )
+                continue
+            if payload.get("deprecated_full_payload") is not True:
+                issues.append(
+                    ArtifactIssue(
+                        severity="error",
+                        code="category-pointer-not-marked",
+                        path=rel_path,
+                        message="category pointer must set deprecated_full_payload=true",
+                    )
+                )
+            if "skills" in payload:
+                issues.append(
+                    ArtifactIssue(
+                        severity="error",
+                        code="category-pointer-contains-skills",
+                        path=rel_path,
+                        message="legacy category pointer must not contain full skills payload",
+                    )
+                )
+            manifest_ref = payload.get("manifest")
+            if not isinstance(manifest_ref, str) or not manifest_ref:
+                issues.append(
+                    ArtifactIssue(
+                        severity="error",
+                        code="category-pointer-missing-manifest",
+                        path=rel_path,
+                        message="category pointer must reference a manifest",
+                    )
+                )
+                continue
+            manifest_path = categories_dir.parent / manifest_ref
+            if not manifest_path.exists():
+                issues.append(
+                    ArtifactIssue(
+                        severity="error",
+                        code="category-manifest-missing",
+                        path=manifest_ref,
+                        message="category manifest referenced by pointer does not exist",
+                    )
+                )
+
+        for part_path in sorted(categories_dir.glob("*/part-*.json")):
+            part_count += 1
+            part_size = part_path.stat().st_size
+            largest_part_bytes = max(largest_part_bytes, part_size)
+            if part_size > part_max_bytes:
+                issues.append(
+                    ArtifactIssue(
+                        severity="error",
+                        code="category-part-too-large",
+                        path=_relative(part_path, categories_dir.parent),
+                        message=(
+                            f"category shard part is {part_size} bytes; "
+                            f"expected <= {part_max_bytes}"
+                        ),
+                    )
+                )
+
+    errors = [issue.as_dict() for issue in issues if issue.severity == "error"]
+    warnings = [issue.as_dict() for issue in issues if issue.severity == "warning"]
+    return {
+        "categories_dir": str(categories_dir),
+        "pointer_count": pointer_count,
+        "part_count": part_count,
+        "largest_pointer_bytes": largest_pointer_bytes,
+        "largest_part_bytes": largest_part_bytes,
+        "pointer_max_bytes": pointer_max_bytes,
+        "part_max_bytes": part_max_bytes,
+        "error_count": len(errors),
+        "warning_count": len(warnings),
+        "errors": errors,
+        "warnings": warnings,
+    }
+
+
+def print_report(report: dict[str, Any], *, limit: int) -> None:
+    print("Category artifact guard")
+    print(f"Pointers: {report['pointer_count']}")
+    print(f"Parts: {report['part_count']}")
+    print(f"Largest pointer: {report['largest_pointer_bytes']} bytes")
+    print(f"Largest part: {report['largest_part_bytes']} bytes")
+    print(f"Errors: {report['error_count']}")
+    if report["errors"]:
+        for item in report["errors"][:limit]:
+            print(f"- {item['code']} {item['path']}: {item['message']}")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--categories-dir", type=Path, default=Path("docs/categories"))
+    parser.add_argument("--pointer-max-kib", type=int, default=16)
+    parser.add_argument("--part-max-mib", type=int, default=10)
+    parser.add_argument("--output-json", type=Path)
+    parser.add_argument("--limit", type=int, default=20)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = build_report(
+        args.categories_dir,
+        pointer_max_bytes=args.pointer_max_kib * 1024,
+        part_max_bytes=args.part_max_mib * 1024 * 1024,
+    )
+    if args.output_json:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(
+            json.dumps(report, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+    print_report(report, limit=args.limit)
+    return 1 if report["error_count"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_taxonomy_governance.py
+++ b/scripts/check_taxonomy_governance.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Validate taxonomy v2 governance rules."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from category_taxonomy import CategoryTaxonomy, load_taxonomy
+
+REVIEW_NAME_TOKENS = {
+    "applied",
+    "core",
+    "extended",
+    "foundation",
+    "misc",
+    "other",
+    "project",
+    "specialized",
+    "string",
+    "template",
+    "test",
+    "utility",
+}
+
+
+@dataclass(frozen=True)
+class GovernanceIssue:
+    severity: str
+    code: str
+    category: str
+    message: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "severity": self.severity,
+            "code": self.code,
+            "category": self.category,
+            "message": self.message,
+        }
+
+
+def _slug_tokens(slug: str) -> set[str]:
+    return {part for part in slug.split("-") if part}
+
+
+def build_report(taxonomy: CategoryTaxonomy) -> dict[str, Any]:
+    issues: list[GovernanceIssue] = []
+
+    if taxonomy.schema_version < 2:
+        issues.append(
+            GovernanceIssue(
+                severity="error",
+                code="schema-version",
+                category="",
+                message="taxonomy schema_version must be at least 2 for governance metadata",
+            )
+        )
+
+    for slug, definition in sorted(taxonomy.categories.items()):
+        if not definition.display_name.strip():
+            issues.append(
+                GovernanceIssue(
+                    severity="error",
+                    code="missing-display-name",
+                    category=slug,
+                    message="category must declare display_name",
+                )
+            )
+        if len(definition.code) > 24:
+            issues.append(
+                GovernanceIssue(
+                    severity="warning",
+                    code="long-code",
+                    category=slug,
+                    message="category code is long for compact index consumers",
+                )
+            )
+        broad_name = bool(_slug_tokens(slug) & REVIEW_NAME_TOKENS)
+        if definition.status == "active" and broad_name and not definition.description:
+            issues.append(
+                GovernanceIssue(
+                    severity="warning",
+                    code="broad-active-name",
+                    category=slug,
+                    message=(
+                        "category name is broad; add status: review/deprecated or "
+                        "a precise description"
+                    ),
+                )
+            )
+        if definition.status == "review" and not definition.description:
+            issues.append(
+                GovernanceIssue(
+                    severity="warning",
+                    code="missing-description",
+                    category=slug,
+                    message="category should describe the user-facing inclusion rule",
+                )
+            )
+        if definition.status == "deprecated" and definition.keywords:
+            issues.append(
+                GovernanceIssue(
+                    severity="warning",
+                    code="deprecated-keywords",
+                    category=slug,
+                    message="deprecated categories should not attract new keyword matches",
+                )
+            )
+
+    errors = [issue.as_dict() for issue in issues if issue.severity == "error"]
+    warnings = [issue.as_dict() for issue in issues if issue.severity == "warning"]
+    status_counts: dict[str, int] = {}
+    for definition in taxonomy.categories.values():
+        status_counts[definition.status] = status_counts.get(definition.status, 0) + 1
+
+    return {
+        "schema_version": taxonomy.schema_version,
+        "category_count": len(taxonomy.categories),
+        "status_counts": dict(sorted(status_counts.items())),
+        "error_count": len(errors),
+        "warning_count": len(warnings),
+        "errors": errors,
+        "warnings": warnings,
+    }
+
+
+def print_report(report: dict[str, Any], *, limit: int) -> None:
+    print(
+        "Taxonomy governance "
+        f"(schema={report['schema_version']}, categories={report['category_count']})"
+    )
+    print(f"Errors: {report['error_count']}")
+    print(f"Warnings: {report['warning_count']}")
+    if report["errors"]:
+        print("Error examples:")
+        for item in report["errors"][:limit]:
+            print(f"- {item['code']} {item['category']}: {item['message']}")
+    if report["warnings"]:
+        print("Warning examples:")
+        for item in report["warnings"][:limit]:
+            print(f"- {item['code']} {item['category']}: {item['message']}")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--taxonomy", type=Path, default=None)
+    parser.add_argument("--output-json", type=Path)
+    parser.add_argument("--fail-on-warnings", action="store_true")
+    parser.add_argument("--limit", type=int, default=20)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        taxonomy = load_taxonomy(args.taxonomy) if args.taxonomy else load_taxonomy()
+        report = build_report(taxonomy)
+    except Exception as exc:
+        report = {
+            "schema_version": None,
+            "category_count": 0,
+            "status_counts": {},
+            "error_count": 1,
+            "warning_count": 0,
+            "errors": [
+                {
+                    "severity": "error",
+                    "code": "load-failed",
+                    "category": "",
+                    "message": str(exc),
+                }
+            ],
+            "warnings": [],
+        }
+
+    if args.output_json:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(
+            json.dumps(report, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+    print_report(report, limit=args.limit)
+    if report["error_count"]:
+        return 1
+    if args.fail_on_warnings and report["warning_count"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/plan_category_migration.py
+++ b/scripts/plan_category_migration.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Build a reviewable category migration plan without changing files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from audit_category_quality import best_suggestion, read_text_prefix
+from category_taxonomy import category_slug, get_taxonomy
+from utils import extract_frontmatter, load_metadata, normalize_name
+
+CONFIDENCE_ORDER = {"high": 0, "medium": 1, "low": 2}
+
+
+def iter_skill_dirs(skills_dir: Path):
+    for dirpath, dirnames, filenames in os.walk(skills_dir):
+        dirnames[:] = sorted(name for name in dirnames if not name.startswith("."))
+        if "SKILL.md" not in filenames:
+            continue
+        skill_file = Path(dirpath) / "SKILL.md"
+        rel = skill_file.relative_to(skills_dir)
+        if any(part.startswith(".") for part in rel.parts):
+            continue
+        yield skill_file.parent, rel
+
+
+def raw_category_sources(
+    rel: Path,
+    metadata: dict[str, Any],
+    frontmatter: dict[str, Any],
+) -> dict[str, str]:
+    directory_category = rel.parts[0] if rel.parts else "other"
+    sources = {
+        "directory": directory_category,
+        "metadata": metadata.get("category") if isinstance(metadata.get("category"), str) else "",
+        "frontmatter": frontmatter.get("category") if isinstance(frontmatter.get("category"), str) else "",
+    }
+    return {source: value for source, value in sources.items() if value}
+
+
+def source_categories(raw_sources: dict[str, str]) -> dict[str, str]:
+    taxonomy = get_taxonomy()
+    return {
+        source: taxonomy.resolve(value, allow_unknown=True)
+        for source, value in raw_sources.items()
+    }
+
+
+def confidence_for_suggestion(
+    current_category: str,
+    suggestion: dict[str, Any],
+    *,
+    high_score: int,
+    high_delta: int,
+) -> str:
+    score = int(suggestion["score"])
+    current_score = int(suggestion["current_score"])
+    delta = score - current_score
+    if current_category == "other" and score >= high_score:
+        return "high"
+    if score >= high_score and delta >= high_delta:
+        return "high"
+    if score >= 3:
+        return "medium"
+    return "low"
+
+
+def build_change(
+    *,
+    action: str,
+    confidence: str,
+    rel: Path,
+    skill_dir: Path,
+    name: str,
+    current_category: str,
+    proposed_category: str,
+    raw_sources: dict[str, str],
+    resolved_sources: dict[str, str],
+    reason: str,
+    signals: list[str] | None = None,
+    score: int | None = None,
+    current_score: int | None = None,
+) -> dict[str, Any]:
+    proposed_name = normalize_name(name or skill_dir.name)
+    return {
+        "action": action,
+        "confidence": confidence,
+        "review_required": confidence != "high" or action in {"resolve_source_conflict"},
+        "path": str(rel),
+        "name": name or skill_dir.name,
+        "current_category": current_category,
+        "proposed_category": proposed_category,
+        "target_path_preview": str(Path(proposed_category) / proposed_name / "SKILL.md"),
+        "raw_sources": raw_sources,
+        "resolved_sources": resolved_sources,
+        "score": score,
+        "current_score": current_score,
+        "signals": signals or [],
+        "reason": reason,
+    }
+
+
+def build_plan(
+    skills_dir: Path,
+    *,
+    include_frontmatter: bool = False,
+    content_chars: int = 0,
+    min_score: int = 2,
+    min_delta: int = 2,
+    high_score: int = 4,
+    high_delta: int = 3,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    taxonomy = get_taxonomy()
+    keyword_map = taxonomy.keyword_map()
+    changes: list[dict[str, Any]] = []
+    total_skills = 0
+    standard_layout_skills = 0
+
+    for skill_dir, rel in iter_skill_dirs(skills_dir):
+        total_skills += 1
+        if len(rel.parts) == 3:
+            standard_layout_skills += 1
+
+        content = ""
+        frontmatter: dict[str, Any] = {}
+        if include_frontmatter or content_chars > 0:
+            content = read_text_prefix(skill_dir / "SKILL.md", max_chars=max(content_chars, 8192))
+            frontmatter = extract_frontmatter(content)
+        metadata = load_metadata(skill_dir)
+        raw_sources = raw_category_sources(rel, metadata, frontmatter)
+        resolved_sources = source_categories(raw_sources)
+        declared_category = (
+            raw_sources.get("metadata")
+            or raw_sources.get("frontmatter")
+            or raw_sources.get("directory")
+            or "other"
+        )
+        current_category = taxonomy.resolve(declared_category, allow_unknown=True)
+        name = str(metadata.get("name") or frontmatter.get("name") or skill_dir.name)
+        tags = metadata.get("tags") or frontmatter.get("tags") or []
+        tag_text = " ".join(str(tag) for tag in tags) if isinstance(tags, list) else str(tags)
+        text = " ".join(
+            [
+                name,
+                str(metadata.get("description") or frontmatter.get("description") or ""),
+                tag_text,
+                str(rel),
+                content[:content_chars],
+            ]
+        )
+
+        source_values = set(resolved_sources.values())
+        migration_target = taxonomy.migration_target(current_category)
+        if migration_target:
+            definition = taxonomy.categories[current_category]
+            changes.append(
+                build_change(
+                    action="taxonomy_deprecation",
+                    confidence="high",
+                    rel=rel,
+                    skill_dir=skill_dir,
+                    name=name,
+                    current_category=current_category,
+                    proposed_category=migration_target,
+                    raw_sources=raw_sources,
+                    resolved_sources=resolved_sources,
+                    reason=(
+                        f"taxonomy marks {current_category} as {definition.status} "
+                        f"with migrate_to={migration_target}"
+                    ),
+                )
+            )
+            continue
+
+        alias_sources = [
+            source
+            for source, value in raw_sources.items()
+            if category_slug(value) in taxonomy.aliases
+        ]
+        if alias_sources:
+            changes.append(
+                build_change(
+                    action="normalize_alias",
+                    confidence="high" if len(source_values) == 1 else "medium",
+                    rel=rel,
+                    skill_dir=skill_dir,
+                    name=name,
+                    current_category=current_category,
+                    proposed_category=current_category,
+                    raw_sources=raw_sources,
+                    resolved_sources=resolved_sources,
+                    reason=f"category source(s) use alias: {', '.join(sorted(alias_sources))}",
+                )
+            )
+            continue
+
+        if len(source_values) > 1:
+            changes.append(
+                build_change(
+                    action="resolve_source_conflict",
+                    confidence="low",
+                    rel=rel,
+                    skill_dir=skill_dir,
+                    name=name,
+                    current_category=current_category,
+                    proposed_category=current_category,
+                    raw_sources=raw_sources,
+                    resolved_sources=resolved_sources,
+                    reason="directory, metadata, or frontmatter categories disagree",
+                )
+            )
+            continue
+
+        suggestion = best_suggestion(
+            current_category,
+            text,
+            keyword_map,
+            min_score=min_score,
+            min_delta=min_delta,
+        )
+        if suggestion:
+            confidence = confidence_for_suggestion(
+                current_category,
+                suggestion,
+                high_score=high_score,
+                high_delta=high_delta,
+            )
+            changes.append(
+                build_change(
+                    action="heuristic_reclassify",
+                    confidence=confidence,
+                    rel=rel,
+                    skill_dir=skill_dir,
+                    name=name,
+                    current_category=current_category,
+                    proposed_category=str(suggestion["suggested_category"]),
+                    raw_sources=raw_sources,
+                    resolved_sources=resolved_sources,
+                    reason=str(suggestion["reason"]),
+                    signals=list(suggestion["signals"]),
+                    score=int(suggestion["score"]),
+                    current_score=int(suggestion["current_score"]),
+                )
+            )
+
+    changes.sort(
+        key=lambda item: (
+            CONFIDENCE_ORDER.get(item["confidence"], 9),
+            item["action"],
+            item["current_category"],
+            item["proposed_category"],
+            item["path"],
+        )
+    )
+    action_counts = Counter(change["action"] for change in changes)
+    confidence_counts = Counter(change["confidence"] for change in changes)
+    category_pairs = Counter(
+        (change["current_category"], change["proposed_category"])
+        for change in changes
+    )
+    emitted_changes = changes[: max(limit, 0)] if limit is not None else changes
+
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "skills_dir": str(skills_dir),
+        "policy": {
+            "min_score": min_score,
+            "min_delta": min_delta,
+            "high_score": high_score,
+            "high_delta": high_delta,
+            "include_frontmatter": include_frontmatter,
+            "content_chars": content_chars,
+            "apply_mode": "review-only",
+        },
+        "summary": {
+            "total_skills": total_skills,
+            "standard_layout_skill_count": standard_layout_skills,
+            "planned_change_count": len(changes),
+            "emitted_change_count": len(emitted_changes),
+            "action_counts": dict(sorted(action_counts.items())),
+            "confidence_counts": dict(sorted(confidence_counts.items())),
+            "category_pair_counts": [
+                {
+                    "current_category": current,
+                    "proposed_category": proposed,
+                    "count": count,
+                }
+                for (current, proposed), count in sorted(
+                    category_pairs.items(),
+                    key=lambda item: (-item[1], item[0][0], item[0][1]),
+                )
+            ],
+        },
+        "changes": emitted_changes,
+        "notes": [
+            "This plan does not modify files.",
+            "target_path_preview is not collision-safe; apply tooling must recompute unique paths.",
+            "High-confidence heuristic entries are still reviewable, not automatically applied.",
+        ],
+    }
+
+
+def print_text_report(plan: dict[str, Any], *, limit: int) -> None:
+    summary = plan["summary"]
+    print("Category migration plan")
+    print(f"Total skills: {summary['total_skills']}")
+    print(f"Planned changes: {summary['planned_change_count']}")
+    print(f"Actions: {summary['action_counts']}")
+    print(f"Confidence: {summary['confidence_counts']}")
+    for change in plan["changes"][:limit]:
+        print(
+            f"- {change['confidence']} {change['action']} "
+            f"{change['path']}: {change['current_category']} -> "
+            f"{change['proposed_category']} ({change['reason']})"
+        )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--skills-dir", type=Path, default=Path("skills"))
+    parser.add_argument("--include-frontmatter", action="store_true")
+    parser.add_argument("--content-chars", type=int, default=0)
+    parser.add_argument("--min-score", type=int, default=2)
+    parser.add_argument("--min-delta", type=int, default=2)
+    parser.add_argument("--high-score", type=int, default=4)
+    parser.add_argument("--high-delta", type=int, default=3)
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--limit-changes", type=int)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if not args.skills_dir.exists():
+        raise SystemExit(f"Skills directory not found: {args.skills_dir}")
+    plan = build_plan(
+        args.skills_dir,
+        include_frontmatter=args.include_frontmatter,
+        content_chars=args.content_chars,
+        min_score=args.min_score,
+        min_delta=args.min_delta,
+        high_score=args.high_score,
+        high_delta=args.high_delta,
+        limit=args.limit_changes,
+    )
+    payload = json.dumps(plan, indent=2, ensure_ascii=False)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload + "\n", encoding="utf-8")
+    if args.json:
+        print(payload)
+    else:
+        print_text_report(plan, limit=args.limit)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_main_repo.sh
+++ b/scripts/sync_main_repo.sh
@@ -71,6 +71,8 @@ if [[ "$rebuild" -eq 1 ]]; then
     --include registry.json \
     --include registry-shards \
     --include docs
+  python "$main_dir/scripts/check_category_artifacts.py" \
+    --categories-dir "$main_dir/docs/categories"
 fi
 
 echo "Generating third-party notices..."

--- a/taxonomy/categories.yaml
+++ b/taxonomy/categories.yaml
@@ -1,5 +1,13 @@
-schema_version: 1
+schema_version: 2
 default_category: other
+governance:
+  status_values: [active, review, deprecated]
+  migration_plan_schema_version: 1
+  review_required_for: [review, deprecated, unknown, source-conflict]
+  confidence_bands:
+    high: "score >= 4 and delta >= 3, or a declared taxonomy deprecation"
+    medium: "score >= 3 with a clear target but not enough evidence to apply"
+    low: "weak signal or conflicting category sources"
 categories:
   - slug: adb-meta-automation
     code: adb-meta-automation
@@ -10,6 +18,7 @@ categories:
   - slug: agent-coordination
     code: agent-coordination
     display_name: Agent Coordination
+    parent: agent
   - slug: ai-llm
     code: ai-llm
     display_name: AI / LLM
@@ -33,6 +42,8 @@ categories:
   - slug: applied
     code: applied
     display_name: Applied
+    status: review
+    description: "Legacy broad bucket; review whether each skill belongs in a user-facing capability category."
   - slug: artifact-generation
     code: artifact-generation
     display_name: Artifact Generation
@@ -63,6 +74,8 @@ categories:
   - slug: core
     code: core
     display_name: Core
+    status: review
+    description: "Broad infrastructure bucket; review whether skills belong in Development, Platform, or another concrete category."
   - slug: creative
     code: creative
     display_name: Creative
@@ -70,41 +83,58 @@ categories:
   - slug: data
     code: dat
     display_name: Data
+    description: "Data engineering, analytics, databases, ETL, SQL, and visualization workflows."
     keywords: [data, analytics, sql, database, etl, pipeline, visualization]
   - slug: data-access
     code: data-access
     display_name: Data Access
+    status: review
+    parent: data
+    description: "Potential data subcategory; review against Data before adding more fine-grained buckets."
   - slug: design
     code: des
     display_name: Design
+    description: "UI, UX, visual design, frontend styling, Figma, components, and interaction design."
     keywords: [design, ui, ux, css, frontend, component, tailwind, figma, animation]
   - slug: design-principles
     code: design-principles
     display_name: Design Principles
+    parent: design
   - slug: development
     code: dev
     display_name: Development
+    description: "Software development workflows, coding, frameworks, builds, debugging, and refactoring."
     aliases: [dev, engineering, software-engineering, programming]
     keywords: [dev, code, programming, framework, build, software, compile, debug, refactor]
   - slug: development-code
     code: development-code
     display_name: Development Code
+    status: review
+    parent: development
+    description: "Potentially redundant with Development; review before using for new skills."
   - slug: development-tools
     code: development-tools
     display_name: Development Tools
+    parent: development
   - slug: devops
     code: ops
     display_name: DevOps
+    description: "CI/CD, infrastructure, Docker, Kubernetes, deployment, and operational automation."
     keywords: [devops, ci, cd, docker, kubernetes, deploy, infra, infrastructure]
   - slug: docs
     code: docs
     display_name: Docs
+    status: deprecated
+    migrate_to: documents
+    description: "Deprecated short-form duplicate of Documents."
   - slug: document-processing
     code: document-processing
     display_name: Document Processing
+    parent: documents
   - slug: documents
     code: doc
     display_name: Documents
+    description: "Document creation, conversion, summarization, office formats, markdown, and PDFs."
     aliases: [documentation]
     keywords: [doc, docs, pdf, word, excel, pptx, xlsx, docx, markdown, documentation]
   - slug: domains
@@ -116,12 +146,16 @@ categories:
   - slug: extended
     code: extended
     display_name: Extended
+    status: review
+    description: "Legacy broad bucket; requires review before accepting more skills."
   - slug: forensics
     code: forensics
     display_name: Forensics
   - slug: foundation
     code: foundation
     display_name: Foundation
+    status: review
+    description: "Legacy broad bucket; classify into a concrete capability where possible."
   - slug: framework
     code: framework
     display_name: Framework
@@ -140,6 +174,7 @@ categories:
   - slug: integration
     code: integration
     display_name: Integration
+    description: "Cross-system connectors, service integrations, API composition, and platform bridges."
   - slug: language
     code: language
     display_name: Language
@@ -167,6 +202,7 @@ categories:
   - slug: other
     code: oth
     display_name: Other
+    description: "Fallback bucket for unclassified skills; should shrink through reviewed migrations."
   - slug: performance
     code: performance
     display_name: Performance
@@ -184,10 +220,12 @@ categories:
   - slug: product
     code: prd
     display_name: Product
+    description: "Product management, PRDs, roadmaps, backlog work, user research, and metrics."
     keywords: [product, prd, roadmap, feature, backlog, user-research, metrics]
   - slug: productivity
     code: pro
     display_name: Productivity
+    description: "Personal/team workflow automation, task management, planning aids, and memory utilities."
     keywords: [productivity, automation, workflow, task, planning, memory]
   - slug: programming-languages
     code: programming-languages
@@ -195,6 +233,8 @@ categories:
   - slug: project
     code: project
     display_name: Project
+    status: review
+    description: "Broad project bucket; review whether skills belong in Product, Planning, Development, or Docs."
   - slug: quality
     code: quality
     display_name: Quality
@@ -205,53 +245,80 @@ categories:
   - slug: security
     code: sec
     display_name: Security
+    description: "Security review, authentication, cryptography, vulnerabilities, OWASP, pentesting, and fuzzing."
     keywords: [security, auth, crypto, vulnerability, audit, owasp, pentest, fuzzing]
   - slug: security-compliance
     code: security-compliance
     display_name: Security Compliance
+    parent: security
   - slug: security-operations
     code: security-operations
     display_name: Security Operations
+    parent: security
   - slug: skills
     code: skills
     display_name: Skills
   - slug: specialized
     code: specialized
     display_name: Specialized
+    status: review
+    description: "Legacy broad bucket; prefer a concrete capability or domain category."
   - slug: specialized-testing
     code: specialized-testing
     display_name: Specialized Testing
+    status: deprecated
+    parent: testing
+    migrate_to: testing
+    description: "Deprecated duplicate of Testing."
   - slug: story-analysis
     code: story-analysis
     display_name: Story Analysis
   - slug: string
     code: string
     display_name: String
+    status: review
+    description: "Likely too implementation-specific for top-level browsing; review usage."
   - slug: system
     code: system
     display_name: System
   - slug: technical-integration
     code: technical-integration
     display_name: Technical Integration
+    status: deprecated
+    parent: integration
+    migrate_to: integration
+    description: "Deprecated duplicate of Integration."
   - slug: template
     code: template
     display_name: Template
+    status: review
+    description: "Review whether template skills should be examples, docs, or a concrete capability."
   - slug: test
     code: test
     display_name: Test
+    status: deprecated
+    migrate_to: testing
+    description: "Deprecated singular duplicate of Testing."
   - slug: testing
     code: tst
     display_name: Testing
+    description: "Testing, QA, TDD, unit/integration/e2e testing, browser automation, and test tooling."
     keywords: [test, qa, tdd, jest, pytest, unittest, integration, e2e, playwright, cypress]
   - slug: testing-methodologies
     code: testing-methodologies
     display_name: Testing Methodologies
+    status: deprecated
+    parent: testing
+    migrate_to: testing
+    description: "Deprecated duplicate of Testing."
   - slug: travel
     code: travel
     display_name: Travel
   - slug: utility
     code: utility
     display_name: Utility
+    status: review
+    description: "Broad utility bucket; review before treating as a stable user-facing category."
   - slug: war-room
     code: war-room
     display_name: War Room

--- a/tests/test_category_taxonomy.py
+++ b/tests/test_category_taxonomy.py
@@ -17,10 +17,13 @@ def _load_module():
 def test_taxonomy_loads_current_category_set():
     taxonomy = _load_module()
     loaded = taxonomy.load_taxonomy()
+    assert loaded.schema_version == 2
     assert loaded.default_category == "other"
     assert "development" in loaded.categories
     assert "other" in loaded.categories
     assert len(loaded.categories) >= 77
+    assert loaded.categories["docs"].status == "deprecated"
+    assert loaded.migration_target("docs") == "documents"
 
 
 def test_taxonomy_resolves_aliases_and_codes():
@@ -66,4 +69,44 @@ categories:
         encoding="utf-8",
     )
     with pytest.raises(ValueError, match="maps to both"):
+        taxonomy.load_taxonomy(taxonomy_file)
+
+
+def test_taxonomy_rejects_deprecated_category_without_target(tmp_path):
+    taxonomy = _load_module()
+    taxonomy_file = tmp_path / "categories.yaml"
+    taxonomy_file.write_text(
+        """
+schema_version: 2
+default_category: other
+categories:
+  - slug: other
+    code: oth
+  - slug: old
+    code: old
+    status: deprecated
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="must declare migrate_to"):
+        taxonomy.load_taxonomy(taxonomy_file)
+
+
+def test_taxonomy_rejects_unknown_parent(tmp_path):
+    taxonomy = _load_module()
+    taxonomy_file = tmp_path / "categories.yaml"
+    taxonomy_file.write_text(
+        """
+schema_version: 2
+default_category: other
+categories:
+  - slug: other
+    code: oth
+  - slug: child
+    code: child
+    parent: missing
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="unknown parent"):
         taxonomy.load_taxonomy(taxonomy_file)

--- a/tests/test_check_category_artifacts.py
+++ b/tests/test_check_category_artifacts.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    return importlib.import_module("check_category_artifacts")
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def test_category_artifact_guard_accepts_pointer_and_parts(tmp_path):
+    guard = _load_module()
+    categories_dir = tmp_path / "docs" / "categories"
+    _write_json(
+        categories_dir / "development.json",
+        {
+            "category": "development",
+            "deprecated_full_payload": True,
+            "manifest": "categories/development/manifest.json",
+        },
+    )
+    _write_json(
+        categories_dir / "development" / "manifest.json",
+        {"parts": [{"path": "categories/development/part-000.json"}]},
+    )
+    _write_json(categories_dir / "development" / "part-000.json", {"skills": []})
+
+    report = guard.build_report(categories_dir, pointer_max_bytes=1024, part_max_bytes=1024)
+
+    assert report["error_count"] == 0
+    assert report["pointer_count"] == 1
+    assert report["part_count"] == 1
+
+
+def test_category_artifact_guard_rejects_full_legacy_payload(tmp_path):
+    guard = _load_module()
+    categories_dir = tmp_path / "docs" / "categories"
+    _write_json(
+        categories_dir / "other.json",
+        {
+            "category": "other",
+            "deprecated_full_payload": False,
+            "skills": [{"name": "too-large"}],
+        },
+    )
+
+    report = guard.build_report(categories_dir, pointer_max_bytes=1024, part_max_bytes=1024)
+    codes = {item["code"] for item in report["errors"]}
+
+    assert "category-pointer-not-marked" in codes
+    assert "category-pointer-contains-skills" in codes
+    assert "category-pointer-missing-manifest" in codes
+
+
+def test_category_artifact_guard_rejects_oversized_pointer(tmp_path):
+    guard = _load_module()
+    categories_dir = tmp_path / "docs" / "categories"
+    _write_json(
+        categories_dir / "other.json",
+        {
+            "category": "other",
+            "deprecated_full_payload": True,
+            "manifest": "categories/other/manifest.json",
+            "padding": "x" * 200,
+        },
+    )
+    _write_json(categories_dir / "other" / "manifest.json", {"parts": []})
+
+    report = guard.build_report(categories_dir, pointer_max_bytes=100, part_max_bytes=1024)
+
+    assert report["error_count"] == 1
+    assert report["errors"][0]["code"] == "category-pointer-too-large"

--- a/tests/test_check_taxonomy_governance.py
+++ b/tests/test_check_taxonomy_governance.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    return importlib.import_module("check_taxonomy_governance")
+
+
+def _taxonomy_module():
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    return importlib.import_module("category_taxonomy")
+
+
+def test_current_taxonomy_has_no_governance_errors():
+    governance = _load_module()
+    taxonomy = _taxonomy_module().load_taxonomy()
+
+    report = governance.build_report(taxonomy)
+
+    assert report["schema_version"] == 2
+    assert report["error_count"] == 0
+    assert report["status_counts"]["deprecated"] >= 1
+    assert report["status_counts"]["review"] >= 1
+
+
+def test_governance_reports_schema_v1_error(tmp_path):
+    governance = _load_module()
+    taxonomy_module = _taxonomy_module()
+    taxonomy_file = tmp_path / "categories.yaml"
+    taxonomy_file.write_text(
+        """
+schema_version: 1
+default_category: other
+categories:
+  - slug: other
+    code: oth
+    display_name: Other
+""",
+        encoding="utf-8",
+    )
+
+    report = governance.build_report(taxonomy_module.load_taxonomy(taxonomy_file))
+
+    assert report["error_count"] == 1
+    assert report["errors"][0]["code"] == "schema-version"

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -23,11 +22,13 @@ def test_publish_sync_runs_generated_size_guard_after_rebuild():
 
     rebuild_pos = sync_script.index("scripts/build_search_index.py")
     guard_pos = sync_script.index("scripts/check_generated_file_sizes.py")
+    category_guard_pos = sync_script.index("scripts/check_category_artifacts.py")
 
-    assert guard_pos > rebuild_pos
+    assert category_guard_pos > guard_pos > rebuild_pos
     assert "--include registry.json" in sync_script
     assert "--include registry-shards" in sync_script
     assert "--include docs" in sync_script
+    assert "--categories-dir" in sync_script
 
 
 def test_build_index_fails_closed_when_security_report_is_missing():
@@ -44,9 +45,10 @@ def test_build_index_runs_generated_size_guard_before_pages_upload():
     workflow = read_repo_file(".github/workflows/build-index.yml")
 
     guard_pos = workflow.index("scripts/check_generated_file_sizes.py")
+    category_guard_pos = workflow.index("scripts/check_category_artifacts.py")
     upload_pos = workflow.index("actions/upload-pages-artifact")
 
-    assert guard_pos < upload_pos
+    assert guard_pos < category_guard_pos < upload_pos
     assert "--include docs" in workflow
 
 
@@ -77,6 +79,8 @@ def test_python_tests_workflow_runs_full_suite_with_coverage_gate():
 
     assert "name: Python Test Health" in workflow
     assert "python -m pytest -q --cov-fail-under=50" in workflow
+    assert "scripts/check_taxonomy_governance.py" in workflow
     assert "--override-ini" not in workflow
     assert "scripts/**" in workflow
+    assert "taxonomy/**" in workflow
     assert "crawler/**" in workflow

--- a/tests/test_plan_category_migration.py
+++ b/tests/test_plan_category_migration.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    return importlib.import_module("plan_category_migration")
+
+
+def _write_skill(root: Path, category: str, name: str, metadata: dict, body: str = "") -> None:
+    skill_dir = root / category / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "metadata.json").write_text(
+        json.dumps(metadata, indent=2),
+        encoding="utf-8",
+    )
+    (skill_dir / "SKILL.md").write_text(
+        body or f"---\nname: {name}\n---\n\n{metadata.get('description', '')}",
+        encoding="utf-8",
+    )
+
+
+def test_plan_includes_taxonomy_deprecation_and_heuristic_reclassify(tmp_path):
+    planner = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "docs",
+        "pdf-helper",
+        {
+            "name": "pdf-helper",
+            "category": "docs",
+            "description": "PDF DOCX markdown conversion helper.",
+        },
+    )
+    _write_skill(
+        skills_dir,
+        "other",
+        "devops-helper",
+        {
+            "name": "devops-helper",
+            "category": "other",
+            "description": "Docker Kubernetes CI CD deploy infrastructure workflow.",
+            "tags": ["docker", "kubernetes", "ci", "cd"],
+        },
+    )
+
+    plan = planner.build_plan(skills_dir, min_score=2, min_delta=2)
+    changes = {item["path"]: item for item in plan["changes"]}
+
+    assert changes["docs/pdf-helper/SKILL.md"]["action"] == "taxonomy_deprecation"
+    assert changes["docs/pdf-helper/SKILL.md"]["proposed_category"] == "documents"
+    assert changes["other/devops-helper/SKILL.md"]["action"] == "heuristic_reclassify"
+    assert changes["other/devops-helper/SKILL.md"]["confidence"] == "high"
+    assert changes["other/devops-helper/SKILL.md"]["proposed_category"] == "devops"
+    assert plan["summary"]["planned_change_count"] == 2
+
+
+def test_plan_reports_alias_and_source_conflict(tmp_path):
+    planner = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "engineering",
+        "builder",
+        {
+            "name": "builder",
+            "category": "engineering",
+            "description": "Build framework compile debug helper.",
+        },
+    )
+    _write_skill(
+        skills_dir,
+        "development",
+        "conflicted",
+        {
+            "name": "conflicted",
+            "category": "development",
+            "description": "Product roadmap PRD backlog helper.",
+        },
+        "---\nname: conflicted\ncategory: product\n---\n\nProduct roadmap PRD backlog helper.",
+    )
+
+    plan = planner.build_plan(skills_dir, include_frontmatter=True)
+    changes = {item["path"]: item for item in plan["changes"]}
+
+    assert changes["engineering/builder/SKILL.md"]["action"] == "normalize_alias"
+    assert changes["engineering/builder/SKILL.md"]["proposed_category"] == "development"
+    assert changes["development/conflicted/SKILL.md"]["action"] == "resolve_source_conflict"
+    assert changes["development/conflicted/SKILL.md"]["review_required"] is True


### PR DESCRIPTION
## Summary
- add taxonomy v2 governance metadata (`status`, `parent`, `migrate_to`, descriptions) and parser validation
- add a review-only category migration plan generator with action/confidence/reason/source fields
- add taxonomy governance and category artifact guards, including publish checks that keep legacy category JSON pointer-only
- document the taxonomy v2 operating spec

Closes #88

## Real data migration-plan snapshot
Generated against the normalized data archive at `/tmp/claude-skill-registry-data-layout`:
- total skills: 229,302
- standard layout skills: 229,302
- planned changes: 6,776
- actions: heuristic_reclassify 6,762; normalize_alias 3; taxonomy_deprecation 11
- confidence: high 230; medium 1,063; low 5,483

## Verification
- python scripts/check_taxonomy_governance.py --output-json /tmp/taxonomy-governance-report.json => 0 errors, 0 warnings
- python scripts/plan_category_migration.py --skills-dir /tmp/claude-skill-registry-data-layout --output /tmp/category-migration-plan-v2.json --limit 8
- python -m ruff check scripts/category_taxonomy.py scripts/check_taxonomy_governance.py scripts/plan_category_migration.py scripts/check_category_artifacts.py tests/test_category_taxonomy.py tests/test_check_taxonomy_governance.py tests/test_plan_category_migration.py tests/test_check_category_artifacts.py tests/test_pipeline_contracts.py
- git diff --check
- python -m pytest -q tests/test_category_taxonomy.py tests/test_check_taxonomy_governance.py tests/test_plan_category_migration.py tests/test_check_category_artifacts.py tests/test_pipeline_contracts.py
- python -m pytest -q
