### PR TITLE
Treat boolean skill key inputs as missing

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -232,7 +232,7 @@ def normalize_category(category: str) -> str:
 
 
 def _skill_key_text(value) -> str:
-    if value is None:
+    if value is None or isinstance(value, bool):
         return ""
     if isinstance(value, str):
         return value

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -175,6 +175,33 @@ def test_build_unified_registry_accepts_non_string_path_values(tmp_path):
     assert module.build_unified_registry(sources_dir, output_path) == 2
 
 
+def test_build_unified_registry_dedupes_boolean_root_path(tmp_path):
+    module = load_module()
+    sources_dir = tmp_path / "sources"
+    sources_dir.mkdir()
+    output_path = tmp_path / "registry.json"
+    root_skill = {
+        "name": "root-skill",
+        "repo": "owner/root-skill",
+        "description": "Repo-root skill.",
+        "category": "productivity",
+    }
+    (sources_dir / "community.json").write_text(
+        json.dumps(
+            {
+                "name": "Community",
+                "skills": [
+                    root_skill,
+                    {**root_skill, "path": False},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert module.build_unified_registry(sources_dir, output_path) == 1
+
+
 def test_download_blocks_security_listed_source_repo(tmp_path, monkeypatch):
     module = load_module()
     registry_path = tmp_path / "registry.json"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -341,6 +341,12 @@ def test_build_skill_key_coerces_non_string_repo_and_path(utils):
     assert utils.build_skill_key(repo="o/r", path={"bad": "path"}) == "o/r:{'bad': 'path'}"
 
 
+def test_build_skill_key_treats_boolean_repo_and_path_as_missing(utils):
+    assert utils.build_skill_key(repo="o/r", path=False) == "o/r"
+    assert utils.build_skill_key(repo="o/r", path=True) == "o/r"
+    assert utils.build_skill_key(repo=False, path="x/y", category="dev", name="foo") == "dev:foo"
+
+
 def test_iter_source_skills_inherits_top_level_repo(utils):
     source = {
         "repo": "anthropics/skills",


### PR DESCRIPTION
## Summary
- treat boolean repo/path key inputs as missing values instead of literal True/False key parts
- add regression coverage for boolean path dedupe in registry builds

## Tests
- pytest tests/test_utils.py tests/test_sync_and_download.py -q
- pytest -q
- git diff --check