### PR TITLE
Normalize security blocklist source forms

### DIFF
--- a/scripts/security_blocklist.py
+++ b/scripts/security_blocklist.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 ROOT_DIR = SCRIPT_DIR.parent
@@ -15,16 +16,44 @@ DEFAULT_BLOCKLIST_PATH = ROOT_DIR / "sources" / "security_blocklist.json"
 def normalize_repo_id(repo: str) -> str:
     """Normalize GitHub repo identifiers to lowercase owner/name form."""
     repo = (repo or "").strip()
-    for prefix in ("https://github.com/", "http://github.com/", "github.com/"):
-        if repo.startswith(prefix):
-            repo = repo[len(prefix):]
-            break
+    lowered = repo.lower()
+    parsed_github_url = False
+    if lowered.startswith("git@github.com:"):
+        repo = repo.split(":", 1)[1]
+    elif "://" in repo:
+        parsed = urlparse(repo)
+        if (parsed.hostname or "").lower() in {
+            "github.com",
+            "www.github.com",
+            "raw.githubusercontent.com",
+        }:
+            repo = parsed.path
+            parsed_github_url = True
+    else:
+        for prefix in ("github.com/", "www.github.com/"):
+            if lowered.startswith(prefix):
+                repo = repo[len(prefix):]
+                break
+    if not parsed_github_url:
+        for prefix in (
+            "https://github.com/",
+            "http://github.com/",
+            "https://www.github.com/",
+            "http://www.github.com/",
+        ):
+            if lowered.startswith(prefix):
+                repo = repo[len(prefix):]
+                break
+    repo = repo.split("?", 1)[0].split("#", 1)[0]
     repo = repo.split("/tree/")[0]
     repo = repo.split("/blob/")[0]
     repo = repo.strip("/")
     parts = [part for part in repo.split("/") if part]
     if len(parts) >= 2:
-        return f"{parts[0]}/{parts[1]}".lower()
+        repo_name = parts[1]
+        if repo_name.lower().endswith(".git"):
+            repo_name = repo_name[:-4]
+        return f"{parts[0]}/{repo_name}".lower()
     return repo.lower()
 
 
@@ -84,6 +113,9 @@ def blocked_metadata_source(
         value = metadata.get(field)
         if not isinstance(value, str):
             continue
+        entry = blocked_repo_entry(value, blocklist)
+        if entry:
+            return entry, field
         normalized_path = value.strip().strip("/").lower()
         for repo, entry in blocklist.items():
             if normalized_path == repo or normalized_path.startswith(f"{repo}/"):

--- a/tests/test_security_blocklist.py
+++ b/tests/test_security_blocklist.py
@@ -49,6 +49,22 @@ def test_blocked_repo_entry_normalizes_urls(tmp_path):
     assert entry["repo"] == "owner/repo"
 
 
+@pytest.mark.parametrize(
+    "repo",
+    [
+        "git@github.com:Owner/Repo.git",
+        "ssh://git@github.com/Owner/Repo.git",
+        "https://github.com/Owner/Repo.git",
+        "https://github.com/Owner/Repo.git/blob/main/SKILL.md",
+        "https://raw.githubusercontent.com/Owner/Repo/main/SKILL.md",
+    ],
+)
+def test_normalize_repo_id_handles_common_git_forms(repo):
+    module = load_module()
+
+    assert module.normalize_repo_id(repo) == "owner/repo"
+
+
 def test_blocked_metadata_source_matches_github_path_prefix():
     module = load_module()
     blocklist = {
@@ -63,6 +79,30 @@ def test_blocked_metadata_source_matches_github_path_prefix():
         {
             "repo": "blisspixel/primr",
             "github_path": "openclaw/skills/primr-strategy",
+        },
+        blocklist,
+    )
+
+    assert result is not None
+    entry, field = result
+    assert entry["repo"] == "openclaw/skills"
+    assert field == "github_path"
+
+
+def test_blocked_metadata_source_matches_github_path_url():
+    module = load_module()
+    blocklist = {
+        "openclaw/skills": {
+            "repo": "openclaw/skills",
+            "reason": "test",
+            "action": "reject",
+        }
+    }
+
+    result = module.blocked_metadata_source(
+        {
+            "repo": "blisspixel/primr",
+            "github_path": "https://github.com/openclaw/skills/tree/main/primr-strategy",
         },
         blocklist,
     )


### PR DESCRIPTION
## Summary
- normalize common GitHub repo forms before blocklist lookup, including SSH and .git URLs
- apply repo normalization to github_path/path metadata before prefix matching
- add regression coverage for alternate repo strings and GitHub URL path metadata

## Tests
- pytest tests/test_security_blocklist.py tests/test_security_scanner.py tests/test_sync_and_download.py -q
- pytest -q
- git diff --check