### PR TITLE
Guard non-string skill key inputs

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -231,8 +231,16 @@ def normalize_category(category: str) -> str:
     return name[:32] if name else "other"
 
 
+def _skill_key_text(value) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
 def _normalize_skill_key_path(path: str = "") -> str:
-    normalized = (path or "").strip().replace("\\", "/").strip("/")
+    normalized = _skill_key_text(path).strip().replace("\\", "/").strip("/")
     while normalized.startswith("./"):
         normalized = normalized[2:]
     if normalized == "." or normalized.lower() == "skill.md":
@@ -242,7 +250,7 @@ def _normalize_skill_key_path(path: str = "") -> str:
 
 def build_skill_key(repo: str = "", path: str = "", name: str = "", category: str = "") -> str:
     """Build a stable key for a skill to detect duplicates."""
-    repo = (repo or "").strip()
+    repo = _skill_key_text(repo).strip()
     path = _normalize_skill_key_path(path)
     if repo and path:
         return f"{repo}:{path}"

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -150,6 +150,31 @@ def test_build_unified_registry_dedupes_root_path_spellings(tmp_path):
     assert registry["skills"][0]["path"] == ""
 
 
+def test_build_unified_registry_accepts_non_string_path_values(tmp_path):
+    module = load_module()
+    sources_dir = tmp_path / "sources"
+    sources_dir.mkdir()
+    output_path = tmp_path / "registry.json"
+    (sources_dir / "community.json").write_text(
+        json.dumps(
+            {
+                "name": "Community",
+                "skills": [
+                    {"name": "numeric-path", "repo": "owner/repo", "path": 123},
+                    {
+                        "name": "object-path",
+                        "repo": "owner/repo",
+                        "path": {"bad": "path"},
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert module.build_unified_registry(sources_dir, output_path) == 2
+
+
 def test_download_blocks_security_listed_source_repo(tmp_path, monkeypatch):
     module = load_module()
     registry_path = tmp_path / "registry.json"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -335,6 +335,12 @@ def test_build_skill_key_priority(utils):
     assert utils.build_skill_key(path="x/y", name="foo") == ":foo"
 
 
+def test_build_skill_key_coerces_non_string_repo_and_path(utils):
+    assert utils.build_skill_key(repo="o/r", path=123) == "o/r:123"
+    assert utils.build_skill_key(repo=123, path="x/y") == "123:x/y"
+    assert utils.build_skill_key(repo="o/r", path={"bad": "path"}) == "o/r:{'bad': 'path'}"
+
+
 def test_iter_source_skills_inherits_top_level_repo(utils):
     source = {
         "repo": "anthropics/skills",


### PR DESCRIPTION
## Summary
- coerce skill key repo/path inputs before normalization so malformed JSON path values do not abort registry builds
- add regression coverage for build_unified_registry with numeric/object path values

## Tests
- pytest tests/test_utils.py tests/test_sync_and_download.py -q
- pytest -q
- git diff --check