### PR TITLE
Gate publish notices on metadata compliance

### DIFF
--- a/scripts/sync_main_repo.sh
+++ b/scripts/sync_main_repo.sh
@@ -79,7 +79,6 @@ echo "Generating third-party notices..."
 python "$main_dir/scripts/check_metadata_compliance.py" \
   --skills-dir "$main_dir/skills" \
   --metadata-schema "$main_dir/schema/metadata.schema.json" \
-  --notices "$main_dir/THIRD_PARTY_NOTICES.md" \
-  --report-only
+  --notices "$main_dir/THIRD_PARTY_NOTICES.md"
 
 echo "Done."

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -45,6 +45,15 @@ def test_publish_sync_runs_generated_size_guard_after_rebuild():
     assert "--categories-dir" in sync_script
 
 
+def test_publish_sync_metadata_compliance_is_strict_for_notices():
+    sync_script = read_repo_file("scripts/sync_main_repo.sh")
+    notices_block = sync_script[sync_script.index("Generating third-party notices...") :]
+
+    assert "scripts/check_metadata_compliance.py" in notices_block
+    assert "--notices \"$main_dir/THIRD_PARTY_NOTICES.md\"" in notices_block
+    assert "--report-only" not in notices_block
+
+
 def test_build_index_fails_closed_when_security_report_is_missing():
     workflow = read_repo_file(".github/workflows/build-index.yml")
 


### PR DESCRIPTION
## Summary
- remove report-only mode from the publish-side metadata compliance notice generation
- add a pipeline contract test that keeps the publish notices scan strict

## Tests
- pytest tests/test_pipeline_contracts.py -q
- git diff --check
- pytest -q