### PR TITLE
Guard non-object LLM chat responses

### DIFF
--- a/scripts/review_category_plan_with_llm.py
+++ b/scripts/review_category_plan_with_llm.py
@@ -91,6 +91,8 @@ class OpenAICompatibleClient:
         except (OSError, URLError, json.JSONDecodeError) as exc:
             raise LLMReviewError(f"chat API request failed: {exc}") from exc
 
+        if not isinstance(response_payload, dict):
+            raise LLMReviewError("chat API response was not a JSON object")
         choices = response_payload.get("choices")
         if not isinstance(choices, list) or not choices:
             raise LLMReviewError("chat API response did not include choices")

--- a/tests/test_review_category_plan_with_llm.py
+++ b/tests/test_review_category_plan_with_llm.py
@@ -198,6 +198,15 @@ def test_openai_compatible_client_reports_api_shape_errors(monkeypatch):
         client.complete([{"role": "user", "content": "hello"}])
 
 
+def test_openai_compatible_client_reports_non_object_payload(monkeypatch):
+    reviewer = _load_module()
+    monkeypatch.setattr(reviewer, "urlopen", lambda request, timeout: FakeResponse(["error"]))
+    client = reviewer.OpenAICompatibleClient(api_key="secret")
+
+    with pytest.raises(reviewer.LLMReviewError, match="JSON object"):
+        client.complete([{"role": "user", "content": "hello"}])
+
+
 def test_openai_compatible_client_reports_http_errors(monkeypatch):
     reviewer = _load_module()
 


### PR DESCRIPTION
## Summary
- convert non-object chat completion JSON payloads into `LLMReviewError`
- add regression coverage so malformed HTTP 200 payloads become per-candidate API errors instead of uncaught `AttributeError`

## Validation
- pytest tests/test_review_category_plan_with_llm.py -q
- pytest -q
- git diff --check

Follow-up for the P2 Codex review comment on #91.