### PR TITLE
Stage registry shard artifacts during sync

### DIFF
--- a/.github/workflows/sync-data.yml
+++ b/.github/workflows/sync-data.yml
@@ -458,7 +458,7 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
-          git add registry.json registry_summary.json sources/ CHANGELOG.md scripts/ schema/ README.md SECURITY.md LICENSE THIRD_PARTY_NOTICES.md .github/workflows/sync-data.yml .github/workflows/metadata-compliance.yml
+          git add registry.json registry_summary.json registry-manifest.json registry-shards/ sources/ CHANGELOG.md scripts/ schema/ README.md SECURITY.md LICENSE THIRD_PARTY_NOTICES.md .github/workflows/sync-data.yml .github/workflows/metadata-compliance.yml
 
           if git diff --staged --quiet; then
             echo "No core changes"

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -65,6 +65,12 @@ def test_sync_data_runs_generated_size_guard_after_registry_rebuild():
     assert "--include docs" in workflow
 
 
+def test_sync_data_stages_registry_shard_artifacts():
+    workflow = read_repo_file(".github/workflows/sync-data.yml")
+
+    assert "git add registry.json registry_summary.json registry-manifest.json registry-shards/" in workflow
+
+
 def test_metadata_compliance_refuses_unexpected_zero_target_scan():
     workflow = read_repo_file(".github/workflows/metadata-compliance.yml")
 


### PR DESCRIPTION
## Summary
- include `registry-manifest.json` and `registry-shards/` in the sync-data core metadata commit
- add a pipeline contract test so sharded registry artifacts stay staged after rebuild

## Validation
- pytest tests/test_pipeline_contracts.py -q
- pytest -q
- git diff --check

Follow-up for the P1 Codex review comment on #64.