### PR TITLE
Load registry manifest shards in index fallback

### DIFF
--- a/scripts/build_search_index.py
+++ b/scripts/build_search_index.py
@@ -719,13 +719,41 @@ def build_search_index(
     return stats
 
 
-def load_from_registry(registry_path: Path) -> List[Dict]:
-    """Load skills from registry.json (fallback mode)."""
-    with open(registry_path, 'r', encoding='utf-8') as f:
-        registry = json.load(f)
+def resolve_registry_artifact(base_dir: Path, artifact_ref: str) -> Path:
+    """Resolve a registry artifact path relative to a manifest or registry directory."""
+    artifact_path = Path(artifact_ref)
+    if artifact_path.is_absolute():
+        return artifact_path
+    return (base_dir / artifact_path).resolve()
 
-    skills = registry.get('skills', [])
 
+def load_registry_manifest_shards(registry_path: Path, registry: Dict) -> List[Dict]:
+    """Load full registry skills from a compatibility registry manifest pointer."""
+    manifest_ref = registry.get("manifest")
+    if not isinstance(manifest_ref, str) or not manifest_ref.strip():
+        return []
+
+    manifest_path = resolve_registry_artifact(registry_path.parent, manifest_ref)
+    with open(manifest_path, 'r', encoding='utf-8') as f:
+        manifest = json.load(f)
+
+    skills: List[Dict] = []
+    for shard in manifest.get("shards", []):
+        shard_ref = shard.get("path") if isinstance(shard, dict) else None
+        if not isinstance(shard_ref, str) or not shard_ref.strip():
+            raise ValueError(f"Invalid registry shard reference in {manifest_path}: {shard!r}")
+        shard_path = resolve_registry_artifact(manifest_path.parent, shard_ref)
+        with open(shard_path, 'r', encoding='utf-8') as f:
+            shard_payload = json.load(f)
+        shard_skills = shard_payload.get("skills")
+        if not isinstance(shard_skills, list):
+            raise ValueError(f"Registry shard is missing skills array: {shard_path}")
+        skills.extend(shard_skills)
+    return skills
+
+
+def add_registry_install_fields(skills: List[Dict]) -> List[Dict]:
+    """Populate install fields for registry fallback rows."""
     for skill in skills:
         repo = skill.get('repo', '')
         path = skill.get('path', '')
@@ -740,6 +768,18 @@ def load_from_registry(registry_path: Path) -> List[Dict]:
             skill['install'] = f"local/{name}"
 
     return skills
+
+
+def load_from_registry(registry_path: Path) -> List[Dict]:
+    """Load skills from registry.json or its manifest shards (fallback mode)."""
+    with open(registry_path, 'r', encoding='utf-8') as f:
+        registry = json.load(f)
+
+    skills = registry.get('skills')
+    if not isinstance(skills, list):
+        skills = load_registry_manifest_shards(registry_path, registry)
+
+    return add_registry_install_fields(skills)
 
 
 def main():

--- a/tests/test_plugin_contract.py
+++ b/tests/test_plugin_contract.py
@@ -400,6 +400,39 @@ def test_load_from_registry_reconstructs_install_without_embedded_install_field(
     ]
 
 
+def test_load_from_registry_reads_manifest_shards(tmp_path):
+    registry_path = tmp_path / "registry.json"
+    manifest_path = tmp_path / "registry-manifest.json"
+    shards_dir = tmp_path / "registry-shards"
+    shards_dir.mkdir()
+    (shards_dir / "00.json").write_text(
+        json.dumps(
+            {
+                "skills": [
+                    {"name": "alpha", "repo": "owner/repo", "path": "skills/alpha/SKILL.md"},
+                    {"name": "beta", "repo": "owner/repo", "path": "skills/beta/SKILL.md"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    manifest_path.write_text(
+        json.dumps({"shards": [{"path": "registry-shards/00.json", "count": 2}]}),
+        encoding="utf-8",
+    )
+    registry_path.write_text(
+        json.dumps({"deprecated_full_payload": True, "manifest": "registry-manifest.json"}),
+        encoding="utf-8",
+    )
+
+    skills = build_search_index.load_from_registry(registry_path)
+
+    assert [skill["install"] for skill in skills] == [
+        "owner/repo/skills/alpha/SKILL.md",
+        "owner/repo/skills/beta/SKILL.md",
+    ]
+
+
 def test_safe_write_registry_writes_compact_json(tmp_path):
     registry_path = tmp_path / "registry.json"
 


### PR DESCRIPTION
## Summary
- teach build_search_index registry fallback to load manifest-backed registry shards
- preserve install reconstruction for shard-loaded rows
- add regression coverage for compatibility registry pointers without embedded skills

## Tests
- pytest tests/test_plugin_contract.py tests/test_build_search_index.py -q
- python -m py_compile scripts/build_search_index.py
- pytest -q
- git diff --check