### PR TITLE
Stabilize transient license fetch failures per run

### DIFF
--- a/scripts/backfill_legal_metadata.py
+++ b/scripts/backfill_legal_metadata.py
@@ -134,10 +134,25 @@ def fetch_repo_license(repo: str, token: str, timeout: int) -> dict[str, str]:
     }
 
 
-def is_refetchable_license_result(result: dict[str, str]) -> bool:
-    """Return True for cache entries produced without durable GitHub license data."""
+def should_refetch_cached_license(result: dict[str, str]) -> bool:
+    """Return True for durable cache entries that should be refreshed with GitHub fetch."""
     error = str(result.get("error") or "")
-    return error == "not_fetched" or error.startswith("fetch_error:") or error == "fetch_failed"
+    return error == "not_fetched"
+
+
+def is_transient_license_result(result: dict[str, str]) -> bool:
+    """Return True for fetch failures that should not be persisted across runs."""
+    error = str(result.get("error") or "")
+    return error.startswith("fetch_error:") or error == "fetch_failed"
+
+
+def durable_license_cache(cache: dict[str, dict[str, str]]) -> dict[str, dict[str, str]]:
+    """Return cache entries safe to persist between backfill runs."""
+    return {
+        repo: result
+        for repo, result in cache.items()
+        if not is_transient_license_result(result)
+    }
 
 
 def load_or_fetch_license(
@@ -150,15 +165,14 @@ def load_or_fetch_license(
     sleep_seconds: float,
 ) -> dict[str, str]:
     cached = cache.get(repo)
-    if cached and not (fetch and is_refetchable_license_result(cached)):
+    if cached and not (fetch and should_refetch_cached_license(cached)):
         return cached
     if not fetch:
         cache[repo] = {"license": "NOASSERTION", "copyright": "", "error": "not_fetched"}
         return cache[repo]
 
     result = fetch_repo_license(repo, token=token, timeout=timeout)
-    if not is_refetchable_license_result(result):
-        cache[repo] = result
+    cache[repo] = result
     if sleep_seconds > 0:
         time.sleep(sleep_seconds)
     return result
@@ -230,7 +244,7 @@ def main() -> int:
         return 1
 
     token = os.environ.get(args.token_env, "")
-    cache: dict[str, dict[str, str]] = load_json(cache_path, {})
+    cache: dict[str, dict[str, str]] = durable_license_cache(load_json(cache_path, {}))
     changed_files: list[str] = []
     skipped_repos: set[str] = set()
     stats = {
@@ -277,7 +291,7 @@ def main() -> int:
             sleep_seconds=args.sleep,
         )
         if not had_cache:
-            write_json(cache_path, cache)
+            write_json(cache_path, durable_license_cache(cache))
         updated = backfill_metadata(metadata, repo_license)
         if updated == metadata:
             stats["unchanged"] += 1
@@ -293,7 +307,7 @@ def main() -> int:
 
     stats["repos_seen"] = len(repos_seen)
     stats["repos_skipped_by_limit"] = len(skipped_repos)
-    write_json(cache_path, cache)
+    write_json(cache_path, durable_license_cache(cache))
 
     report = {
         **stats,

--- a/tests/test_backfill_legal_metadata.py
+++ b/tests/test_backfill_legal_metadata.py
@@ -168,19 +168,20 @@ def test_load_or_fetch_license_refetches_dry_run_placeholder(monkeypatch):
     assert cache["owner/repo"]["license"] == "MIT"
 
 
-def test_load_or_fetch_license_does_not_cache_transient_fetch_errors(monkeypatch):
+def test_load_or_fetch_license_caches_transient_fetch_errors_for_run(monkeypatch):
     module = load_module()
     cache = {}
+    calls = []
 
-    monkeypatch.setattr(
-        module,
-        "fetch_repo_license",
-        lambda *args, **kwargs: {
+    def fetch_repo_license(*args, **kwargs):
+        calls.append(args[0])
+        return {
             "license": "NOASSERTION",
             "copyright": "",
             "error": "fetch_error:tls eof",
-        },
-    )
+        }
+
+    monkeypatch.setattr(module, "fetch_repo_license", fetch_repo_license)
 
     result = module.load_or_fetch_license(
         "owner/repo",
@@ -192,7 +193,78 @@ def test_load_or_fetch_license_does_not_cache_transient_fetch_errors(monkeypatch
     )
 
     assert result["error"] == "fetch_error:tls eof"
-    assert "owner/repo" not in cache
+    assert cache["owner/repo"]["error"] == "fetch_error:tls eof"
+
+    second = module.load_or_fetch_license(
+        "owner/repo",
+        cache,
+        fetch=True,
+        token="",
+        timeout=1,
+        sleep_seconds=0,
+    )
+
+    assert second["error"] == "fetch_error:tls eof"
+    assert calls == ["owner/repo"]
+
+
+def test_durable_license_cache_excludes_transient_fetch_errors():
+    module = load_module()
+    cache = {
+        "owner/transient": {
+            "license": "NOASSERTION",
+            "copyright": "",
+            "error": "fetch_error:tls eof",
+        },
+        "owner/durable": {
+            "license": "NOASSERTION",
+            "copyright": "",
+            "error": "not_fetched",
+        },
+    }
+
+    assert module.durable_license_cache(cache) == {"owner/durable": cache["owner/durable"]}
+
+
+def test_main_keeps_transient_fetch_failure_stable_but_not_persisted(
+    tmp_path,
+    monkeypatch,
+):
+    module = load_module()
+    first_metadata = tmp_path / "skills" / "development" / "demo-a" / "metadata.json"
+    second_metadata = tmp_path / "skills" / "development" / "demo-b" / "metadata.json"
+    write_metadata(first_metadata)
+    write_metadata(second_metadata)
+    cache_path = tmp_path / "cache.json"
+    calls = []
+
+    def fetch_repo_license(repo, *args, **kwargs):
+        calls.append(repo)
+        return {
+            "license": "NOASSERTION",
+            "copyright": "",
+            "error": "fetch_error:tls eof",
+        }
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(module, "fetch_repo_license", fetch_repo_license)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "backfill_legal_metadata.py",
+            "--skills-dir",
+            "skills",
+            "--cache",
+            "cache.json",
+            "--fetch-github",
+            "--apply",
+        ],
+    )
+
+    assert module.main() == 0
+    assert calls == ["owner/repo"]
+    assert json.loads(cache_path.read_text(encoding="utf-8")) == {}
 
 
 def test_license_classification_covers_backfill_spdx_values():


### PR DESCRIPTION
## Summary
- keep transient GitHub license fetch failures cached during the current backfill run
- filter transient failures out when persisting the repo license cache
- add regression coverage for same-run stability and durable cache filtering

## Tests
- pytest tests/test_backfill_legal_metadata.py -q
- git diff --check
- pytest -q