### PR TITLE
Run publish notices compliance in strict mode

### DIFF
--- a/scripts/sync_main_repo.sh
+++ b/scripts/sync_main_repo.sh
@@ -79,6 +79,7 @@ echo "Generating third-party notices..."
 python "$main_dir/scripts/check_metadata_compliance.py" \
   --skills-dir "$main_dir/skills" \
   --metadata-schema "$main_dir/schema/metadata.schema.json" \
-  --notices "$main_dir/THIRD_PARTY_NOTICES.md"
+  --notices "$main_dir/THIRD_PARTY_NOTICES.md" \
+  --strict
 
 echo "Done."

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -51,6 +51,7 @@ def test_publish_sync_metadata_compliance_is_strict_for_notices():
 
     assert "scripts/check_metadata_compliance.py" in notices_block
     assert "--notices \"$main_dir/THIRD_PARTY_NOTICES.md\"" in notices_block
+    assert "--strict" in notices_block
     assert "--report-only" not in notices_block
 
 


### PR DESCRIPTION
## Summary
- pass --strict when publish sync generates third-party notices
- update the pipeline contract test to require strict mode explicitly

## Tests
- pytest tests/test_pipeline_contracts.py -q
- git diff --check
- pytest -q