### PR TITLE
Fix LLM review checkpoint validation

### DIFF
--- a/scripts/review_category_plan_with_llm.py
+++ b/scripts/review_category_plan_with_llm.py
@@ -26,6 +26,21 @@ DEFAULT_MAX_COMPLETION_TOKENS = 1024
 DEFAULT_THINKING = "disabled"
 CONFIDENCE_PRIORITY = {"low": 0, "medium": 1, "high": 2}
 CHECKPOINT_SCHEMA_VERSION = 1
+CHECKPOINT_REQUIRED_REVIEW_FIELDS = (
+    "review_key",
+    "path",
+    "name",
+    "action",
+    "current_category",
+    "heuristic_proposed_category",
+    "llm_proposed_category",
+    "llm_confidence",
+    "decision",
+    "parse_status",
+    "review_required",
+    "reason",
+    "evidence",
+)
 
 
 class ChatClient(Protocol):
@@ -300,6 +315,33 @@ def build_error_entry(
     }
 
 
+def is_valid_checkpoint_review(payload: dict[str, Any]) -> bool:
+    if any(field not in payload for field in CHECKPOINT_REQUIRED_REVIEW_FIELDS):
+        return False
+    review_key = payload.get("review_key")
+    if not isinstance(review_key, str) or not review_key:
+        return False
+    for field in (
+        "path",
+        "name",
+        "action",
+        "current_category",
+        "heuristic_proposed_category",
+        "llm_proposed_category",
+        "decision",
+        "parse_status",
+        "reason",
+    ):
+        if not isinstance(payload.get(field), str):
+            return False
+    if not isinstance(payload.get("review_required"), bool):
+        return False
+    if not isinstance(payload.get("evidence"), list):
+        return False
+    confidence = payload.get("llm_confidence")
+    return confidence is None or isinstance(confidence, (int, float))
+
+
 def load_checkpoint_reviews(checkpoint_path: Path | None) -> tuple[dict[str, dict[str, Any]], int]:
     if checkpoint_path is None or not checkpoint_path.exists():
         return {}, 0
@@ -317,10 +359,10 @@ def load_checkpoint_reviews(checkpoint_path: Path | None) -> tuple[dict[str, dic
         if not isinstance(payload, dict):
             malformed_row_count += 1
             continue
-        review_key = payload.get("review_key")
-        if not isinstance(review_key, str) or not review_key:
+        if not is_valid_checkpoint_review(payload):
             malformed_row_count += 1
             continue
+        review_key = payload["review_key"]
         reviews[review_key] = payload
     return reviews, malformed_row_count
 
@@ -515,6 +557,8 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit(f"Category migration plan not found: {args.plan}")
     if args.resume and not args.checkpoint_jsonl:
         raise SystemExit("--resume requires --checkpoint-jsonl")
+    if args.checkpoint_jsonl and args.plan.resolve() == args.checkpoint_jsonl.resolve():
+        raise SystemExit("--plan and --checkpoint-jsonl must be different paths")
     if (
         args.output
         and args.checkpoint_jsonl

--- a/tests/test_review_category_plan_with_llm.py
+++ b/tests/test_review_category_plan_with_llm.py
@@ -406,6 +406,57 @@ def test_resume_ignores_malformed_checkpoint_rows(tmp_path):
     assert report["summary"]["skipped_checkpoint_count"] == 1
 
 
+def test_resume_ignores_checkpoint_rows_missing_required_fields(tmp_path):
+    reviewer = _load_module()
+    change = _change("other/a/SKILL.md", confidence="low", proposed_category="data")
+    review_key = reviewer.candidate_review_key(change)
+    checkpoint_path = tmp_path / "review.checkpoint.jsonl"
+    checkpoint_path.write_text(
+        json.dumps({"review_key": review_key}, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    client = FakeClient(
+        ['{"category":"data","confidence":0.9,"reason":"fresh","evidence":["csv"]}']
+    )
+
+    report = reviewer.build_review_report(
+        {"changes": [change]},
+        client=client,
+        model="m",
+        base_url="u",
+        api_key_env="KEY",
+        checkpoint_path=checkpoint_path,
+        resume=True,
+    )
+
+    assert len(client.messages) == 1
+    assert report["reviews"][0]["reason"] == "fresh"
+    assert report["summary"]["malformed_checkpoint_row_count"] == 1
+    assert report["summary"]["skipped_checkpoint_count"] == 0
+    assert report["summary"]["new_review_count"] == 1
+
+
+def test_main_rejects_checkpoint_path_aliasing_plan(tmp_path, monkeypatch):
+    reviewer = _load_module()
+    monkeypatch.setenv("KEY", "test-key")
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(json.dumps({"changes": []}) + "\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="--plan and --checkpoint-jsonl must be different paths"):
+        reviewer.main(
+            [
+                "--plan",
+                str(plan_path),
+                "--checkpoint-jsonl",
+                str(plan_path),
+                "--api-key-env",
+                "KEY",
+                "--limit",
+                "0",
+            ]
+        )
+
+
 def test_review_report_marks_api_error_without_raising():
     reviewer = _load_module()
     client = FakeClient([reviewer.LLMReviewError("temporary outage")])


### PR DESCRIPTION
## Summary
- reject checkpoint JSONL paths that alias the input category plan
- validate resumed checkpoint rows before accepting them
- add regression coverage for the post-merge #93 review comments

## Validation
- pytest tests/test_review_category_plan_with_llm.py -q
- pytest -q

Follow-up for late Codex review comments on #93.