### PR TITLE
Preserve discovery archives on scan failure

### DIFF
--- a/scripts/discover_by_topic.py
+++ b/scripts/discover_by_topic.py
@@ -8,7 +8,7 @@ import os
 import json
 import time
 import logging
-import shutil
+import tempfile
 from collections import defaultdict
 import requests
 from datetime import datetime
@@ -337,10 +337,6 @@ class GitHubTopicDiscovery:
                     # Save skill (case-safe)
                     category = "other"
                     key = build_skill_key(repo, path, name=skill_dir, category=category)
-                    skill_path = ensure_unique_dir(output_dir / category, skill_dir, key, repo=repo)
-                    skill_path.mkdir(parents=True, exist_ok=True)
-
-                    (skill_path / 'SKILL.md').write_text(content, encoding='utf-8')
 
                     # Save metadata
                     legal_meta = build_legal_metadata(
@@ -355,20 +351,30 @@ class GitHubTopicDiscovery:
                         'github_branch': branch,
                         'category': category,
                         'source': f'github.com/{repo}',
-                        'dir_name': skill_path.name,
+                        'dir_name': skill_dir,
                         'downloaded_at': datetime.utcnow().isoformat() + 'Z',
                         **legal_meta,
                     }
-                    (skill_path / 'metadata.json').write_text(
-                        json.dumps(metadata, indent=2), encoding='utf-8'
-                    )
 
-                    is_safe, issues = self.security_scanner.scan_file(skill_path / 'SKILL.md')
+                    output_dir.mkdir(parents=True, exist_ok=True)
+                    with tempfile.TemporaryDirectory(
+                        prefix=".discover-scan-",
+                        dir=output_dir,
+                    ) as temp_dir:
+                        temp_skill_path = Path(temp_dir) / skill_dir
+                        temp_skill_path.mkdir(parents=True, exist_ok=True)
+                        (temp_skill_path / 'SKILL.md').write_text(content, encoding='utf-8')
+                        (temp_skill_path / 'metadata.json').write_text(
+                            json.dumps(metadata, indent=2), encoding='utf-8'
+                        )
+                        is_safe, issues = self.security_scanner.scan_file(
+                            temp_skill_path / 'SKILL.md'
+                        )
+
                     if not is_safe:
                         issue_types = sorted(
                             {str(issue.get("type") or "unknown") for issue in issues}
                         )
-                        shutil.rmtree(skill_path, ignore_errors=True)
                         logger.warning(
                             "Rejected discovered skill after security scan: %s/%s (%s)",
                             repo,
@@ -376,6 +382,15 @@ class GitHubTopicDiscovery:
                             ", ".join(issue_types[:8]),
                         )
                         return False
+
+                    skill_path = ensure_unique_dir(output_dir / category, skill_dir, key, repo=repo)
+                    skill_path.mkdir(parents=True, exist_ok=True)
+
+                    metadata['dir_name'] = skill_path.name
+                    (skill_path / 'SKILL.md').write_text(content, encoding='utf-8')
+                    (skill_path / 'metadata.json').write_text(
+                        json.dumps(metadata, indent=2), encoding='utf-8'
+                    )
 
                     return True
             except Exception as e:

--- a/tests/test_discover_by_topic_learning_outputs.py
+++ b/tests/test_discover_by_topic_learning_outputs.py
@@ -160,3 +160,53 @@ def test_download_skill_removes_security_scan_failure(tmp_path):
 
     assert downloaded is False
     assert not list(tmp_path.rglob("SKILL.md"))
+
+
+def test_download_skill_preserves_existing_archive_on_security_scan_failure(tmp_path):
+    module = load_module()
+    discovery = module.GitHubTopicDiscovery(request_delay=0.0)
+    discovery.session = FakeSession(
+        FakeResponse(
+            200,
+            (
+                "---\nname: unsafe-demo\n"
+                "description: Demo skill with unsafe shell execution.\n---\n"
+                "# Unsafe Demo\n"
+                "```python\n"
+                "import subprocess\n"
+                "subprocess.run('echo unsafe', shell=True)\n"
+                "```\n"
+            ),
+        )
+    )
+
+    existing_dir = tmp_path / "skills" / "other" / "unsafe-demo"
+    existing_dir.mkdir(parents=True)
+    existing_skill = (
+        "---\nname: unsafe-demo\n"
+        "description: Previously archived safe version.\n---\n"
+        "# Existing Demo\n"
+    )
+    existing_metadata = module.json.dumps(
+        {
+            "name": "unsafe-demo",
+            "repo": "acme/unsafe-demo",
+            "path": "skills/unsafe-demo/SKILL.md",
+            "category": "other",
+            "source": "github.com/acme/unsafe-demo",
+            "dir_name": "unsafe-demo",
+        },
+        indent=2,
+    )
+    (existing_dir / "SKILL.md").write_text(existing_skill, encoding="utf-8")
+    (existing_dir / "metadata.json").write_text(existing_metadata, encoding="utf-8")
+
+    downloaded = discovery.download_skill(
+        "acme/unsafe-demo",
+        "skills/unsafe-demo/SKILL.md",
+        tmp_path / "skills",
+    )
+
+    assert downloaded is False
+    assert (existing_dir / "SKILL.md").read_text(encoding="utf-8") == existing_skill
+    assert (existing_dir / "metadata.json").read_text(encoding="utf-8") == existing_metadata


### PR DESCRIPTION
## Summary
- scan newly discovered skill content in a temporary directory before touching archive paths
- keep existing archived directories intact when refreshed content fails security scanning
- add regression coverage for same-key archive preservation

## Tests
- pytest tests/test_discover_by_topic_learning_outputs.py -q
- pytest -q
- git diff --check