### PR TITLE
Prefer source conflicts before category deprecation

### DIFF
--- a/scripts/plan_category_migration.py
+++ b/scripts/plan_category_migration.py
@@ -157,28 +157,6 @@ def build_plan(
         )
 
         source_values = set(resolved_sources.values())
-        migration_target = taxonomy.migration_target(current_category)
-        if migration_target:
-            definition = taxonomy.categories[current_category]
-            changes.append(
-                build_change(
-                    action="taxonomy_deprecation",
-                    confidence="high",
-                    rel=rel,
-                    skill_dir=skill_dir,
-                    name=name,
-                    current_category=current_category,
-                    proposed_category=migration_target,
-                    raw_sources=raw_sources,
-                    resolved_sources=resolved_sources,
-                    reason=(
-                        f"taxonomy marks {current_category} as {definition.status} "
-                        f"with migrate_to={migration_target}"
-                    ),
-                )
-            )
-            continue
-
         alias_sources = [
             source
             for source, value in raw_sources.items()
@@ -214,6 +192,28 @@ def build_plan(
                     raw_sources=raw_sources,
                     resolved_sources=resolved_sources,
                     reason="directory, metadata, or frontmatter categories disagree",
+                )
+            )
+            continue
+
+        migration_target = taxonomy.migration_target(current_category)
+        if migration_target:
+            definition = taxonomy.categories[current_category]
+            changes.append(
+                build_change(
+                    action="taxonomy_deprecation",
+                    confidence="high",
+                    rel=rel,
+                    skill_dir=skill_dir,
+                    name=name,
+                    current_category=current_category,
+                    proposed_category=migration_target,
+                    raw_sources=raw_sources,
+                    resolved_sources=resolved_sources,
+                    reason=(
+                        f"taxonomy marks {current_category} as {definition.status} "
+                        f"with migrate_to={migration_target}"
+                    ),
                 )
             )
             continue

--- a/tests/test_plan_category_migration.py
+++ b/tests/test_plan_category_migration.py
@@ -94,3 +94,28 @@ def test_plan_reports_alias_and_source_conflict(tmp_path):
     assert changes["engineering/builder/SKILL.md"]["proposed_category"] == "development"
     assert changes["development/conflicted/SKILL.md"]["action"] == "resolve_source_conflict"
     assert changes["development/conflicted/SKILL.md"]["review_required"] is True
+
+
+def test_plan_reports_source_conflict_before_deprecation(tmp_path):
+    planner = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "product",
+        "misfiled-docs",
+        {
+            "name": "misfiled-docs",
+            "category": "docs",
+            "description": "Product roadmap documentation helper.",
+        },
+    )
+
+    plan = planner.build_plan(skills_dir)
+    change = {item["path"]: item for item in plan["changes"]}[
+        "product/misfiled-docs/SKILL.md"
+    ]
+
+    assert change["action"] == "resolve_source_conflict"
+    assert change["current_category"] == "docs"
+    assert change["proposed_category"] == "docs"
+    assert change["review_required"] is True


### PR DESCRIPTION
## Summary
- classify disagreeing category sources as `resolve_source_conflict` before deprecated-category migration
- keep deprecated `migrate_to` handling for records whose category sources agree
- add regression coverage for a `docs` metadata entry filed under `product`

## Validation
- pytest tests/test_plan_category_migration.py -q
- pytest -q
- git diff --check

Follow-up for the P2 Codex review comment on #89.