### PR TITLE
Canonicalize root skill path keys

### DIFF
--- a/scripts/sync_pipeline.py
+++ b/scripts/sync_pipeline.py
@@ -14,7 +14,7 @@ sys.path.insert(0, str(ROOT_DIR))
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from discover_by_topic import GitHubTopicDiscovery
-from utils import iter_source_skills
+from utils import build_skill_key, iter_source_skills
 
 from crawler.skillsmp_sync import SkillsMPSync
 
@@ -113,7 +113,14 @@ def build_unified_registry(
             repo = skill.get("repo", "")
             name = skill.get("name", "")
             path = skill.get("path", "")
-            key = f"{repo}/{path}/{name}"
+            if isinstance(path, str) and path.strip().strip("/") == ".":
+                path = ""
+            key = build_skill_key(
+                repo,
+                path,
+                name=name,
+                category=skill.get("category", "development"),
+            )
 
             if key in seen:
                 continue

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -231,10 +231,19 @@ def normalize_category(category: str) -> str:
     return name[:32] if name else "other"
 
 
+def _normalize_skill_key_path(path: str = "") -> str:
+    normalized = (path or "").strip().replace("\\", "/").strip("/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    if normalized == "." or normalized.lower() == "skill.md":
+        return ""
+    return normalized
+
+
 def build_skill_key(repo: str = "", path: str = "", name: str = "", category: str = "") -> str:
     """Build a stable key for a skill to detect duplicates."""
     repo = (repo or "").strip()
-    path = (path or "").strip().lstrip("/")
+    path = _normalize_skill_key_path(path)
     if repo and path:
         return f"{repo}:{path}"
     if repo:

--- a/scripts/validate_sources.py
+++ b/scripts/validate_sources.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from category_taxonomy import category_aliases, category_slug, known_categories
+from utils import build_skill_key
 
 # -- Canonical category rules -------------------------------------------------
 
@@ -286,10 +287,15 @@ def validate_skill_entry(
             )
         )
 
-    # De-duplication key across all sources. Use repo+path because the same
-    # repo can host several skills under different paths.
+    # De-duplication key across all sources. Use the shared key builder so
+    # repo-root spellings such as "", ".", and "SKILL.md" collapse together.
     if isinstance(repo, str) and (path is None or isinstance(path, str)):
-        key = f"{repo.strip()}:{(path or '').strip().strip('/')}"
+        key = build_skill_key(
+            repo,
+            path or "",
+            name=entry.get("name", ""),
+            category=entry.get("category", ""),
+        )
         if key in report.seen_keys:
             report.add(
                 Issue(

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -120,6 +120,36 @@ def test_build_unified_registry_inherits_top_level_repo(tmp_path):
     assert registry["skills"][0]["repo"] == "anthropics/skills"
 
 
+def test_build_unified_registry_dedupes_root_path_spellings(tmp_path):
+    module = load_module()
+    sources_dir = tmp_path / "sources"
+    sources_dir.mkdir()
+    output_path = tmp_path / "registry.json"
+    root_skill = {
+        "name": "root-skill",
+        "repo": "owner/root-skill",
+        "description": "Repo-root skill.",
+        "category": "productivity",
+    }
+    (sources_dir / "community.json").write_text(
+        json.dumps({"name": "Community", "skills": [root_skill]}),
+        encoding="utf-8",
+    )
+    (sources_dir / "custom.json").write_text(
+        json.dumps(
+            {
+                "name": "Custom",
+                "skills": [{**root_skill, "path": "."}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert module.build_unified_registry(sources_dir, output_path) == 1
+    registry = json.loads(output_path.read_text(encoding="utf-8"))
+    assert registry["skills"][0]["path"] == ""
+
+
 def test_download_blocks_security_listed_source_repo(tmp_path, monkeypatch):
     module = load_module()
     registry_path = tmp_path / "registry.json"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -326,6 +326,9 @@ def test_build_skill_key_priority(utils):
     # Per implementation: repo+path > repo > category:name > "".
     assert utils.build_skill_key(repo="o/r", path="x/y") == "o/r:x/y"
     assert utils.build_skill_key(repo="o/r") == "o/r"
+    assert utils.build_skill_key(repo="o/r", path=".") == "o/r"
+    assert utils.build_skill_key(repo="o/r", path="SKILL.md") == "o/r"
+    assert utils.build_skill_key(repo="o/r", path="./SKILL.md") == "o/r"
     assert utils.build_skill_key(category="dev", name="foo") == "dev:foo"
     assert utils.build_skill_key() == ""
     # path alone is ignored once repo is missing — the category:name fallback wins.

--- a/tests/test_validate_sources.py
+++ b/tests/test_validate_sources.py
@@ -425,6 +425,37 @@ def test_duplicate_keys_across_files_warn(vs, sources, capsys):
     assert "W_DUPLICATE" in out
 
 
+def test_duplicate_root_path_spellings_warn(vs, sources, capsys):
+    _write(
+        sources / "community.json",
+        {
+            "name": "Community",
+            "description": "x",
+            "skills": [
+                {
+                    "name": "root-skill",
+                    "repo": "owner/root-skill",
+                    "path": "",
+                    "description": "Long enough description here.",
+                    "category": "productivity",
+                },
+                {
+                    "name": "root-skill",
+                    "repo": "owner/root-skill",
+                    "path": ".",
+                    "description": "Same root skill with dot path.",
+                    "category": "productivity",
+                },
+            ],
+        },
+    )
+
+    rc = vs.main(["--sources-dir", str(sources)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "W_DUPLICATE" in out
+
+
 def test_short_description_warns(vs, sources, capsys):
     _write(
         sources / "community.json",


### PR DESCRIPTION
## Summary
- canonicalize repo-root path spellings for shared skill identity keys
- use the shared key builder in registry build and source validation dedupe
- add regression coverage for '.', empty path, and SKILL.md root spellings

## Tests
- pytest tests/test_utils.py tests/test_sync_and_download.py tests/test_validate_sources.py -q
- git diff --check
- pytest -q