### PR TITLE
Reuse existing targets for duplicate depth normalization keys

### DIFF
--- a/scripts/normalize_skill_depth.py
+++ b/scripts/normalize_skill_depth.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
@@ -60,8 +61,8 @@ def infer_category(rel_parts: tuple[str, ...], meta: dict[str, Any]) -> str:
     return category or "other"
 
 
-def existing_category_state(skills_dir: Path) -> dict[str, dict[str, set[str]]]:
-    state: dict[str, dict[str, set[str]]] = defaultdict(lambda: {"names": set(), "keys": set()})
+def existing_category_state(skills_dir: Path) -> dict[str, dict[str, Any]]:
+    state: dict[str, dict[str, Any]] = defaultdict(lambda: {"names": set(), "key_to_name": {}})
     for category_dir in sorted(skills_dir.iterdir()):
         if not category_dir.is_dir() or category_dir.name.startswith("."):
             continue
@@ -76,23 +77,25 @@ def existing_category_state(skills_dir: Path) -> dict[str, dict[str, set[str]]]:
             key = build_skill_key(repo, path, name=name, category=category)
             state[category]["names"].add(skill_dir.name.lower())
             if key:
-                state[category]["keys"].add(key)
+                state[category]["key_to_name"].setdefault(key, skill_dir.name)
     return state
 
 
 def unique_dir_name(
     *,
-    category_state: dict[str, set[str]],
+    category_state: dict[str, Any],
     base_name: str,
     repo: str,
     key: str,
-) -> str:
+) -> tuple[str, bool]:
     base = normalize_name(base_name)
+    key_to_name = category_state["key_to_name"]
+    if key and key in key_to_name:
+        return key_to_name[key], True
+
     if base.lower() not in category_state["names"]:
         category_state["names"].add(base.lower())
-        if key:
-            category_state["keys"].add(key)
-        return base
+        return base, False
 
     suffix = get_repo_suffix(repo)
     if suffix and not base.endswith(f"-{suffix}"):
@@ -107,9 +110,7 @@ def unique_dir_name(
         counter += 1
 
     category_state["names"].add(candidate.lower())
-    if key:
-        category_state["keys"].add(key)
-    return candidate
+    return candidate, False
 
 
 def build_depth_plan(skills_dir: Path) -> dict[str, Any]:
@@ -125,7 +126,7 @@ def build_depth_plan(skills_dir: Path) -> dict[str, Any]:
         path = meta.get("github_path") or meta.get("path") or ""
         key = build_skill_key(repo, path, name=name, category=category)
         category_state = state[category]
-        target_name = unique_dir_name(
+        target_name, reuses_existing_key = unique_dir_name(
             category_state=category_state,
             base_name=name,
             repo=repo,
@@ -136,6 +137,7 @@ def build_depth_plan(skills_dir: Path) -> dict[str, Any]:
             {
                 "source_path": str(skill_dir.relative_to(skills_dir)),
                 "source_skill": str(rel),
+                "operation": "remove_duplicate" if reuses_existing_key else "move",
                 "target_path": str(target_rel),
                 "target_skill": str(target_rel / "SKILL.md"),
                 "category": category,
@@ -148,12 +150,22 @@ def build_depth_plan(skills_dir: Path) -> dict[str, Any]:
             }
         )
 
+    duplicate_count = sum(1 for move in moves if move["operation"] == "remove_duplicate")
     return {
         "skills_dir": str(skills_dir),
         "expected_layout": LAYOUT_EXPECTED,
         "move_count": len(moves),
+        "duplicate_count": duplicate_count,
         "moves": moves,
     }
+
+
+def skill_key_for_dir(skill_dir: Path, category: str) -> str:
+    meta = load_metadata(skill_dir)
+    name = normalize_name(meta.get("name") or skill_dir.name)
+    repo = normalize_repo(meta.get("repo", ""))
+    path = meta.get("github_path") or meta.get("path") or ""
+    return build_skill_key(repo, path, name=name, category=category)
 
 
 def apply_depth_plan(skills_dir: Path, plan: dict[str, Any]) -> None:
@@ -166,6 +178,13 @@ def apply_depth_plan(skills_dir: Path, plan: dict[str, Any]) -> None:
         target = skills_dir / move["target_path"]
         if not source.exists():
             raise FileNotFoundError(f"Planned source does not exist: {source}")
+        if move.get("operation") == "remove_duplicate":
+            if not target.exists():
+                raise FileNotFoundError(f"Duplicate target does not exist: {target}")
+            if skill_key_for_dir(target, str(move["category"])) != move.get("key"):
+                raise ValueError(f"Duplicate target key mismatch: {target}")
+            shutil.rmtree(source)
+            continue
         if target.exists():
             raise FileExistsError(f"Planned target already exists: {target}")
         target.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_normalize_skill_depth.py
+++ b/tests/test_normalize_skill_depth.py
@@ -99,6 +99,46 @@ def test_apply_depth_plan_preserves_existing_target_with_suffix(tmp_path):
     assert not (skills_dir / "other" / "other" / "auth-audit").exists()
 
 
+def test_depth_plan_reuses_existing_target_for_same_skill_key(tmp_path):
+    module = _load_module()
+    skills_dir = tmp_path / "skills"
+    metadata = {
+        "name": "auth-audit",
+        "category": "security",
+        "repo": "acme/security-pack",
+        "path": "skills/auth-audit",
+    }
+    _write_skill(skills_dir, "security/auth-audit", metadata)
+    _write_skill(skills_dir, "other/other/auth-audit", metadata)
+
+    plan = module.build_depth_plan(skills_dir)
+
+    assert plan["move_count"] == 1
+    assert plan["duplicate_count"] == 1
+    assert plan["moves"][0]["operation"] == "remove_duplicate"
+    assert plan["moves"][0]["target_path"] == "security/auth-audit"
+
+
+def test_apply_depth_plan_removes_nested_duplicate_for_same_skill_key(tmp_path):
+    module = _load_module()
+    skills_dir = tmp_path / "skills"
+    metadata = {
+        "name": "auth-audit",
+        "category": "security",
+        "repo": "acme/security-pack",
+        "path": "skills/auth-audit",
+    }
+    existing = _write_skill(skills_dir, "security/auth-audit", metadata)
+    _write_skill(skills_dir, "other/other/auth-audit", metadata)
+
+    plan = module.build_depth_plan(skills_dir)
+    module.apply_depth_plan(skills_dir, plan)
+
+    assert (existing / "SKILL.md").exists()
+    assert not (skills_dir / "other" / "other" / "auth-audit").exists()
+    assert not (skills_dir / "security" / "auth-audit-acme-security-pack").exists()
+
+
 def test_apply_depth_plan_moves_child_before_parent(tmp_path):
     module = _load_module()
     skills_dir = tmp_path / "skills"


### PR DESCRIPTION
## Summary
- reuse an existing standard-layout target when a nested skill resolves to the same metadata key
- mark same-key nested entries as explicit `remove_duplicate` operations instead of creating suffixed duplicate directories
- validate the target key before removing the non-standard duplicate during apply

## Validation
- pytest tests/test_normalize_skill_depth.py -q
- pytest tests/test_normalize_skill_depth.py tests/test_audit_category_quality.py tests/test_utils.py -q
- pytest -q
- git diff --check

Follow-up for the P1 Codex review comment on #86.