### PR TITLE
Use SKILL.md frontmatter for category semantics

### DIFF
--- a/scripts/audit_category_quality.py
+++ b/scripts/audit_category_quality.py
@@ -18,7 +18,7 @@ from category_taxonomy import (
     category_slug,
     resolve_category,
 )
-from utils import extract_frontmatter, load_metadata
+from utils import extract_frontmatter, load_metadata, skill_semantic_fields
 
 
 def iter_skill_dirs(skills_dir: Path):
@@ -135,18 +135,20 @@ def build_report(
                     "depth": len(rel.parts),
                 }
             )
-        content = ""
-        frontmatter: dict[str, Any] = {}
-        if include_frontmatter or content_chars > 0:
-            content = read_text_prefix(skill_dir / "SKILL.md", max_chars=max(content_chars, 8192))
-            frontmatter = extract_frontmatter(content)
+        content = read_text_prefix(skill_dir / "SKILL.md", max_chars=max(content_chars, 8192))
+        frontmatter = extract_frontmatter(content)
+        category_frontmatter = frontmatter if include_frontmatter or content_chars > 0 else {}
         metadata = load_metadata(skill_dir)
 
         dir_category = rel.parts[0] if rel.parts else "other"
         raw_sources = {
             "directory": dir_category,
             "metadata": metadata.get("category") if isinstance(metadata.get("category"), str) else "",
-            "frontmatter": frontmatter.get("category") if isinstance(frontmatter.get("category"), str) else "",
+            "frontmatter": (
+                category_frontmatter.get("category")
+                if isinstance(category_frontmatter.get("category"), str)
+                else ""
+            ),
         }
         declared_category = raw_sources["metadata"] or raw_sources["frontmatter"] or raw_sources["directory"]
         current_category = resolve_category(declared_category, allow_unknown=True)
@@ -163,11 +165,19 @@ def build_report(
             for source, value in raw_sources.items()
             if value
         }
+        semantics = skill_semantic_fields(
+            skill_dir,
+            metadata=metadata,
+            frontmatter=frontmatter,
+            rel=rel,
+            content=content,
+            content_chars=content_chars,
+        )
         if len(set(resolved_sources.values())) > 1:
             category_conflicts.append(
                 {
                     "path": str(rel),
-                    "name": metadata.get("name") or frontmatter.get("name") or skill_dir.name,
+                    "name": semantics["name"],
                     "resolved_sources": resolved_sources,
                     "raw_sources": {k: v for k, v in raw_sources.items() if v},
                 }
@@ -185,20 +195,7 @@ def build_report(
                     }
                 )
 
-        tags = metadata.get("tags") or frontmatter.get("tags") or []
-        if isinstance(tags, list):
-            tag_text = " ".join(str(tag) for tag in tags)
-        else:
-            tag_text = str(tags)
-        text = " ".join(
-            [
-                str(metadata.get("name") or frontmatter.get("name") or skill_dir.name),
-                str(metadata.get("description") or frontmatter.get("description") or ""),
-                tag_text,
-                str(rel),
-                content[:content_chars],
-            ]
-        )
+        text = str(semantics["text"])
         suggestion = best_suggestion(
             current_category,
             text,
@@ -210,7 +207,7 @@ def build_report(
             candidates.append(
                 {
                     "path": str(rel),
-                    "name": metadata.get("name") or frontmatter.get("name") or skill_dir.name,
+                    "name": semantics["name"],
                     "current_category": current_category,
                     **suggestion,
                 }
@@ -252,7 +249,8 @@ def build_report(
         "notes": [
             "Candidates are heuristic review targets, not automatic migrations.",
             "The audit scores every category, including non-other categories.",
-            "Default mode uses metadata and paths for speed; pass --include-frontmatter or --content-chars for deeper scans.",
+            "Semantic scoring reads SKILL.md frontmatter before metadata.json.",
+            "Pass --include-frontmatter to audit frontmatter category sources; pass --content-chars for deeper body scans.",
             "Layout issues catch nested paths such as category/category/skill/SKILL.md.",
         ],
     }

--- a/scripts/plan_category_migration.py
+++ b/scripts/plan_category_migration.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from audit_category_quality import best_suggestion, read_text_prefix
 from category_taxonomy import category_slug, get_taxonomy
-from utils import extract_frontmatter, load_metadata, normalize_name
+from utils import extract_frontmatter, load_metadata, normalize_name, skill_semantic_fields
 
 CONFIDENCE_ORDER = {"high": 0, "medium": 1, "low": 2}
 
@@ -128,13 +128,11 @@ def build_plan(
         if len(rel.parts) == 3:
             standard_layout_skills += 1
 
-        content = ""
-        frontmatter: dict[str, Any] = {}
-        if include_frontmatter or content_chars > 0:
-            content = read_text_prefix(skill_dir / "SKILL.md", max_chars=max(content_chars, 8192))
-            frontmatter = extract_frontmatter(content)
+        content = read_text_prefix(skill_dir / "SKILL.md", max_chars=max(content_chars, 8192))
+        frontmatter = extract_frontmatter(content)
+        category_frontmatter = frontmatter if include_frontmatter or content_chars > 0 else {}
         metadata = load_metadata(skill_dir)
-        raw_sources = raw_category_sources(rel, metadata, frontmatter)
+        raw_sources = raw_category_sources(rel, metadata, category_frontmatter)
         resolved_sources = source_categories(raw_sources)
         declared_category = (
             raw_sources.get("metadata")
@@ -143,18 +141,16 @@ def build_plan(
             or "other"
         )
         current_category = taxonomy.resolve(declared_category, allow_unknown=True)
-        name = str(metadata.get("name") or frontmatter.get("name") or skill_dir.name)
-        tags = metadata.get("tags") or frontmatter.get("tags") or []
-        tag_text = " ".join(str(tag) for tag in tags) if isinstance(tags, list) else str(tags)
-        text = " ".join(
-            [
-                name,
-                str(metadata.get("description") or frontmatter.get("description") or ""),
-                tag_text,
-                str(rel),
-                content[:content_chars],
-            ]
+        semantics = skill_semantic_fields(
+            skill_dir,
+            metadata=metadata,
+            frontmatter=frontmatter,
+            rel=rel,
+            content=content,
+            content_chars=content_chars,
         )
+        name = str(semantics["name"])
+        text = str(semantics["text"])
 
         source_values = set(resolved_sources.values())
         alias_sources = [
@@ -278,6 +274,7 @@ def build_plan(
             "high_delta": high_delta,
             "include_frontmatter": include_frontmatter,
             "content_chars": content_chars,
+            "semantic_source_order": ["SKILL.md frontmatter", "metadata.json", "SKILL.md body", "path"],
             "apply_mode": "review-only",
         },
         "summary": {

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -8,6 +8,7 @@ import json
 import logging
 import re
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 import yaml
@@ -431,6 +432,83 @@ def extract_description(content: str, max_length: int = 200) -> str:
             line = re.sub(r"[*_`]", "", line)
             return line[:max_length]
     return ""
+
+
+def _semantic_text(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value.strip()
+
+
+def _semantic_tags(value: Any) -> tuple[list[str], str]:
+    if isinstance(value, list):
+        tags = [str(item).strip() for item in value if str(item).strip()]
+        return tags, "list" if tags else ""
+    tag_text = _semantic_text(value)
+    if tag_text:
+        return [tag_text], "string"
+    return [], ""
+
+
+def skill_semantic_fields(
+    skill_dir: Path,
+    *,
+    metadata: dict[str, Any],
+    frontmatter: dict[str, Any],
+    rel: Path | None = None,
+    content: str = "",
+    content_chars: int = 0,
+) -> dict[str, Any]:
+    """Build SKILL.md-first semantic fields for classification and audit text."""
+    sources: dict[str, str] = {}
+
+    name = _semantic_text(frontmatter.get("name"))
+    if name:
+        sources["name"] = "frontmatter"
+    else:
+        name = _semantic_text(metadata.get("name"))
+        sources["name"] = "metadata" if name else "directory"
+    if not name:
+        name = skill_dir.name
+
+    description = _semantic_text(frontmatter.get("description"))
+    if description:
+        sources["description"] = "frontmatter"
+    else:
+        description = _semantic_text(metadata.get("description"))
+        if description:
+            sources["description"] = "metadata"
+        elif content:
+            description = extract_description(content)
+            if description:
+                sources["description"] = "body"
+
+    tags, tag_shape = _semantic_tags(frontmatter.get("tags"))
+    if tags:
+        sources["tags"] = f"frontmatter:{tag_shape}"
+    else:
+        tags, tag_shape = _semantic_tags(metadata.get("tags"))
+        if tags:
+            sources["tags"] = f"metadata:{tag_shape}"
+
+    tag_text = " ".join(tags)
+    text_parts = [
+        name,
+        description,
+        tag_text,
+        str(rel) if rel else "",
+        content[:content_chars] if content_chars > 0 else "",
+    ]
+    text = " ".join(part for part in text_parts if part)
+
+    return {
+        "name": name,
+        "description": description,
+        "tags": tags,
+        "tag_text": tag_text,
+        "text": text,
+        "sources": sources,
+    }
 
 
 def load_metadata(skill_dir: Path) -> dict:

--- a/tests/test_audit_category_quality.py
+++ b/tests/test_audit_category_quality.py
@@ -99,3 +99,34 @@ def test_audit_reports_nonstandard_nested_layout(tmp_path):
     assert report["standard_layout_skill_count"] == 0
     assert report["layout_issue_count"] == 1
     assert report["layout_issues"][0]["path"] == "other/other/nested-skill/SKILL.md"
+
+
+def test_audit_uses_frontmatter_description_when_metadata_description_missing(tmp_path):
+    audit = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "other",
+        "frontmatter-devops",
+        {
+            "name": "frontmatter-devops",
+            "category": "other",
+        },
+        (
+            "---\n"
+            "name: frontmatter-devops\n"
+            "description: Docker Kubernetes CI CD deploy infrastructure workflow.\n"
+            "tags:\n"
+            "  - docker\n"
+            "  - kubernetes\n"
+            "---\n"
+        ),
+    )
+
+    report = audit.build_report(skills_dir, min_score=2, min_delta=2)
+    candidates = {
+        item["path"]: item
+        for item in report["candidate_reclassifications"]
+    }
+
+    assert candidates["other/frontmatter-devops/SKILL.md"]["suggested_category"] == "devops"

--- a/tests/test_plan_category_migration.py
+++ b/tests/test_plan_category_migration.py
@@ -119,3 +119,34 @@ def test_plan_reports_source_conflict_before_deprecation(tmp_path):
     assert change["current_category"] == "docs"
     assert change["proposed_category"] == "docs"
     assert change["review_required"] is True
+
+
+def test_plan_uses_frontmatter_description_when_metadata_description_missing(tmp_path):
+    planner = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "other",
+        "frontmatter-devops",
+        {
+            "name": "frontmatter-devops",
+            "category": "other",
+        },
+        (
+            "---\n"
+            "name: frontmatter-devops\n"
+            "description: Docker Kubernetes CI CD deploy infrastructure workflow.\n"
+            "tags:\n"
+            "  - docker\n"
+            "  - kubernetes\n"
+            "---\n"
+        ),
+    )
+
+    plan = planner.build_plan(skills_dir, min_score=2, min_delta=2)
+    change = {item["path"]: item for item in plan["changes"]}[
+        "other/frontmatter-devops/SKILL.md"
+    ]
+
+    assert change["action"] == "heuristic_reclassify"
+    assert change["proposed_category"] == "devops"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -517,6 +517,42 @@ def test_extract_description_truncates_at_max_length(utils):
     assert len(desc) == 100
 
 
+def test_skill_semantic_fields_prefer_frontmatter(utils, tmp_path):
+    skill_dir = tmp_path / "skill-c"
+    skill_dir.mkdir()
+    content = (
+        "---\n"
+        "name: frontmatter-name\n"
+        "description: Docker Kubernetes CI CD deploy infrastructure workflow.\n"
+        "tags:\n"
+        "  - docker\n"
+        "  - kubernetes\n"
+        "---\n"
+    )
+    frontmatter = utils.extract_frontmatter(content)
+    metadata = {
+        "name": "metadata-name",
+        "description": "",
+        "tags": ["metadata-tag"],
+    }
+
+    fields = utils.skill_semantic_fields(
+        skill_dir,
+        metadata=metadata,
+        frontmatter=frontmatter,
+        rel=Path("other/skill-c/SKILL.md"),
+        content=content,
+    )
+
+    assert fields["name"] == "frontmatter-name"
+    assert fields["description"].startswith("Docker Kubernetes")
+    assert fields["tags"] == ["docker", "kubernetes"]
+    assert fields["sources"]["name"] == "frontmatter"
+    assert fields["sources"]["description"] == "frontmatter"
+    assert fields["sources"]["tags"] == "frontmatter:list"
+    assert "metadata-tag" not in fields["text"]
+
+
 def test_load_metadata_returns_dict_or_empty(utils, tmp_path):
     skill_dir = tmp_path / "skill-a"
     skill_dir.mkdir()


### PR DESCRIPTION
## Summary

- add a shared SKILL.md-first semantic extraction helper
- wire taxonomy migration planning and category quality audit through that helper
- keep frontmatter category-source auditing behind the existing flag while always using frontmatter semantic fields for scoring
- cover metadata-missing-description cases in utils, planner, and audit tests

Fixes #120

## Tests

- `python -m pytest tests/test_utils.py tests/test_plan_category_migration.py tests/test_audit_category_quality.py -q`
- `python -m pytest tests/test_category_taxonomy.py tests/test_check_taxonomy_governance.py tests/test_review_category_plan_with_llm.py tests/test_plan_category_migration.py tests/test_audit_category_quality.py -q`
- `python scripts/check_taxonomy_governance.py`
- `python -m pytest -q`