### PR TITLE
Preserve markdown source file URLs

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -115,8 +115,8 @@ def build_source_url(repo: str = "", path: str = "", branch: str = "main") -> st
     if not path:
         return f"https://github.com/{repo}"
 
-    # path may be folder or file path
-    if not path.lower().endswith("skill.md"):
+    # path may be a folder or a direct markdown file path
+    if not path.lower().endswith(".md"):
         path = f"{path}/SKILL.md"
     return f"https://github.com/{repo}/blob/{branch}/{path}"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -144,6 +144,10 @@ def test_build_source_url_handles_repo_only_and_path(utils):
         utils.build_source_url(repo="owner/repo", path="skills/demo/SKILL.md")
         == "https://github.com/owner/repo/blob/main/skills/demo/SKILL.md"
     )
+    assert (
+        utils.build_source_url(repo="owner/repo", path="packs/core/skills/memory-protocol.md")
+        == "https://github.com/owner/repo/blob/main/packs/core/skills/memory-protocol.md"
+    )
 
 
 def test_build_source_url_passthrough_for_external_url(utils):


### PR DESCRIPTION
## Summary
- treat direct markdown paths as file paths when building GitHub source URLs
- keep folder paths suffixed with SKILL.md as before
- add a regression test for non-SKILL markdown file paths

## Tests
- pytest tests/test_utils.py -q
- git diff --check
- pytest -q