### PR TITLE
Move CI archive cleanup before discovery

### DIFF
--- a/.github/workflows/sync-data.yml
+++ b/.github/workflows/sync-data.yml
@@ -92,6 +92,9 @@ jobs:
           echo "profile=$profile" >> "$GITHUB_OUTPUT"
           echo "Discovery profile: $profile (event=$EVENT_NAME schedule=$EVENT_SCHEDULE full_scan=$INPUT_FULL_SCAN skip_discovery=$INPUT_SKIP_DISCOVERY)"
 
+      - name: Clean CI archive leftovers before discovery
+        run: python scripts/sync_and_download.py --cleanup-ci-untracked-archive-files-only
+
       - name: Discover new skills from GitHub (full)
         if: steps.discovery.outputs.profile == 'full'
         id: discover_full
@@ -157,6 +160,7 @@ jobs:
           echo "⬇️ Downloading skills from existing registry (full mode)..."
           python scripts/sync_and_download.py \
             --download-only \
+            --skip-ci-untracked-cleanup \
             --fail-on-empty-download \
             --observations-output sources/learning/discovery_observations.jsonl \
             --learning-priors sources/learning/discovery_priors.json 2>&1 | tee download.log
@@ -173,6 +177,7 @@ jobs:
           python scripts/sync_and_download.py \
             --download-only \
             --max-pending 3000 \
+            --skip-ci-untracked-cleanup \
             --fail-on-empty-download \
             --observations-output sources/learning/discovery_observations.jsonl \
             --learning-priors sources/learning/discovery_priors.json 2>&1 | tee download.log

--- a/scripts/sync_and_download.py
+++ b/scripts/sync_and_download.py
@@ -74,6 +74,7 @@ from sync_pipeline_support import (
     load_acquisition_manifest,
     not_found_cooldown_hours,
     prune_negative_cache,
+    remove_ci_untracked_archive_files,
     save_acquisition_manifest,
     select_shard_skills,
     should_recurse_bundled_dir,
@@ -165,6 +166,16 @@ def main():
         help="Exit non-zero when download-only mode records failures but no successful downloads",
     )
     parser.add_argument(
+        "--skip-ci-untracked-cleanup",
+        action="store_true",
+        help="Skip CI-only untracked archive cleanup before download",
+    )
+    parser.add_argument(
+        "--cleanup-ci-untracked-archive-files-only",
+        action="store_true",
+        help="Only remove CI-only untracked archive leftovers, then exit",
+    )
+    parser.add_argument(
         "--acquisition-manifest",
         default="sources/acquisition_manifest.json",
         help="Path to acquisition manifest JSON (relative to repo root unless absolute)",
@@ -238,6 +249,11 @@ def main():
     else:
         learning_priors = registry_dir / learning_priors_arg
 
+    if args.cleanup_ci_untracked_archive_files_only:
+        removed = remove_ci_untracked_archive_files(output_dir)
+        logger.info("CI-only untracked archive cleanup removed %s file(s)", removed)
+        return
+
     github_token = os.environ.get("GITHUB_TOKEN", "")
 
     start_time = time.time()
@@ -293,6 +309,7 @@ def main():
                 failure_report_path=failure_report,
                 observations_output_path=observations_output,
                 learning_priors_path=learning_priors,
+                cleanup_ci_untracked=not args.skip_ci_untracked_cleanup,
             )
         )
         if args.fail_on_empty_download and should_fail_on_empty_download(stats):

--- a/scripts/sync_download.py
+++ b/scripts/sync_download.py
@@ -72,6 +72,7 @@ async def download_skills(
     failure_report_path: Path | None = None,
     observations_output_path: Path | None = None,
     learning_priors_path: Path | None = None,
+    cleanup_ci_untracked: bool = True,
 ) -> dict:
     """Download skills using optimized downloader."""
     logger.info("=" * 60)
@@ -111,7 +112,9 @@ async def download_skills(
         security_blocklist,
         remove_blocked=True,
     )
-    removed_ci_untracked_files = remove_ci_untracked_archive_files(output_dir)
+    removed_ci_untracked_files = (
+        remove_ci_untracked_archive_files(output_dir) if cleanup_ci_untracked else 0
+    )
 
     # Check existing (across all categories)
     exclude = {".git", ".github-skills", ".template", ".templates", ".attic"}

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -71,6 +71,18 @@ def test_sync_data_stages_registry_shard_artifacts():
     assert "git add registry.json registry_summary.json registry-manifest.json registry-shards/" in workflow
 
 
+def test_sync_data_cleans_ci_archive_leftovers_before_discovery():
+    workflow = read_repo_file(".github/workflows/sync-data.yml")
+
+    cleanup_pos = workflow.index("Clean CI archive leftovers before discovery")
+    discovery_pos = workflow.index("Discover new skills from GitHub")
+    download_pos = workflow.index("Download skills from registry")
+
+    assert cleanup_pos < discovery_pos < download_pos
+    assert "--cleanup-ci-untracked-archive-files-only" in workflow
+    assert workflow.count("--skip-ci-untracked-cleanup") == 2
+
+
 def test_metadata_compliance_refuses_unexpected_zero_target_scan():
     workflow = read_repo_file(".github/workflows/metadata-compliance.yml")
 

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -319,6 +319,47 @@ description: Stale file left by the core checkout.
     assert not stale_dir.exists()
 
 
+def test_download_can_skip_ci_untracked_archive_cleanup(tmp_path, monkeypatch):
+    module = load_module()
+    registry_path = tmp_path / "registry.json"
+    output_dir = tmp_path / "skills"
+    discovered_dir = output_dir / "other" / "new-discovery"
+    discovered_dir.mkdir(parents=True)
+    (discovered_dir / "SKILL.md").write_text(
+        """---
+name: new-discovery
+description: Newly discovered in this workflow run.
+---
+
+# Demo
+""",
+        encoding="utf-8",
+    )
+    (discovered_dir / "metadata.json").write_text("{}", encoding="utf-8")
+    registry_path.write_text(json.dumps({"skills": []}), encoding="utf-8")
+    install_fake_aiohttp(monkeypatch, {})
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+
+    subprocess_result = subprocess.run(
+        ["git", "init"],
+        cwd=output_dir,
+        check=True,
+        capture_output=True,
+    )
+    assert subprocess_result.returncode == 0
+
+    stats = asyncio.run(
+        module.download_skills(
+            registry_path,
+            output_dir,
+            cleanup_ci_untracked=False,
+        )
+    )
+
+    assert stats["ci_untracked_files_removed"] == 0
+    assert (discovered_dir / "SKILL.md").exists()
+
+
 def test_existing_archive_blocks_security_listed_github_path(tmp_path):
     module = load_module()
     output_dir = tmp_path / "skills"
@@ -1012,3 +1053,43 @@ def test_main_allows_existing_archive_when_all_pending_fail(monkeypatch):
     )
 
     module.main()
+
+
+def test_main_passes_skip_ci_untracked_cleanup(monkeypatch):
+    module = load_module()
+    captured = {}
+
+    async def fake_download_skills(*args, **kwargs):
+        captured.update(kwargs)
+        return {"downloaded": 0, "failed": 0, "skipped": 0, "total": 0}
+
+    monkeypatch.setattr(module, "download_skills", fake_download_skills)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["sync_and_download.py", "--download-only", "--skip-ci-untracked-cleanup"],
+    )
+
+    module.main()
+
+    assert captured["cleanup_ci_untracked"] is False
+
+
+def test_main_cleanup_only_runs_ci_archive_cleanup(monkeypatch):
+    module = load_module()
+    captured = {}
+
+    def fake_cleanup(output_dir):
+        captured["output_dir"] = output_dir
+        return 2
+
+    monkeypatch.setattr(module, "remove_ci_untracked_archive_files", fake_cleanup)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["sync_and_download.py", "--cleanup-ci-untracked-archive-files-only"],
+    )
+
+    module.main()
+
+    assert captured["output_dir"].name == "skills"


### PR DESCRIPTION
## Summary
- add a cleanup-only mode for CI archive leftovers
- run that cleanup before discovery in sync-data
- skip the second cleanup during download so newly discovered archive files survive bounded downloads
- add workflow contract and downloader regression coverage

## Tests
- pytest tests/test_sync_and_download.py tests/test_pipeline_contracts.py -q
- pytest -q
- git diff --check