### PR TITLE
Make MiMo category review token policy explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,13 @@ signals, and reason for every proposed change; it does not move files.
 For a bounded second-pass model review, set `MIMO_API_KEY` and run
 `python scripts/review_category_plan_with_llm.py --plan category-migration-plan.json --output category-llm-review.json --checkpoint-jsonl category-llm-review.checkpoint.jsonl --resume`.
 The default endpoint is `https://token-plan-sgp.xiaomimimo.com/v1` with
-`mimo-v2.5-pro`, and the report remains review-only: it records model category,
-confidence, decision, parse status, and evidence without modifying the archive.
+`mimo-v2.5-pro`. The default request uses `--thinking disabled` and
+`--max-completion-tokens 1024` so the model output budget is reserved for the
+required JSON; raise the token value for larger reviews, or pass
+`--thinking default` when using a non-MiMo endpoint that does not accept the
+provider-specific thinking field. The report remains review-only: it records
+model category, confidence, decision, parse status, token/thinking policy, and
+evidence without modifying the archive.
 The checkpoint file is append-only JSONL, so interrupted long reviews can resume
 without re-calling the model for completed candidates.
 

--- a/scripts/review_category_plan_with_llm.py
+++ b/scripts/review_category_plan_with_llm.py
@@ -22,6 +22,8 @@ DEFAULT_BASE_URL = "https://token-plan-sgp.xiaomimimo.com/v1"
 DEFAULT_MODEL = "mimo-v2.5-pro"
 DEFAULT_API_KEY_ENV = "MIMO_API_KEY"
 DEFAULT_ACTIONS = ("heuristic_reclassify", "resolve_source_conflict")
+DEFAULT_MAX_COMPLETION_TOKENS = 1024
+DEFAULT_THINKING = "disabled"
 CONFIDENCE_PRIORITY = {"low": 0, "medium": 1, "high": 2}
 CHECKPOINT_SCHEMA_VERSION = 1
 
@@ -41,8 +43,9 @@ class OpenAICompatibleClient:
     base_url: str = DEFAULT_BASE_URL
     model: str = DEFAULT_MODEL
     timeout: int = 60
-    max_completion_tokens: int = 512
+    max_completion_tokens: int = DEFAULT_MAX_COMPLETION_TOKENS
     temperature: float = 0.0
+    thinking: str = DEFAULT_THINKING
 
     def complete(self, messages: list[dict[str, str]]) -> str:
         payload = {
@@ -52,6 +55,9 @@ class OpenAICompatibleClient:
             "temperature": self.temperature,
             "stream": False,
         }
+        normalized_thinking = self.thinking.strip().lower()
+        if normalized_thinking and normalized_thinking != "default":
+            payload["thinking"] = {"type": normalized_thinking}
         request = Request(
             f"{self.base_url.rstrip('/')}/chat/completions",
             data=json.dumps(payload).encode("utf-8"),
@@ -273,7 +279,9 @@ def build_review_entry(
     return entry
 
 
-def build_error_entry(change: dict[str, Any], error: Exception, *, review_key: str) -> dict[str, Any]:
+def build_error_entry(
+    change: dict[str, Any], error: Exception, *, review_key: str
+) -> dict[str, Any]:
     return {
         "checkpoint_schema_version": CHECKPOINT_SCHEMA_VERSION,
         "review_key": review_key,
@@ -341,6 +349,8 @@ def build_review_report(
     source_plan: str = "",
     checkpoint_path: Path | None = None,
     resume: bool = False,
+    max_completion_tokens: int = DEFAULT_MAX_COMPLETION_TOKENS,
+    thinking: str = DEFAULT_THINKING,
 ) -> dict[str, Any]:
     taxonomy = get_taxonomy()
     categories = active_category_payload(taxonomy)
@@ -405,6 +415,8 @@ def build_review_report(
             "priority": priority,
             "sleep_seconds": sleep_seconds,
             "override_confidence": override_confidence,
+            "max_completion_tokens": max_completion_tokens,
+            "thinking": thinking,
             "api_key_env": api_key_env,
             "checkpoint_jsonl": str(checkpoint_path) if checkpoint_path else "",
             "resume": resume,
@@ -465,8 +477,21 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
     parser.add_argument("--api-key-env", default=DEFAULT_API_KEY_ENV)
     parser.add_argument("--timeout", type=int, default=60)
-    parser.add_argument("--max-completion-tokens", type=int, default=512)
+    parser.add_argument(
+        "--max-completion-tokens",
+        type=int,
+        default=DEFAULT_MAX_COMPLETION_TOKENS,
+    )
     parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument(
+        "--thinking",
+        choices=["disabled", "default"],
+        default=DEFAULT_THINKING,
+        help=(
+            "Set MiMo thinking mode. Use 'default' to omit the provider-specific "
+            "thinking field for non-MiMo endpoints."
+        ),
+    )
     parser.add_argument("--limit", type=int, default=25)
     parser.add_argument("--action", action="append")
     parser.add_argument("--confidence", action="append")
@@ -508,6 +533,7 @@ def main(argv: list[str] | None = None) -> int:
         timeout=args.timeout,
         max_completion_tokens=args.max_completion_tokens,
         temperature=args.temperature,
+        thinking=args.thinking,
     )
     report = build_review_report(
         plan,
@@ -525,6 +551,8 @@ def main(argv: list[str] | None = None) -> int:
         source_plan=str(args.plan),
         checkpoint_path=args.checkpoint_jsonl,
         resume=args.resume,
+        max_completion_tokens=args.max_completion_tokens,
+        thinking=args.thinking,
     )
     payload = json.dumps(report, indent=2, ensure_ascii=False)
     if args.output:

--- a/tests/test_review_category_plan_with_llm.py
+++ b/tests/test_review_category_plan_with_llm.py
@@ -116,6 +116,8 @@ def test_review_report_records_agree_override_and_uncertain():
         "uncertain": 1,
     }
     assert report["policy"]["apply_mode"] == "review-only"
+    assert report["policy"]["max_completion_tokens"] == reviewer.DEFAULT_MAX_COMPLETION_TOKENS
+    assert report["policy"]["thinking"] == reviewer.DEFAULT_THINKING
     assert "MIMO_API_KEY" in report["notes"][1]
 
 
@@ -157,7 +159,34 @@ def test_openai_compatible_client_posts_chat_completion(monkeypatch):
     assert captured["headers"]["Authorization"] == "Bearer secret"
     assert captured["payload"]["model"] == "m"
     assert captured["payload"]["max_completion_tokens"] == 123
+    assert captured["payload"]["thinking"] == {"type": "disabled"}
     assert captured["payload"]["stream"] is False
+
+
+def test_openai_compatible_client_can_omit_thinking_for_non_mimo(monkeypatch):
+    reviewer = _load_module()
+    captured = {}
+
+    def fake_urlopen(request, timeout):
+        captured["payload"] = json.loads(request.data.decode("utf-8"))
+        return FakeResponse(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": '{"category":"data","confidence":0.8,"reason":"etl","evidence":[]}'
+                        }
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setattr(reviewer, "urlopen", fake_urlopen)
+    client = reviewer.OpenAICompatibleClient(api_key="secret", thinking="default")
+
+    client.complete([{"role": "user", "content": "hello"}])
+
+    assert "thinking" not in captured["payload"]
 
 
 def test_openai_compatible_client_reports_api_shape_errors(monkeypatch):
@@ -461,11 +490,7 @@ def test_main_writes_json_report(monkeypatch, tmp_path, capsys):
     checkpoint_path = tmp_path / "review.checkpoint.jsonl"
     plan_path.write_text(
         json.dumps(
-            {
-                "changes": [
-                    _change("other/a/SKILL.md", confidence="low", proposed_category="data")
-                ]
-            }
+            {"changes": [_change("other/a/SKILL.md", confidence="low", proposed_category="data")]}
         ),
         encoding="utf-8",
     )
@@ -473,10 +498,12 @@ def test_main_writes_json_report(monkeypatch, tmp_path, capsys):
     class FakeOpenAICompatibleClient:
         def __init__(self, **kwargs):
             self.kwargs = kwargs
+            created_clients.append(kwargs)
 
         def complete(self, messages):
             return '{"category":"data","confidence":0.9,"reason":"etl","evidence":["csv"]}'
 
+    created_clients = []
     monkeypatch.setenv("MIMO_API_KEY", "secret")
     monkeypatch.setattr(reviewer, "OpenAICompatibleClient", FakeOpenAICompatibleClient)
 
@@ -490,6 +517,10 @@ def test_main_writes_json_report(monkeypatch, tmp_path, capsys):
                 "--json",
                 "--limit",
                 "1",
+                "--max-completion-tokens",
+                "2048",
+                "--thinking",
+                "default",
                 "--checkpoint-jsonl",
                 str(checkpoint_path),
             ]
@@ -499,5 +530,9 @@ def test_main_writes_json_report(monkeypatch, tmp_path, capsys):
     stdout = capsys.readouterr().out
     output = json.loads(output_path.read_text(encoding="utf-8"))
     assert json.loads(stdout)["summary"]["reviewed_count"] == 1
+    assert created_clients[0]["max_completion_tokens"] == 2048
+    assert created_clients[0]["thinking"] == "default"
+    assert output["policy"]["max_completion_tokens"] == 2048
+    assert output["policy"]["thinking"] == "default"
     assert output["reviews"][0]["decision"] == "agree"
     assert checkpoint_path.exists()


### PR DESCRIPTION
## Summary

- default category review calls to MiMo thinking disabled so completion budget is reserved for JSON output
- raise the default max_completion_tokens from 512 to 1024 and record token/thinking policy in review reports
- add a --thinking default escape hatch for non-MiMo OpenAI-compatible endpoints
- document the MiMo review defaults

Closes #94.

## Validation

- python -m ruff check scripts/review_category_plan_with_llm.py tests/test_review_category_plan_with_llm.py
- python -m ruff format --check scripts/review_category_plan_with_llm.py tests/test_review_category_plan_with_llm.py
- python -m pytest tests/test_review_category_plan_with_llm.py -q
- python -m pytest -q
- python scripts/check_taxonomy_governance.py
- MIMO_API_KEY=dummy python scripts/review_category_plan_with_llm.py --plan /tmp/category-migration-plan-latest.json --output /tmp/category-llm-review-cli-smoke.json --limit 0 --json

## Note

- python scripts/check_category_artifacts.py --categories-dir docs/categories still fails on existing generated category payload files in core; this PR does not edit generated category artifacts.
