### PR TITLE
Restore category guessing for uncategorized imports

### DIFF
--- a/scripts/clone_and_import.py
+++ b/scripts/clone_and_import.py
@@ -138,7 +138,8 @@ def import_skill(skill_file: Path, skills_dir: Path, repo_slug: str, stats: dict
         return False
 
     # Determine category
-    category = normalize_category(metadata.get("category", ""))
+    raw_category = metadata.get("category", "")
+    category = normalize_category(raw_category) if raw_category else ""
     if not category or category == "unknown":
         category = guess_category(str(skill_file) + " " + content[:1000])
 

--- a/tests/test_clone_and_import.py
+++ b/tests/test_clone_and_import.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    return importlib.import_module("clone_and_import")
+
+
+def test_import_skill_guesses_category_when_frontmatter_category_missing(tmp_path):
+    module = _load_module()
+    repo_dir = tmp_path / "repo" / "skills" / "roadmap-helper"
+    repo_dir.mkdir(parents=True)
+    skill_file = repo_dir / "SKILL.md"
+    skill_file.write_text(
+        "---\n"
+        "name: roadmap-helper\n"
+        "description: Product roadmap PRD backlog feature metrics helper.\n"
+        "---\n\n"
+        "Product roadmap PRD backlog feature metrics helper for planning work.",
+        encoding="utf-8",
+    )
+    skills_dir = tmp_path / "skills"
+    stats = {"imported": 0, "skipped": 0, "errors": 0}
+
+    assert module.import_skill(skill_file, skills_dir, "acme/roadmap", stats) is True
+
+    metadata = json.loads(
+        (skills_dir / "product" / "roadmap-helper" / "metadata.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert metadata["category"] == "product"
+    assert stats["imported"] == 1


### PR DESCRIPTION
## Summary
- keep missing frontmatter category empty so clone/import can use content-based `guess_category`
- add regression coverage for an uncategorized product-oriented SKILL.md

## Validation
- pytest tests/test_clone_and_import.py -q
- pytest -q
- git diff --check

Follow-up for the P2 Codex review comment on #85.