### PR TITLE
Scan staged discovery refresh archives

### DIFF
--- a/scripts/discover_by_topic.py
+++ b/scripts/discover_by_topic.py
@@ -8,6 +8,7 @@ import os
 import json
 import time
 import logging
+import shutil
 import tempfile
 from collections import defaultdict
 import requests
@@ -384,9 +385,38 @@ class GitHubTopicDiscovery:
                         return False
 
                     skill_path = ensure_unique_dir(output_dir / category, skill_dir, key, repo=repo)
-                    skill_path.mkdir(parents=True, exist_ok=True)
-
                     metadata['dir_name'] = skill_path.name
+
+                    with tempfile.TemporaryDirectory(
+                        prefix=".discover-final-scan-",
+                        dir=output_dir,
+                    ) as temp_dir:
+                        staged_skill_path = Path(temp_dir) / skill_path.name
+                        if skill_path.exists():
+                            shutil.copytree(skill_path, staged_skill_path)
+                        else:
+                            staged_skill_path.mkdir(parents=True, exist_ok=True)
+                        (staged_skill_path / 'SKILL.md').write_text(content, encoding='utf-8')
+                        (staged_skill_path / 'metadata.json').write_text(
+                            json.dumps(metadata, indent=2), encoding='utf-8'
+                        )
+                        is_safe, issues = self.security_scanner.scan_file(
+                            staged_skill_path / 'SKILL.md'
+                        )
+
+                    if not is_safe:
+                        issue_types = sorted(
+                            {str(issue.get("type") or "unknown") for issue in issues}
+                        )
+                        logger.warning(
+                            "Rejected discovered skill after final archive scan: %s/%s (%s)",
+                            repo,
+                            path,
+                            ", ".join(issue_types[:8]),
+                        )
+                        return False
+
+                    skill_path.mkdir(parents=True, exist_ok=True)
                     (skill_path / 'SKILL.md').write_text(content, encoding='utf-8')
                     (skill_path / 'metadata.json').write_text(
                         json.dumps(metadata, indent=2), encoding='utf-8'

--- a/tests/test_discover_by_topic_learning_outputs.py
+++ b/tests/test_discover_by_topic_learning_outputs.py
@@ -210,3 +210,52 @@ def test_download_skill_preserves_existing_archive_on_security_scan_failure(tmp_
     assert downloaded is False
     assert (existing_dir / "SKILL.md").read_text(encoding="utf-8") == existing_skill
     assert (existing_dir / "metadata.json").read_text(encoding="utf-8") == existing_metadata
+
+
+def test_download_skill_scans_existing_bundled_files_before_refresh(tmp_path):
+    module = load_module()
+    discovery = module.GitHubTopicDiscovery(request_delay=0.0)
+    discovery.session = FakeSession(
+        FakeResponse(
+            200,
+            (
+                "---\nname: bundled-demo\n"
+                "description: Safe refreshed skill content.\n---\n"
+                "# Refreshed Demo\n"
+            ),
+        )
+    )
+
+    existing_dir = tmp_path / "skills" / "other" / "bundled-demo"
+    existing_dir.mkdir(parents=True)
+    (existing_dir / "scripts").mkdir()
+    existing_skill = (
+        "---\nname: bundled-demo\n"
+        "description: Previously archived version.\n---\n"
+        "# Existing Demo\n"
+    )
+    existing_metadata = module.json.dumps(
+        {
+            "name": "bundled-demo",
+            "repo": "acme/bundled-demo",
+            "path": "skills/bundled-demo/SKILL.md",
+            "category": "other",
+            "source": "github.com/acme/bundled-demo",
+            "dir_name": "bundled-demo",
+        },
+        indent=2,
+    )
+    (existing_dir / "SKILL.md").write_text(existing_skill, encoding="utf-8")
+    (existing_dir / "metadata.json").write_text(existing_metadata, encoding="utf-8")
+    (existing_dir / "scripts" / "tool.py").write_text("eval('unsafe')\n", encoding="utf-8")
+
+    downloaded = discovery.download_skill(
+        "acme/bundled-demo",
+        "skills/bundled-demo/SKILL.md",
+        tmp_path / "skills",
+    )
+
+    assert downloaded is False
+    assert (existing_dir / "SKILL.md").read_text(encoding="utf-8") == existing_skill
+    assert (existing_dir / "metadata.json").read_text(encoding="utf-8") == existing_metadata
+    assert (existing_dir / "scripts" / "tool.py").exists()


### PR DESCRIPTION
## Summary
- scan refreshed discovery content in a staging copy of the final archive directory
- include existing bundled support files in the final safety decision before writing back
- preserve the existing archive when stale bundled content causes the final scan to fail

## Tests
- pytest tests/test_discover_by_topic_learning_outputs.py -q
- pytest -q
- git diff --check