### PR TITLE
Add review-only MIMO category classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,11 @@ For semantic reclassification, generate a review-only migration plan with
 `python scripts/plan_category_migration.py --skills-dir skills --output category-migration-plan.json`.
 The plan records action, confidence, source categories, target category, keyword
 signals, and reason for every proposed change; it does not move files.
+For a bounded second-pass model review, set `MIMO_API_KEY` and run
+`python scripts/review_category_plan_with_llm.py --plan category-migration-plan.json --output category-llm-review.json`.
+The default endpoint is `https://token-plan-sgp.xiaomimimo.com/v1` with
+`mimo-v2.5-pro`, and the report remains review-only: it records model category,
+confidence, decision, parse status, and evidence without modifying the archive.
 
 Category counts are published in `categories/index.json`; full category payloads
 are available through `categories/<category>/manifest.json` and bounded

--- a/docs/plan/taxonomy-v2-governance-spec.md
+++ b/docs/plan/taxonomy-v2-governance-spec.md
@@ -86,6 +86,37 @@ The plan is review-only. A later apply tool must recompute collision-safe
 targets using the same deterministic directory rules as the existing archive
 normalizers.
 
+## LLM Review Contract
+
+`scripts/review_category_plan_with_llm.py` can run a bounded second-pass review
+against an existing migration plan. It is intentionally separate from
+`plan_category_migration.py` so deterministic planning remains reproducible and
+offline.
+
+Defaults:
+
+- OpenAI-compatible endpoint: `https://token-plan-sgp.xiaomimimo.com/v1`.
+- Model: `mimo-v2.5-pro`.
+- API key source: `MIMO_API_KEY`.
+- Candidate actions: `heuristic_reclassify` and `resolve_source_conflict`.
+- Selection order: `risky-first`, reviewing `low`, then `medium`, then `high`.
+- Apply mode: `review-only`.
+
+The review report contains:
+
+- `schema_version`, `generated_at`, `source_plan`, `model`, `base_url`,
+  `policy`, `summary`, `reviews`, and `notes`.
+- Per review: candidate path/name/action, current category, heuristic proposed
+  category, model proposed category, model confidence, decision, parse status,
+  reason, and evidence.
+- `decision`: `agree`, `override`, or `uncertain`.
+- `parse_status`: `ok`, `invalid_json`, `unknown_category`,
+  `invalid_confidence`, or `api_error`.
+
+Secrets must not be written to files or committed. The report records the
+environment variable name, never the API key value. API errors are represented
+as `uncertain` review rows so failed model calls are visible in the audit trail.
+
 ## Confidence Rules
 
 - `high`: declared taxonomy deprecation, or heuristic score at least 4 with a

--- a/scripts/review_category_plan_with_llm.py
+++ b/scripts/review_category_plan_with_llm.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""Review category migration candidates with an OpenAI-compatible chat model."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from category_taxonomy import CategoryTaxonomy, get_taxonomy
+
+DEFAULT_BASE_URL = "https://token-plan-sgp.xiaomimimo.com/v1"
+DEFAULT_MODEL = "mimo-v2.5-pro"
+DEFAULT_API_KEY_ENV = "MIMO_API_KEY"
+DEFAULT_ACTIONS = ("heuristic_reclassify", "resolve_source_conflict")
+CONFIDENCE_PRIORITY = {"low": 0, "medium": 1, "high": 2}
+
+
+class ChatClient(Protocol):
+    def complete(self, messages: list[dict[str, str]]) -> str:
+        """Return assistant message content for the supplied chat messages."""
+
+
+class LLMReviewError(RuntimeError):
+    """Raised when the chat API request cannot produce a response."""
+
+
+@dataclass(frozen=True)
+class OpenAICompatibleClient:
+    api_key: str
+    base_url: str = DEFAULT_BASE_URL
+    model: str = DEFAULT_MODEL
+    timeout: int = 60
+    max_completion_tokens: int = 512
+    temperature: float = 0.0
+
+    def complete(self, messages: list[dict[str, str]]) -> str:
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "max_completion_tokens": self.max_completion_tokens,
+            "temperature": self.temperature,
+            "stream": False,
+        }
+        request = Request(
+            f"{self.base_url.rstrip('/')}/chat/completions",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        try:
+            with urlopen(request, timeout=self.timeout) as response:
+                response_payload = json.loads(response.read().decode("utf-8"))
+        except HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")[:1000]
+            raise LLMReviewError(f"chat API returned HTTP {exc.code}: {body}") from exc
+        except (OSError, URLError, json.JSONDecodeError) as exc:
+            raise LLMReviewError(f"chat API request failed: {exc}") from exc
+
+        choices = response_payload.get("choices")
+        if not isinstance(choices, list) or not choices:
+            raise LLMReviewError("chat API response did not include choices")
+        message = choices[0].get("message") if isinstance(choices[0], dict) else None
+        content = message.get("content") if isinstance(message, dict) else None
+        if not isinstance(content, str):
+            raise LLMReviewError("chat API response did not include message content")
+        return content.strip()
+
+
+def active_category_payload(taxonomy: CategoryTaxonomy) -> list[dict[str, str]]:
+    return [
+        {
+            "slug": definition.slug,
+            "display_name": definition.display_name,
+            "status": definition.status,
+            "description": definition.description,
+        }
+        for definition in sorted(taxonomy.categories.values(), key=lambda item: item.slug)
+        if definition.status != "deprecated"
+    ]
+
+
+def select_changes(
+    plan: dict[str, Any],
+    *,
+    actions: set[str],
+    confidences: set[str],
+    limit: int | None,
+    priority: str,
+) -> list[dict[str, Any]]:
+    changes = [
+        change
+        for change in plan.get("changes", [])
+        if isinstance(change, dict)
+        and (not actions or str(change.get("action", "")) in actions)
+        and (not confidences or str(change.get("confidence", "")) in confidences)
+    ]
+    if priority == "risky-first":
+        changes.sort(
+            key=lambda change: (
+                CONFIDENCE_PRIORITY.get(str(change.get("confidence", "")), 9),
+                str(change.get("action", "")),
+                str(change.get("path", "")),
+            )
+        )
+    if limit is None:
+        return changes
+    return changes[: max(limit, 0)]
+
+
+def build_messages(
+    change: dict[str, Any],
+    *,
+    categories: list[dict[str, str]],
+) -> list[dict[str, str]]:
+    candidate = {
+        "path": change.get("path", ""),
+        "name": change.get("name", ""),
+        "action": change.get("action", ""),
+        "current_category": change.get("current_category", ""),
+        "heuristic_proposed_category": change.get("proposed_category", ""),
+        "raw_sources": change.get("raw_sources", {}),
+        "resolved_sources": change.get("resolved_sources", {}),
+        "signals": change.get("signals", []),
+        "heuristic_reason": change.get("reason", ""),
+        "score": change.get("score"),
+        "current_score": change.get("current_score"),
+    }
+    system_prompt = (
+        "You are auditing a skill registry taxonomy migration. "
+        "Choose exactly one category slug from allowed_categories. "
+        "Return only valid compact JSON with keys: category, confidence, reason, evidence. "
+        "confidence must be a number from 0 to 1. evidence must be a short array of strings. "
+        "Do not include markdown, prose outside JSON, or hidden reasoning."
+    )
+    user_payload = {
+        "allowed_categories": categories,
+        "candidate": candidate,
+    }
+    return [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": json.dumps(user_payload, ensure_ascii=False)},
+    ]
+
+
+def parse_json_content(content: str) -> tuple[dict[str, Any] | None, str]:
+    stripped = content.strip()
+    if stripped.startswith("```"):
+        lines = stripped.splitlines()
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        stripped = "\n".join(lines).strip()
+    try:
+        payload = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None, "invalid_json"
+    if not isinstance(payload, dict):
+        return None, "invalid_json"
+    return payload, "ok"
+
+
+def normalized_confidence(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        confidence = float(value)
+        if 0.0 <= confidence <= 1.0:
+            return confidence
+    return None
+
+
+def decide_review(
+    *,
+    current_proposed: str,
+    llm_category: str,
+    llm_confidence: float | None,
+    parse_status: str,
+    override_confidence: float,
+) -> str:
+    if parse_status != "ok" or llm_confidence is None:
+        return "uncertain"
+    if llm_category == current_proposed:
+        return "agree"
+    if llm_confidence >= override_confidence:
+        return "override"
+    return "uncertain"
+
+
+def build_review_entry(
+    change: dict[str, Any],
+    *,
+    content: str,
+    taxonomy: CategoryTaxonomy,
+    override_confidence: float,
+    include_raw: bool,
+) -> dict[str, Any]:
+    parsed, parse_status = parse_json_content(content)
+    raw_category = parsed.get("category") if parsed else ""
+    llm_category = taxonomy.resolve(str(raw_category), allow_unknown=True) if raw_category else ""
+    allowed_category = llm_category in taxonomy.categories and (
+        taxonomy.categories[llm_category].status != "deprecated"
+    )
+    llm_confidence = normalized_confidence(parsed.get("confidence") if parsed else None)
+    if parse_status == "ok" and not allowed_category:
+        parse_status = "unknown_category"
+    if parse_status == "ok" and llm_confidence is None:
+        parse_status = "invalid_confidence"
+
+    decision = decide_review(
+        current_proposed=str(change.get("proposed_category", "")),
+        llm_category=llm_category,
+        llm_confidence=llm_confidence,
+        parse_status=parse_status,
+        override_confidence=override_confidence,
+    )
+    entry = {
+        "path": change.get("path", ""),
+        "name": change.get("name", ""),
+        "action": change.get("action", ""),
+        "current_category": change.get("current_category", ""),
+        "heuristic_proposed_category": change.get("proposed_category", ""),
+        "llm_proposed_category": llm_category,
+        "llm_confidence": llm_confidence,
+        "decision": decision,
+        "parse_status": parse_status,
+        "review_required": True,
+        "reason": parsed.get("reason", "") if parsed else "",
+        "evidence": parsed.get("evidence", []) if parsed else [],
+    }
+    if include_raw:
+        entry["raw_response"] = content
+    return entry
+
+
+def build_error_entry(change: dict[str, Any], error: Exception) -> dict[str, Any]:
+    return {
+        "path": change.get("path", ""),
+        "name": change.get("name", ""),
+        "action": change.get("action", ""),
+        "current_category": change.get("current_category", ""),
+        "heuristic_proposed_category": change.get("proposed_category", ""),
+        "llm_proposed_category": "",
+        "llm_confidence": None,
+        "decision": "uncertain",
+        "parse_status": "api_error",
+        "review_required": True,
+        "reason": str(error),
+        "evidence": [],
+    }
+
+
+def build_review_report(
+    plan: dict[str, Any],
+    *,
+    client: ChatClient,
+    model: str,
+    base_url: str,
+    api_key_env: str,
+    actions: set[str] | None = None,
+    confidences: set[str] | None = None,
+    limit: int | None = 25,
+    priority: str = "risky-first",
+    sleep_seconds: float = 0.0,
+    override_confidence: float = 0.8,
+    include_raw: bool = False,
+    source_plan: str = "",
+) -> dict[str, Any]:
+    taxonomy = get_taxonomy()
+    categories = active_category_payload(taxonomy)
+    selected_changes = select_changes(
+        plan,
+        actions=actions or set(DEFAULT_ACTIONS),
+        confidences=confidences or set(),
+        limit=limit,
+        priority=priority,
+    )
+    reviews: list[dict[str, Any]] = []
+    for index, change in enumerate(selected_changes):
+        if index and sleep_seconds > 0:
+            time.sleep(sleep_seconds)
+        messages = build_messages(change, categories=categories)
+        try:
+            content = client.complete(messages)
+            reviews.append(
+                build_review_entry(
+                    change,
+                    content=content,
+                    taxonomy=taxonomy,
+                    override_confidence=override_confidence,
+                    include_raw=include_raw,
+                )
+            )
+        except LLMReviewError as exc:
+            reviews.append(build_error_entry(change, exc))
+
+    decision_counts = Counter(review["decision"] for review in reviews)
+    parse_status_counts = Counter(review["parse_status"] for review in reviews)
+    category_pairs = Counter(
+        (review["heuristic_proposed_category"], review["llm_proposed_category"])
+        for review in reviews
+    )
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "source_plan": source_plan,
+        "model": model,
+        "base_url": base_url,
+        "policy": {
+            "actions": sorted(actions or set(DEFAULT_ACTIONS)),
+            "confidences": sorted(confidences or []),
+            "limit": limit,
+            "priority": priority,
+            "sleep_seconds": sleep_seconds,
+            "override_confidence": override_confidence,
+            "api_key_env": api_key_env,
+            "apply_mode": "review-only",
+        },
+        "summary": {
+            "candidate_count": len(selected_changes),
+            "reviewed_count": len(reviews),
+            "decision_counts": dict(sorted(decision_counts.items())),
+            "parse_status_counts": dict(sorted(parse_status_counts.items())),
+            "category_pair_counts": [
+                {
+                    "heuristic_proposed_category": heuristic,
+                    "llm_proposed_category": llm,
+                    "count": count,
+                }
+                for (heuristic, llm), count in sorted(
+                    category_pairs.items(),
+                    key=lambda item: (-item[1], item[0][0], item[0][1]),
+                )
+            ],
+        },
+        "reviews": reviews,
+        "notes": [
+            "This report does not modify files.",
+            f"API credentials are read from {api_key_env} and are not written to the report.",
+            "LLM recommendations require human review before any archive migration is applied.",
+        ],
+    }
+
+
+def print_text_report(report: dict[str, Any], *, limit: int) -> None:
+    summary = report["summary"]
+    print("LLM category review")
+    print(f"Candidates: {summary['candidate_count']}")
+    print(f"Reviewed: {summary['reviewed_count']}")
+    print(f"Decisions: {summary['decision_counts']}")
+    print(f"Parse status: {summary['parse_status_counts']}")
+    for review in report["reviews"][:limit]:
+        print(
+            f"- {review['decision']} {review['path']}: "
+            f"{review['heuristic_proposed_category']} -> "
+            f"{review['llm_proposed_category']} ({review['parse_status']})"
+        )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--plan", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    parser.add_argument("--api-key-env", default=DEFAULT_API_KEY_ENV)
+    parser.add_argument("--timeout", type=int, default=60)
+    parser.add_argument("--max-completion-tokens", type=int, default=512)
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--limit", type=int, default=25)
+    parser.add_argument("--action", action="append")
+    parser.add_argument("--confidence", action="append")
+    parser.add_argument("--priority", choices=["risky-first", "plan"], default="risky-first")
+    parser.add_argument("--sleep-seconds", type=float, default=0.0)
+    parser.add_argument("--override-confidence", type=float, default=0.8)
+    parser.add_argument("--include-raw", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--print-limit", type=int, default=20)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    api_key = os.environ.get(args.api_key_env)
+    if not api_key:
+        raise SystemExit(f"Missing API key environment variable: {args.api_key_env}")
+    if not args.plan.exists():
+        raise SystemExit(f"Category migration plan not found: {args.plan}")
+
+    plan = json.loads(args.plan.read_text(encoding="utf-8"))
+    if not isinstance(plan, dict):
+        raise SystemExit("Category migration plan must contain a JSON object")
+
+    client = OpenAICompatibleClient(
+        api_key=api_key,
+        base_url=args.base_url,
+        model=args.model,
+        timeout=args.timeout,
+        max_completion_tokens=args.max_completion_tokens,
+        temperature=args.temperature,
+    )
+    report = build_review_report(
+        plan,
+        client=client,
+        model=args.model,
+        base_url=args.base_url,
+        api_key_env=args.api_key_env,
+        actions=set(args.action or DEFAULT_ACTIONS),
+        confidences=set(args.confidence or []),
+        limit=args.limit,
+        priority=args.priority,
+        sleep_seconds=args.sleep_seconds,
+        override_confidence=args.override_confidence,
+        include_raw=args.include_raw,
+        source_plan=str(args.plan),
+    )
+    payload = json.dumps(report, indent=2, ensure_ascii=False)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload + "\n", encoding="utf-8")
+    if args.json:
+        print(payload)
+    else:
+        print_text_report(report, limit=args.print_limit)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_review_category_plan_with_llm.py
+++ b/tests/test_review_category_plan_with_llm.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from urllib.error import HTTPError
+
+import pytest
+
+
+def _load_module():
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    return importlib.import_module("review_category_plan_with_llm")
+
+
+class FakeClient:
+    def __init__(self, responses: list[str | Exception]):
+        self.responses = responses
+        self.messages: list[list[dict[str, str]]] = []
+
+    def complete(self, messages: list[dict[str, str]]) -> str:
+        self.messages.append(messages)
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+class FakeResponse:
+    def __init__(self, payload: dict):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+
+class FakeErrorBody:
+    def read(self) -> bytes:
+        return b'{"error":{"message":"bad request"}}'
+
+    def close(self) -> None:
+        return None
+
+
+def _change(
+    path: str,
+    *,
+    confidence: str,
+    proposed_category: str,
+    action: str = "heuristic_reclassify",
+) -> dict:
+    return {
+        "path": path,
+        "name": path.split("/")[-2],
+        "action": action,
+        "confidence": confidence,
+        "current_category": "other",
+        "proposed_category": proposed_category,
+        "raw_sources": {"directory": "other"},
+        "resolved_sources": {"directory": "other"},
+        "signals": ["video"],
+        "reason": "keyword match",
+        "score": 4,
+        "current_score": 0,
+    }
+
+
+def test_review_report_records_agree_override_and_uncertain():
+    reviewer = _load_module()
+    plan = {
+        "changes": [
+            _change("other/high/SKILL.md", confidence="high", proposed_category="devops"),
+            _change("other/low/SKILL.md", confidence="low", proposed_category="data"),
+            _change("other/medium/SKILL.md", confidence="medium", proposed_category="marketing"),
+        ]
+    }
+    client = FakeClient(
+        [
+            '{"category":"documents","confidence":0.91,"reason":"doc workflow","evidence":["pdf"]}',
+            '{"category":"marketing","confidence":0.99,"reason":"campaign copy","evidence":["seo"]}',
+            '{"category":"not-a-category","confidence":0.95,"reason":"bad","evidence":[]}',
+        ]
+    )
+
+    report = reviewer.build_review_report(
+        plan,
+        client=client,
+        model="mimo-v2.5-pro",
+        base_url="https://token-plan-sgp.xiaomimimo.com/v1",
+        api_key_env="MIMO_API_KEY",
+        limit=3,
+    )
+
+    assert [review["path"] for review in report["reviews"]] == [
+        "other/low/SKILL.md",
+        "other/medium/SKILL.md",
+        "other/high/SKILL.md",
+    ]
+    assert report["reviews"][0]["decision"] == "override"
+    assert report["reviews"][0]["llm_proposed_category"] == "documents"
+    assert report["reviews"][1]["decision"] == "agree"
+    assert report["reviews"][2]["decision"] == "uncertain"
+    assert report["reviews"][2]["parse_status"] == "unknown_category"
+    assert report["summary"]["decision_counts"] == {
+        "agree": 1,
+        "override": 1,
+        "uncertain": 1,
+    }
+    assert report["policy"]["apply_mode"] == "review-only"
+    assert "MIMO_API_KEY" in report["notes"][1]
+
+
+def test_openai_compatible_client_posts_chat_completion(monkeypatch):
+    reviewer = _load_module()
+    captured = {}
+
+    def fake_urlopen(request, timeout):
+        captured["url"] = request.full_url
+        captured["timeout"] = timeout
+        captured["headers"] = dict(request.header_items())
+        captured["payload"] = json.loads(request.data.decode("utf-8"))
+        return FakeResponse(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": '{"category":"data","confidence":0.8,"reason":"etl","evidence":[]}'
+                        }
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setattr(reviewer, "urlopen", fake_urlopen)
+    client = reviewer.OpenAICompatibleClient(
+        api_key="secret",
+        base_url="https://example.test/v1/",
+        model="m",
+        timeout=7,
+        max_completion_tokens=123,
+    )
+
+    content = client.complete([{"role": "user", "content": "hello"}])
+
+    assert content == '{"category":"data","confidence":0.8,"reason":"etl","evidence":[]}'
+    assert captured["url"] == "https://example.test/v1/chat/completions"
+    assert captured["timeout"] == 7
+    assert captured["headers"]["Authorization"] == "Bearer secret"
+    assert captured["payload"]["model"] == "m"
+    assert captured["payload"]["max_completion_tokens"] == 123
+    assert captured["payload"]["stream"] is False
+
+
+def test_openai_compatible_client_reports_api_shape_errors(monkeypatch):
+    reviewer = _load_module()
+    monkeypatch.setattr(reviewer, "urlopen", lambda request, timeout: FakeResponse({"choices": []}))
+    client = reviewer.OpenAICompatibleClient(api_key="secret")
+
+    with pytest.raises(reviewer.LLMReviewError, match="did not include choices"):
+        client.complete([{"role": "user", "content": "hello"}])
+
+
+def test_openai_compatible_client_reports_http_errors(monkeypatch):
+    reviewer = _load_module()
+
+    def fake_urlopen(request, timeout):
+        raise HTTPError(
+            request.full_url,
+            401,
+            "Unauthorized",
+            hdrs=None,
+            fp=FakeErrorBody(),
+        )
+
+    monkeypatch.setattr(reviewer, "urlopen", fake_urlopen)
+    client = reviewer.OpenAICompatibleClient(api_key="secret")
+
+    with pytest.raises(reviewer.LLMReviewError, match="HTTP 401"):
+        client.complete([{"role": "user", "content": "hello"}])
+
+
+def test_review_report_filters_actions_and_confidences():
+    reviewer = _load_module()
+    plan = {
+        "changes": [
+            _change("other/a/SKILL.md", confidence="high", proposed_category="devops"),
+            _change(
+                "other/b/SKILL.md",
+                confidence="low",
+                proposed_category="data",
+                action="resolve_source_conflict",
+            ),
+            _change("other/c/SKILL.md", confidence="low", proposed_category="security"),
+        ]
+    }
+    client = FakeClient(
+        ['{"category":"security","confidence":0.7,"reason":"audit","evidence":["scan"]}']
+    )
+
+    report = reviewer.build_review_report(
+        plan,
+        client=client,
+        model="m",
+        base_url="u",
+        api_key_env="KEY",
+        actions={"heuristic_reclassify"},
+        confidences={"low"},
+        limit=10,
+    )
+
+    assert len(client.messages) == 1
+    assert report["reviews"][0]["path"] == "other/c/SKILL.md"
+    assert report["reviews"][0]["decision"] == "agree"
+    prompt_payload = json.loads(client.messages[0][1]["content"])
+    assert prompt_payload["candidate"]["path"] == "other/c/SKILL.md"
+    assert {item["slug"] for item in prompt_payload["allowed_categories"]} >= {
+        "security",
+        "data",
+    }
+    assert "docs" not in {item["slug"] for item in prompt_payload["allowed_categories"]}
+
+
+def test_review_report_can_preserve_plan_order_sleep_and_raw(monkeypatch):
+    reviewer = _load_module()
+    plan = {
+        "changes": [
+            _change("other/high/SKILL.md", confidence="high", proposed_category="data"),
+            _change("other/low/SKILL.md", confidence="low", proposed_category="data"),
+        ]
+    }
+    client = FakeClient(
+        [
+            '{"category":"data","confidence":0.5,"reason":"match","evidence":[]}',
+            '{"category":"data","confidence":0.5,"reason":"match","evidence":[]}',
+        ]
+    )
+    sleeps = []
+    monkeypatch.setattr(reviewer.time, "sleep", sleeps.append)
+
+    report = reviewer.build_review_report(
+        plan,
+        client=client,
+        model="m",
+        base_url="u",
+        api_key_env="KEY",
+        limit=None,
+        priority="plan",
+        sleep_seconds=0.25,
+        include_raw=True,
+    )
+
+    assert [review["path"] for review in report["reviews"]] == [
+        "other/high/SKILL.md",
+        "other/low/SKILL.md",
+    ]
+    assert sleeps == [0.25]
+    assert report["reviews"][0]["raw_response"].startswith('{"category":"data"')
+
+
+def test_review_report_marks_api_error_without_raising():
+    reviewer = _load_module()
+    client = FakeClient([reviewer.LLMReviewError("temporary outage")])
+
+    report = reviewer.build_review_report(
+        {"changes": [_change("other/a/SKILL.md", confidence="low", proposed_category="data")]},
+        client=client,
+        model="m",
+        base_url="u",
+        api_key_env="KEY",
+    )
+
+    assert report["reviews"][0]["decision"] == "uncertain"
+    assert report["reviews"][0]["parse_status"] == "api_error"
+    assert "temporary outage" in report["reviews"][0]["reason"]
+
+
+def test_parse_json_content_accepts_markdown_fence_and_rejects_non_objects():
+    reviewer = _load_module()
+
+    payload, status = reviewer.parse_json_content(
+        '```json\n{"category":"data","confidence":0.8,"reason":"etl","evidence":["csv"]}\n```'
+    )
+
+    assert status == "ok"
+    assert payload == {
+        "category": "data",
+        "confidence": 0.8,
+        "reason": "etl",
+        "evidence": ["csv"],
+    }
+    assert reviewer.parse_json_content("not-json") == (None, "invalid_json")
+    assert reviewer.parse_json_content("[1, 2, 3]") == (None, "invalid_json")
+    assert reviewer.normalized_confidence(True) is None
+    assert reviewer.normalized_confidence(1.5) is None
+
+
+def test_main_requires_api_key(monkeypatch, tmp_path):
+    reviewer = _load_module()
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text('{"changes":[]}', encoding="utf-8")
+    monkeypatch.delenv("MIMO_API_KEY", raising=False)
+
+    with pytest.raises(SystemExit, match="Missing API key environment variable"):
+        reviewer.main(["--plan", str(plan_path)])
+
+
+def test_main_writes_json_report(monkeypatch, tmp_path, capsys):
+    reviewer = _load_module()
+    plan_path = tmp_path / "plan.json"
+    output_path = tmp_path / "review.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "changes": [
+                    _change("other/a/SKILL.md", confidence="low", proposed_category="data")
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class FakeOpenAICompatibleClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def complete(self, messages):
+            return '{"category":"data","confidence":0.9,"reason":"etl","evidence":["csv"]}'
+
+    monkeypatch.setenv("MIMO_API_KEY", "secret")
+    monkeypatch.setattr(reviewer, "OpenAICompatibleClient", FakeOpenAICompatibleClient)
+
+    assert (
+        reviewer.main(
+            [
+                "--plan",
+                str(plan_path),
+                "--output",
+                str(output_path),
+                "--json",
+                "--limit",
+                "1",
+            ]
+        )
+        == 0
+    )
+    stdout = capsys.readouterr().out
+    output = json.loads(output_path.read_text(encoding="utf-8"))
+    assert json.loads(stdout)["summary"]["reviewed_count"] == 1
+    assert output["reviews"][0]["decision"] == "agree"


### PR DESCRIPTION
## Summary
- Add a review-only OpenAI-compatible classifier for category migration plans.
- Default the classifier to the Xiaomi MiMo token-plan endpoint and mimo-v2.5-pro.
- Document the LLM review contract and add mocked tests for API, parsing, filtering, and CLI output.

## Safety
- Credentials are read only from MIMO_API_KEY or a caller-selected environment variable.
- Reports record the environment variable name, never the API key value.
- Model output cannot mutate archive files; it only writes an audit report.

## Verification
- python -m pytest -q
- python scripts/check_taxonomy_governance.py
- python -m ruff check scripts/review_category_plan_with_llm.py tests/test_review_category_plan_with_llm.py
- git diff --check

Closes #90