### PR TITLE
Reject community top-level metadata edits

### DIFF
--- a/scripts/check_community_intake_diff.py
+++ b/scripts/check_community_intake_diff.py
@@ -75,6 +75,21 @@ def validate_community_intake_text(base_text: str, head_text: str) -> list[str]:
         if base_payload.get(key) != head_payload.get(key):
             errors.append(f"top-level `{key}` must not change in community intake PRs")
 
+    base_metadata = {
+        key: value
+        for key, value in base_payload.items()
+        if key not in {"name", "description", "skills"}
+    }
+    head_metadata = {
+        key: value
+        for key, value in head_payload.items()
+        if key not in {"name", "description", "skills"}
+    }
+    if base_metadata != head_metadata:
+        errors.append(
+            "top-level metadata fields other than `skills` must not change in community intake PRs"
+        )
+
     base_skills = base_payload["skills"]
     head_skills = head_payload["skills"]
 

--- a/tests/test_check_community_intake_diff.py
+++ b/tests/test_check_community_intake_diff.py
@@ -222,3 +222,45 @@ def test_rejects_reformatting_before_final_existing_entry():
     assert validate_community_intake_text(base, head) == [
         "community intake PRs must not rewrite lines before the final existing catalog entry"
     ]
+
+
+def test_rejects_appended_top_level_metadata_fields():
+    base = render_catalog(
+        [
+            {
+                "name": "alpha",
+                "repo": "acme/alpha",
+                "path": "",
+                "description": "A",
+                "category": "development",
+                "tags": ["a"],
+                "stars": 0,
+            },
+        ]
+    )
+    head = render_catalog(
+        [
+            {
+                "name": "alpha",
+                "repo": "acme/alpha",
+                "path": "",
+                "description": "A",
+                "category": "development",
+                "tags": ["a"],
+                "stars": 0,
+            },
+            {
+                "name": "beta",
+                "repo": "acme/beta",
+                "path": "",
+                "description": "B",
+                "category": "development",
+                "tags": ["b"],
+                "stars": 0,
+            },
+        ]
+    ).replace('  ]\n}', '  ],\n  "owner": "acme"\n}')
+
+    assert validate_community_intake_text(base, head) == [
+        "top-level metadata fields other than `skills` must not change in community intake PRs"
+    ]


### PR DESCRIPTION
## Summary
- compare all non-skills top-level community catalog metadata during intake validation
- add a regression test for appending a new top-level field after the skills block

## Tests
- pytest tests/test_check_community_intake_diff.py -q
- git diff --check
- pytest -q