### PR TITLE
Reject boolean checkpoint confidence values

### DIFF
--- a/scripts/review_category_plan_with_llm.py
+++ b/scripts/review_category_plan_with_llm.py
@@ -341,7 +341,9 @@ def is_valid_checkpoint_review(payload: dict[str, Any]) -> bool:
     if not isinstance(payload.get("evidence"), list):
         return False
     confidence = payload.get("llm_confidence")
-    return confidence is None or isinstance(confidence, (int, float))
+    return confidence is None or (
+        not isinstance(confidence, bool) and isinstance(confidence, (int, float))
+    )
 
 
 def load_checkpoint_reviews(checkpoint_path: Path | None) -> tuple[dict[str, dict[str, Any]], int]:

--- a/tests/test_review_category_plan_with_llm.py
+++ b/tests/test_review_category_plan_with_llm.py
@@ -445,6 +445,53 @@ def test_resume_ignores_checkpoint_rows_missing_required_fields(tmp_path):
     assert report["summary"]["new_review_count"] == 1
 
 
+def test_resume_ignores_checkpoint_rows_with_boolean_confidence(tmp_path):
+    reviewer = _load_module()
+    change = _change("other/a/SKILL.md", confidence="low", proposed_category="data")
+    review_key = reviewer.candidate_review_key(change)
+    checkpoint_path = tmp_path / "review.checkpoint.jsonl"
+    checkpoint_path.write_text(
+        json.dumps(
+            {
+                "review_key": review_key,
+                "path": "other/a/SKILL.md",
+                "name": "a",
+                "action": "heuristic_reclassify",
+                "current_category": "other",
+                "heuristic_proposed_category": "data",
+                "llm_proposed_category": "data",
+                "llm_confidence": True,
+                "decision": "agree",
+                "parse_status": "ok",
+                "review_required": True,
+                "reason": "checkpointed",
+                "evidence": [],
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    client = FakeClient(
+        ['{"category":"data","confidence":0.9,"reason":"fresh","evidence":["csv"]}']
+    )
+
+    report = reviewer.build_review_report(
+        {"changes": [change]},
+        client=client,
+        model="m",
+        base_url="u",
+        api_key_env="KEY",
+        checkpoint_path=checkpoint_path,
+        resume=True,
+    )
+
+    assert len(client.messages) == 1
+    assert report["reviews"][0]["reason"] == "fresh"
+    assert report["summary"]["malformed_checkpoint_row_count"] == 1
+    assert report["summary"]["skipped_checkpoint_count"] == 0
+
+
 def test_main_rejects_checkpoint_path_aliasing_plan(tmp_path, monkeypatch):
     reviewer = _load_module()
     monkeypatch.setenv("KEY", "test-key")


### PR DESCRIPTION
## Summary
- reject boolean `llm_confidence` values when loading checkpoint rows
- add regression coverage so malformed checkpoint rows are counted and re-reviewed

## Validation
- pytest tests/test_review_category_plan_with_llm.py -q
- pytest -q
- git diff --check

Follow-up for the late P2 Codex review comment on #96.