### PR TITLE
Add resumable LLM category review checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,10 +206,12 @@ For semantic reclassification, generate a review-only migration plan with
 The plan records action, confidence, source categories, target category, keyword
 signals, and reason for every proposed change; it does not move files.
 For a bounded second-pass model review, set `MIMO_API_KEY` and run
-`python scripts/review_category_plan_with_llm.py --plan category-migration-plan.json --output category-llm-review.json`.
+`python scripts/review_category_plan_with_llm.py --plan category-migration-plan.json --output category-llm-review.json --checkpoint-jsonl category-llm-review.checkpoint.jsonl --resume`.
 The default endpoint is `https://token-plan-sgp.xiaomimimo.com/v1` with
 `mimo-v2.5-pro`, and the report remains review-only: it records model category,
 confidence, decision, parse status, and evidence without modifying the archive.
+The checkpoint file is append-only JSONL, so interrupted long reviews can resume
+without re-calling the model for completed candidates.
 
 Category counts are published in `categories/index.json`; full category payloads
 are available through `categories/<category>/manifest.json` and bounded

--- a/docs/plan/taxonomy-v2-governance-spec.md
+++ b/docs/plan/taxonomy-v2-governance-spec.md
@@ -100,6 +100,8 @@ Defaults:
 - API key source: `MIMO_API_KEY`.
 - Candidate actions: `heuristic_reclassify` and `resolve_source_conflict`.
 - Selection order: `risky-first`, reviewing `low`, then `medium`, then `high`.
+- Optional checkpoint: `--checkpoint-jsonl <path>` appends one JSONL row per
+  completed review and `--resume` skips matching completed `review_key` values.
 - Apply mode: `review-only`.
 
 The review report contains:
@@ -108,7 +110,7 @@ The review report contains:
   `policy`, `summary`, `reviews`, and `notes`.
 - Per review: candidate path/name/action, current category, heuristic proposed
   category, model proposed category, model confidence, decision, parse status,
-  reason, and evidence.
+  reason, evidence, and a stable `review_key`.
 - `decision`: `agree`, `override`, or `uncertain`.
 - `parse_status`: `ok`, `invalid_json`, `unknown_category`,
   `invalid_confidence`, or `api_error`.
@@ -116,6 +118,8 @@ The review report contains:
 Secrets must not be written to files or committed. The report records the
 environment variable name, never the API key value. API errors are represented
 as `uncertain` review rows so failed model calls are visible in the audit trail.
+Checkpoint rows are append-only audit records. Malformed checkpoint lines are
+ignored for resume and counted in `malformed_checkpoint_row_count`.
 
 ## Confidence Rules
 

--- a/scripts/review_category_plan_with_llm.py
+++ b/scripts/review_category_plan_with_llm.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import time
@@ -22,6 +23,7 @@ DEFAULT_MODEL = "mimo-v2.5-pro"
 DEFAULT_API_KEY_ENV = "MIMO_API_KEY"
 DEFAULT_ACTIONS = ("heuristic_reclassify", "resolve_source_conflict")
 CONFIDENCE_PRIORITY = {"low": 0, "medium": 1, "high": 2}
+CHECKPOINT_SCHEMA_VERSION = 1
 
 
 class ChatClient(Protocol):
@@ -119,6 +121,29 @@ def select_changes(
     return changes[: max(limit, 0)]
 
 
+def candidate_review_key(change: dict[str, Any]) -> str:
+    payload = {
+        "path": change.get("path", ""),
+        "name": change.get("name", ""),
+        "action": change.get("action", ""),
+        "current_category": change.get("current_category", ""),
+        "proposed_category": change.get("proposed_category", ""),
+        "raw_sources": change.get("raw_sources", {}),
+        "resolved_sources": change.get("resolved_sources", {}),
+        "signals": change.get("signals", []),
+        "reason": change.get("reason", ""),
+        "score": change.get("score"),
+        "current_score": change.get("current_score"),
+    }
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
 def build_messages(
     change: dict[str, Any],
     *,
@@ -206,6 +231,7 @@ def build_review_entry(
     taxonomy: CategoryTaxonomy,
     override_confidence: float,
     include_raw: bool,
+    review_key: str,
 ) -> dict[str, Any]:
     parsed, parse_status = parse_json_content(content)
     raw_category = parsed.get("category") if parsed else ""
@@ -227,6 +253,8 @@ def build_review_entry(
         override_confidence=override_confidence,
     )
     entry = {
+        "checkpoint_schema_version": CHECKPOINT_SCHEMA_VERSION,
+        "review_key": review_key,
         "path": change.get("path", ""),
         "name": change.get("name", ""),
         "action": change.get("action", ""),
@@ -245,8 +273,10 @@ def build_review_entry(
     return entry
 
 
-def build_error_entry(change: dict[str, Any], error: Exception) -> dict[str, Any]:
+def build_error_entry(change: dict[str, Any], error: Exception, *, review_key: str) -> dict[str, Any]:
     return {
+        "checkpoint_schema_version": CHECKPOINT_SCHEMA_VERSION,
+        "review_key": review_key,
         "path": change.get("path", ""),
         "name": change.get("name", ""),
         "action": change.get("action", ""),
@@ -260,6 +290,38 @@ def build_error_entry(change: dict[str, Any], error: Exception) -> dict[str, Any
         "reason": str(error),
         "evidence": [],
     }
+
+
+def load_checkpoint_reviews(checkpoint_path: Path | None) -> tuple[dict[str, dict[str, Any]], int]:
+    if checkpoint_path is None or not checkpoint_path.exists():
+        return {}, 0
+
+    reviews: dict[str, dict[str, Any]] = {}
+    malformed_row_count = 0
+    for line in checkpoint_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            malformed_row_count += 1
+            continue
+        if not isinstance(payload, dict):
+            malformed_row_count += 1
+            continue
+        review_key = payload.get("review_key")
+        if not isinstance(review_key, str) or not review_key:
+            malformed_row_count += 1
+            continue
+        reviews[review_key] = payload
+    return reviews, malformed_row_count
+
+
+def append_checkpoint_review(checkpoint_path: Path, review: dict[str, Any]) -> None:
+    checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+    with checkpoint_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(review, ensure_ascii=False, sort_keys=True) + "\n")
+        handle.flush()
 
 
 def build_review_report(
@@ -277,6 +339,8 @@ def build_review_report(
     override_confidence: float = 0.8,
     include_raw: bool = False,
     source_plan: str = "",
+    checkpoint_path: Path | None = None,
+    resume: bool = False,
 ) -> dict[str, Any]:
     taxonomy = get_taxonomy()
     categories = active_category_payload(taxonomy)
@@ -287,24 +351,40 @@ def build_review_report(
         limit=limit,
         priority=priority,
     )
+    checkpoint_reviews, malformed_checkpoint_rows = load_checkpoint_reviews(
+        checkpoint_path if resume else None
+    )
     reviews: list[dict[str, Any]] = []
-    for index, change in enumerate(selected_changes):
-        if index and sleep_seconds > 0:
+    skipped_checkpoint_count = 0
+    new_review_count = 0
+    for change in selected_changes:
+        review_key = candidate_review_key(change)
+        checkpoint_review = checkpoint_reviews.get(review_key)
+        if checkpoint_review:
+            reviews.append(checkpoint_review)
+            skipped_checkpoint_count += 1
+            continue
+
+        if new_review_count and sleep_seconds > 0:
             time.sleep(sleep_seconds)
         messages = build_messages(change, categories=categories)
         try:
             content = client.complete(messages)
-            reviews.append(
-                build_review_entry(
-                    change,
-                    content=content,
-                    taxonomy=taxonomy,
-                    override_confidence=override_confidence,
-                    include_raw=include_raw,
-                )
+            review = build_review_entry(
+                change,
+                content=content,
+                taxonomy=taxonomy,
+                override_confidence=override_confidence,
+                include_raw=include_raw,
+                review_key=review_key,
             )
         except LLMReviewError as exc:
-            reviews.append(build_error_entry(change, exc))
+            review = build_error_entry(change, exc, review_key=review_key)
+
+        if checkpoint_path:
+            append_checkpoint_review(checkpoint_path, review)
+        reviews.append(review)
+        new_review_count += 1
 
     decision_counts = Counter(review["decision"] for review in reviews)
     parse_status_counts = Counter(review["parse_status"] for review in reviews)
@@ -326,11 +406,16 @@ def build_review_report(
             "sleep_seconds": sleep_seconds,
             "override_confidence": override_confidence,
             "api_key_env": api_key_env,
+            "checkpoint_jsonl": str(checkpoint_path) if checkpoint_path else "",
+            "resume": resume,
             "apply_mode": "review-only",
         },
         "summary": {
             "candidate_count": len(selected_changes),
             "reviewed_count": len(reviews),
+            "new_review_count": new_review_count,
+            "skipped_checkpoint_count": skipped_checkpoint_count,
+            "malformed_checkpoint_row_count": malformed_checkpoint_rows,
             "decision_counts": dict(sorted(decision_counts.items())),
             "parse_status_counts": dict(sorted(parse_status_counts.items())),
             "category_pair_counts": [
@@ -349,6 +434,7 @@ def build_review_report(
         "notes": [
             "This report does not modify files.",
             f"API credentials are read from {api_key_env} and are not written to the report.",
+            "Checkpoint JSONL rows are append-only review records keyed by review_key.",
             "LLM recommendations require human review before any archive migration is applied.",
         ],
     }
@@ -359,6 +445,8 @@ def print_text_report(report: dict[str, Any], *, limit: int) -> None:
     print("LLM category review")
     print(f"Candidates: {summary['candidate_count']}")
     print(f"Reviewed: {summary['reviewed_count']}")
+    print(f"New reviews: {summary['new_review_count']}")
+    print(f"Skipped from checkpoint: {summary['skipped_checkpoint_count']}")
     print(f"Decisions: {summary['decision_counts']}")
     print(f"Parse status: {summary['parse_status_counts']}")
     for review in report["reviews"][:limit]:
@@ -385,6 +473,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--priority", choices=["risky-first", "plan"], default="risky-first")
     parser.add_argument("--sleep-seconds", type=float, default=0.0)
     parser.add_argument("--override-confidence", type=float, default=0.8)
+    parser.add_argument("--checkpoint-jsonl", type=Path)
+    parser.add_argument("--resume", action="store_true")
     parser.add_argument("--include-raw", action="store_true")
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--print-limit", type=int, default=20)
@@ -398,6 +488,14 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit(f"Missing API key environment variable: {args.api_key_env}")
     if not args.plan.exists():
         raise SystemExit(f"Category migration plan not found: {args.plan}")
+    if args.resume and not args.checkpoint_jsonl:
+        raise SystemExit("--resume requires --checkpoint-jsonl")
+    if (
+        args.output
+        and args.checkpoint_jsonl
+        and args.output.resolve() == args.checkpoint_jsonl.resolve()
+    ):
+        raise SystemExit("--output and --checkpoint-jsonl must be different paths")
 
     plan = json.loads(args.plan.read_text(encoding="utf-8"))
     if not isinstance(plan, dict):
@@ -425,6 +523,8 @@ def main(argv: list[str] | None = None) -> int:
         override_confidence=args.override_confidence,
         include_raw=args.include_raw,
         source_plan=str(args.plan),
+        checkpoint_path=args.checkpoint_jsonl,
+        resume=args.resume,
     )
     payload = json.dumps(report, indent=2, ensure_ascii=False)
     if args.output:

--- a/tests/test_review_category_plan_with_llm.py
+++ b/tests/test_review_category_plan_with_llm.py
@@ -266,6 +266,117 @@ def test_review_report_can_preserve_plan_order_sleep_and_raw(monkeypatch):
     assert report["reviews"][0]["raw_response"].startswith('{"category":"data"')
 
 
+def test_candidate_review_key_changes_when_candidate_changes():
+    reviewer = _load_module()
+    first = _change("other/a/SKILL.md", confidence="low", proposed_category="data")
+    second = _change("other/a/SKILL.md", confidence="low", proposed_category="security")
+
+    assert reviewer.candidate_review_key(first) != reviewer.candidate_review_key(second)
+
+
+def test_review_report_writes_checkpoint_and_resume_skips_completed(tmp_path):
+    reviewer = _load_module()
+    checkpoint_path = tmp_path / "review.checkpoint.jsonl"
+    plan = {
+        "changes": [
+            _change("other/a/SKILL.md", confidence="low", proposed_category="data"),
+            _change("other/b/SKILL.md", confidence="medium", proposed_category="security"),
+        ]
+    }
+    client = FakeClient(
+        [
+            '{"category":"data","confidence":0.9,"reason":"etl","evidence":["csv"]}',
+            '{"category":"security","confidence":0.9,"reason":"audit","evidence":["scan"]}',
+        ]
+    )
+
+    report = reviewer.build_review_report(
+        plan,
+        client=client,
+        model="m",
+        base_url="u",
+        api_key_env="KEY",
+        limit=2,
+        checkpoint_path=checkpoint_path,
+    )
+
+    checkpoint_rows = [
+        json.loads(line) for line in checkpoint_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(client.messages) == 2
+    assert len(checkpoint_rows) == 2
+    assert {row["review_key"] for row in checkpoint_rows} == {
+        review["review_key"] for review in report["reviews"]
+    }
+    assert report["summary"]["new_review_count"] == 2
+    assert report["summary"]["skipped_checkpoint_count"] == 0
+
+    resume_client = FakeClient([])
+    resumed = reviewer.build_review_report(
+        plan,
+        client=resume_client,
+        model="m",
+        base_url="u",
+        api_key_env="KEY",
+        limit=2,
+        checkpoint_path=checkpoint_path,
+        resume=True,
+    )
+
+    assert resume_client.messages == []
+    assert [review["path"] for review in resumed["reviews"]] == [
+        "other/a/SKILL.md",
+        "other/b/SKILL.md",
+    ]
+    assert resumed["summary"]["new_review_count"] == 0
+    assert resumed["summary"]["skipped_checkpoint_count"] == 2
+    assert checkpoint_path.read_text(encoding="utf-8").count("\n") == 2
+
+
+def test_resume_ignores_malformed_checkpoint_rows(tmp_path):
+    reviewer = _load_module()
+    change = _change("other/a/SKILL.md", confidence="low", proposed_category="data")
+    review_key = reviewer.candidate_review_key(change)
+    checkpoint_path = tmp_path / "review.checkpoint.jsonl"
+    checkpoint_path.write_text(
+        "not-json\n"
+        + json.dumps(
+            {
+                "review_key": review_key,
+                "path": "other/a/SKILL.md",
+                "name": "a",
+                "action": "heuristic_reclassify",
+                "current_category": "other",
+                "heuristic_proposed_category": "data",
+                "llm_proposed_category": "data",
+                "llm_confidence": 0.9,
+                "decision": "agree",
+                "parse_status": "ok",
+                "review_required": True,
+                "reason": "checkpointed",
+                "evidence": [],
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = reviewer.build_review_report(
+        {"changes": [change]},
+        client=FakeClient([]),
+        model="m",
+        base_url="u",
+        api_key_env="KEY",
+        checkpoint_path=checkpoint_path,
+        resume=True,
+    )
+
+    assert report["reviews"][0]["reason"] == "checkpointed"
+    assert report["summary"]["malformed_checkpoint_row_count"] == 1
+    assert report["summary"]["skipped_checkpoint_count"] == 1
+
+
 def test_review_report_marks_api_error_without_raising():
     reviewer = _load_module()
     client = FakeClient([reviewer.LLMReviewError("temporary outage")])
@@ -313,10 +424,41 @@ def test_main_requires_api_key(monkeypatch, tmp_path):
         reviewer.main(["--plan", str(plan_path)])
 
 
+def test_main_requires_checkpoint_for_resume(monkeypatch, tmp_path):
+    reviewer = _load_module()
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text('{"changes":[]}', encoding="utf-8")
+    monkeypatch.setenv("MIMO_API_KEY", "secret")
+
+    with pytest.raises(SystemExit, match="--resume requires --checkpoint-jsonl"):
+        reviewer.main(["--plan", str(plan_path), "--resume"])
+
+
+def test_main_rejects_same_output_and_checkpoint(monkeypatch, tmp_path):
+    reviewer = _load_module()
+    plan_path = tmp_path / "plan.json"
+    output_path = tmp_path / "review.json"
+    plan_path.write_text('{"changes":[]}', encoding="utf-8")
+    monkeypatch.setenv("MIMO_API_KEY", "secret")
+
+    with pytest.raises(SystemExit, match="must be different paths"):
+        reviewer.main(
+            [
+                "--plan",
+                str(plan_path),
+                "--output",
+                str(output_path),
+                "--checkpoint-jsonl",
+                str(output_path),
+            ]
+        )
+
+
 def test_main_writes_json_report(monkeypatch, tmp_path, capsys):
     reviewer = _load_module()
     plan_path = tmp_path / "plan.json"
     output_path = tmp_path / "review.json"
+    checkpoint_path = tmp_path / "review.checkpoint.jsonl"
     plan_path.write_text(
         json.dumps(
             {
@@ -348,6 +490,8 @@ def test_main_writes_json_report(monkeypatch, tmp_path, capsys):
                 "--json",
                 "--limit",
                 "1",
+                "--checkpoint-jsonl",
+                str(checkpoint_path),
             ]
         )
         == 0
@@ -356,3 +500,4 @@ def test_main_writes_json_report(monkeypatch, tmp_path, capsys):
     output = json.loads(output_path.read_text(encoding="utf-8"))
     assert json.loads(stdout)["summary"]["reviewed_count"] == 1
     assert output["reviews"][0]["decision"] == "agree"
+    assert checkpoint_path.exists()


### PR DESCRIPTION
## Summary
- add append-only JSONL checkpoints for the MIMO category review tool
- add stable review_key resume support so completed candidates are skipped safely
- include checkpoint, resume, skipped, and malformed-row counts in final reports
- document the long-run workflow and add tests for checkpoint writing, resume, malformed rows, and CLI guards

## Safety
- still review-only: no archive files are modified
- API keys are still read only from environment variables
- final JSON output and checkpoint JSONL must use different paths

## Verification
- python -m pytest -q
- python scripts/check_taxonomy_governance.py
- python -m ruff check scripts/review_category_plan_with_llm.py tests/test_review_category_plan_with_llm.py
- git diff --check

Closes #92