### PR TITLE
Load full data for leaderboard rankings

### DIFF
--- a/docs/js/app-render.js
+++ b/docs/js/app-render.js
@@ -12,19 +12,26 @@ function showFeatured() {
 }
 
 // Show leaderboard
-function showLeaderboard(categoryFilter = '') {
+async function showLeaderboard(categoryFilter = '') {
     elements.leaderboardSection.classList.remove('hidden');
+    elements.leaderboardList.innerHTML = '';
 
-    // Get all skills sorted by stars
-    let skills = [...state.index.s].filter(s => s.r > 0);
-
-    // Apply category filter
-    if (categoryFilter) {
-        skills = skills.filter(s => s.c === categoryFilter);
+    let skills;
+    try {
+        skills = categoryFilter
+            ? await loadCategorySkills(categoryFilter)
+            : await loadFullSearchSkills();
+    } catch (error) {
+        console.warn('Failed to load full leaderboard data; using startup index:', error);
+        skills = categoryFilter
+            ? state.index.s.filter(s => s.c === categoryFilter)
+            : state.index.s;
     }
 
     // Sort by stars descending
-    skills.sort((a, b) => (b.r || 0) - (a.r || 0));
+    skills = [...skills]
+        .filter(s => s.r > 0)
+        .sort((a, b) => (b.r || 0) - (a.r || 0));
 
     // Take top N
     const topSkills = skills.slice(0, CONFIG.LEADERBOARD_SIZE);

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -68,6 +68,7 @@ const CATEGORY_COLORS = {
 // State
 let state = {
     index: null,
+    fullIndex: null,
     fuse: null,
     featured: [],
     plugins: [],
@@ -331,6 +332,18 @@ async function loadCategorySkills(categoryCode) {
         .map(normalizeSkillRecord);
     state.categoryCache[categoryCode] = skills;
     return skills;
+}
+
+async function loadFullSearchSkills() {
+    if (!state.index?.isLite) {
+        return state.index?.s || [];
+    }
+    if (state.fullIndex) {
+        return state.fullIndex.s;
+    }
+
+    state.fullIndex = await loadSearchIndexUrl(CONFIG.LEGACY_INDEX_URL);
+    return state.fullIndex.s;
 }
 
 async function getFilterBaseSkills() {

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -14,7 +14,21 @@ def test_pages_app_prefers_lite_index_with_full_index_fallback():
     assert "LEGACY_INDEX_URL: 'search-index.json'" in app_js
     assert "function normalizeSearchIndex" in app_js
     assert "function loadSearchIndex" in app_js
+    assert "return await loadSearchIndexUrl(CONFIG.INDEX_URL)" in app_js
+    assert "return await loadSearchIndexUrl(CONFIG.LEGACY_INDEX_URL)" in app_js
     assert "in highlighted index" in app_js
+
+
+def test_pages_leaderboard_loads_full_data_before_ranking():
+    app_js = read_repo_file("docs/js/app.js")
+    render_js = read_repo_file("docs/js/app-render.js")
+
+    assert "fullIndex: null" in app_js
+    assert "async function loadFullSearchSkills()" in app_js
+    assert "loadSearchIndexUrl(CONFIG.LEGACY_INDEX_URL)" in app_js
+    assert "async function showLeaderboard" in render_js
+    assert "await loadCategorySkills(categoryFilter)" in render_js
+    assert "await loadFullSearchSkills()" in render_js
 
 
 def test_publish_sync_runs_generated_size_guard_after_rebuild():


### PR DESCRIPTION
## Summary
- cache the full sharded search index for global leaderboard rankings
- load category part manifests before category-specific leaderboard ranking
- keep lite startup index as fallback only when full leaderboard data cannot be loaded
- add page contract coverage for awaited fallback and full-data leaderboard loading

## Tests
- pytest tests/test_pipeline_contracts.py -q
- node --check docs/js/app.js
- node --check docs/js/app-render.js
- git diff --check
- pytest -q