### PR TITLE
Honor disabled acquisition manifest

### DIFF
--- a/scripts/sync_download.py
+++ b/scripts/sync_download.py
@@ -66,7 +66,7 @@ async def download_skills(
     output_dir: Path,
     github_token: str = "",
     max_pending: int = 0,
-    manifest_path: Path | None = None,
+    manifest_path: Path | None = DEFAULT_MANIFEST_PATH,
     shard_count: int = 1,
     shard_index: int = 0,
     failure_report_path: Path | None = None,
@@ -97,13 +97,18 @@ async def download_skills(
 
     skills = registry.get("skills", [])
     logger.info(f"Total skills in registry: {len(skills)}")
-    manifest_file = manifest_path or DEFAULT_MANIFEST_PATH
-    manifest_entries = load_acquisition_manifest(manifest_file)
-    logger.info(
-        "Acquisition manifest loaded: %s entries from %s",
-        len(manifest_entries),
-        manifest_file,
+    manifest_file = Path(manifest_path) if manifest_path is not None else None
+    manifest_entries = (
+        load_acquisition_manifest(manifest_file) if manifest_file is not None else {}
     )
+    if manifest_file is not None:
+        logger.info(
+            "Acquisition manifest loaded: %s entries from %s",
+            len(manifest_entries),
+            manifest_file,
+        )
+    else:
+        logger.info("Acquisition manifest disabled")
     security_blocklist = load_security_blocklist()
     logger.info("Security blocklist loaded: %s repos", len(security_blocklist))
     security_scanner = SecurityScanner()
@@ -527,11 +532,14 @@ async def download_skills(
             return False
 
         manifest_key = build_manifest_key(repo, path, name, category)
-        manifest_entry = manifest_entries.get(manifest_key)
-        if manifest_entry:
-            stats["manifest_hits"] += 1
-        else:
-            stats["manifest_misses"] += 1
+        manifest_entry = (
+            manifest_entries.get(manifest_key) if manifest_file is not None else None
+        )
+        if manifest_file is not None:
+            if manifest_entry:
+                stats["manifest_hits"] += 1
+            else:
+                stats["manifest_misses"] += 1
 
         relative_candidates = build_relative_candidates(path, name, normalized_name)
         relative_candidates = build_relative_probe_order(relative_candidates, manifest_entry)
@@ -653,13 +661,14 @@ async def download_skills(
                                         )
                                         return False
                                     preferred_branch_by_repo[repo] = branch
-                                    manifest_entries[manifest_key] = {
-                                        "repo": repo,
-                                        "branch": branch,
-                                        "relative_path": relative_path,
-                                        "updated_at": datetime.utcnow().isoformat() + "Z",
-                                    }
-                                    manifest_state["dirty"] = True
+                                    if manifest_file is not None:
+                                        manifest_entries[manifest_key] = {
+                                            "repo": repo,
+                                            "branch": branch,
+                                            "relative_path": relative_path,
+                                            "updated_at": datetime.utcnow().isoformat() + "Z",
+                                        }
+                                        manifest_state["dirty"] = True
                                     stats["url_attempts"] += attempts
                                     if candidate_key in negative_cache:
                                         del negative_cache[candidate_key]
@@ -744,7 +753,7 @@ async def download_skills(
 
     # Final count
     final_count = sum(1 for _ in output_dir.rglob("SKILL.md"))
-    if manifest_state["dirty"] or not manifest_file.exists():
+    if manifest_file is not None and (manifest_state["dirty"] or not manifest_file.exists()):
         save_acquisition_manifest(manifest_file, manifest_entries)
         logger.info(
             "Acquisition manifest saved: %s entries to %s",

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -466,6 +466,72 @@ def test_probe_order_removes_duplicates():
     assert path_order == ["skills/demo/SKILL.md", "SKILL.md"]
 
 
+def test_download_skills_can_disable_acquisition_manifest(tmp_path, monkeypatch):
+    module = load_module()
+    registry_path = tmp_path / "registry.json"
+    output_dir = tmp_path / "skills"
+    failure_report_path = tmp_path / "failure_report.json"
+    default_manifest = tmp_path / "default_manifest.json"
+    stale_manifest = {
+        "entries": {
+            "acme/demo:skills/demo": {
+                "repo": "acme/demo",
+                "branch": "release",
+                "relative_path": "stale/SKILL.md",
+                "updated_at": "2026-04-10T00:00:00Z",
+            }
+        }
+    }
+    default_manifest.write_text(json.dumps(stale_manifest), encoding="utf-8")
+    monkeypatch.setitem(
+        module.download_skills.__globals__,
+        "DEFAULT_MANIFEST_PATH",
+        default_manifest,
+    )
+    registry_path.write_text(
+        json.dumps(
+            {
+                "skills": [
+                    {
+                        "name": "demo",
+                        "repo": "acme/demo",
+                        "path": "skills/demo",
+                        "category": "development",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    install_fake_aiohttp(
+        monkeypatch,
+        {
+            "https://raw.githubusercontent.com/acme/demo/main/skills/demo/SKILL.md": FakeResponse(
+                200,
+                text=(
+                    "---\nname: demo\n"
+                    "description: Demo skill without manifest help.\n---\n"
+                    "# Demo\nUse this skill directly.\n"
+                ),
+            ),
+        },
+    )
+
+    stats = asyncio.run(
+        module.download_skills(
+            registry_path,
+            output_dir,
+            manifest_path=None,
+            failure_report_path=failure_report_path,
+        )
+    )
+
+    assert stats["downloaded"] == 1
+    assert stats["manifest_hits"] == 0
+    assert stats["manifest_misses"] == 0
+    assert json.loads(default_manifest.read_text(encoding="utf-8")) == stale_manifest
+
+
 def test_skill_source_dir_resolves_skill_parent():
     module = load_module()
 


### PR DESCRIPTION
## Summary
- treat manifest_path=None as an explicit acquisition manifest disable in the downloader
- avoid manifest hit/miss accounting and write-back when manifest use is disabled
- add a regression test proving stale default manifest data does not affect disabled runs

## Tests
- pytest tests/test_sync_and_download.py -q
- git diff --check
- pytest -q