### PR TITLE
Refresh legal backfill cache placeholders

### DIFF
--- a/scripts/backfill_legal_metadata.py
+++ b/scripts/backfill_legal_metadata.py
@@ -134,6 +134,12 @@ def fetch_repo_license(repo: str, token: str, timeout: int) -> dict[str, str]:
     }
 
 
+def is_refetchable_license_result(result: dict[str, str]) -> bool:
+    """Return True for cache entries produced without durable GitHub license data."""
+    error = str(result.get("error") or "")
+    return error == "not_fetched" or error.startswith("fetch_error:") or error == "fetch_failed"
+
+
 def load_or_fetch_license(
     repo: str,
     cache: dict[str, dict[str, str]],
@@ -143,14 +149,16 @@ def load_or_fetch_license(
     timeout: int,
     sleep_seconds: float,
 ) -> dict[str, str]:
-    if repo in cache:
-        return cache[repo]
+    cached = cache.get(repo)
+    if cached and not (fetch and is_refetchable_license_result(cached)):
+        return cached
     if not fetch:
         cache[repo] = {"license": "NOASSERTION", "copyright": "", "error": "not_fetched"}
         return cache[repo]
 
     result = fetch_repo_license(repo, token=token, timeout=timeout)
-    cache[repo] = result
+    if not is_refetchable_license_result(result):
+        cache[repo] = result
     if sleep_seconds > 0:
         time.sleep(sleep_seconds)
     return result
@@ -158,8 +166,18 @@ def load_or_fetch_license(
 
 def backfill_metadata(metadata: dict[str, Any], repo_license: dict[str, str]) -> dict[str, Any]:
     repo = normalize_repo(str(metadata.get("repo") or ""))
-    license_name = metadata.get("license") or repo_license.get("license") or "NOASSERTION"
-    copyright_text = metadata.get("copyright") or repo_license.get("copyright") or ""
+    current_license = metadata.get("license")
+    current_copyright = metadata.get("copyright")
+    license_name = (
+        current_license
+        if not is_missing(current_license)
+        else repo_license.get("license") or "NOASSERTION"
+    )
+    copyright_text = (
+        current_copyright
+        if not is_missing(current_copyright)
+        else repo_license.get("copyright") or ""
+    )
 
     legal = build_legal_metadata(
         repo=repo,

--- a/tests/test_backfill_legal_metadata.py
+++ b/tests/test_backfill_legal_metadata.py
@@ -64,6 +64,27 @@ def test_backfill_metadata_uses_repo_license_cache():
     assert updated["license_class"] == "compatible"
 
 
+def test_backfill_metadata_uses_repo_license_for_placeholder_values():
+    module = load_module()
+    metadata = {
+        "name": "demo",
+        "repo": "owner/repo",
+        "category": "development",
+        "dir_name": "demo",
+        "github_path": ".github/skills/demo",
+        "license": "unknown",
+        "copyright": "n/a",
+    }
+
+    updated = module.backfill_metadata(
+        metadata,
+        {"license": "MIT", "copyright": "Copyright (c) 2026 Owner"},
+    )
+
+    assert updated["license"] == "MIT"
+    assert updated["copyright"] == "Copyright (c) 2026 Owner"
+
+
 def test_extract_copyright_notice_ignores_apache_definition_lines():
     module = load_module()
     license_text = """
@@ -119,6 +140,59 @@ def test_fetch_repo_license_degrades_after_incomplete_read(monkeypatch):
 
     assert result["license"] == "NOASSERTION"
     assert result["error"].startswith("fetch_error:IncompleteRead")
+
+
+def test_load_or_fetch_license_refetches_dry_run_placeholder(monkeypatch):
+    module = load_module()
+    cache = {"owner/repo": {"license": "NOASSERTION", "copyright": "", "error": "not_fetched"}}
+
+    monkeypatch.setattr(
+        module,
+        "fetch_repo_license",
+        lambda *args, **kwargs: {
+            "license": "MIT",
+            "copyright": "Copyright (c) 2026 Owner",
+        },
+    )
+
+    result = module.load_or_fetch_license(
+        "owner/repo",
+        cache,
+        fetch=True,
+        token="",
+        timeout=1,
+        sleep_seconds=0,
+    )
+
+    assert result["license"] == "MIT"
+    assert cache["owner/repo"]["license"] == "MIT"
+
+
+def test_load_or_fetch_license_does_not_cache_transient_fetch_errors(monkeypatch):
+    module = load_module()
+    cache = {}
+
+    monkeypatch.setattr(
+        module,
+        "fetch_repo_license",
+        lambda *args, **kwargs: {
+            "license": "NOASSERTION",
+            "copyright": "",
+            "error": "fetch_error:tls eof",
+        },
+    )
+
+    result = module.load_or_fetch_license(
+        "owner/repo",
+        cache,
+        fetch=True,
+        token="",
+        timeout=1,
+        sleep_seconds=0,
+    )
+
+    assert result["error"] == "fetch_error:tls eof"
+    assert "owner/repo" not in cache
 
 
 def test_license_classification_covers_backfill_spdx_values():


### PR DESCRIPTION
## Summary
- refetch dry-run not_fetched license cache placeholders when GitHub fetching is enabled
- avoid caching transient fetch-error license results
- treat placeholder legal metadata values as missing before repo-license fallback

## Tests
- pytest tests/test_backfill_legal_metadata.py -q
- python -m py_compile scripts/backfill_legal_metadata.py
- pytest -q
- git diff --check