### PR TITLE
Fail closed unknown security trust signals

### DIFF
--- a/scripts/build_search_index.py
+++ b/scripts/build_search_index.py
@@ -136,7 +136,7 @@ def score_skill_quality(skill: Dict[str, Any], install_status: str, security_sta
         "path": 15 if has_install_location(path) else 0,
         "tags": 10 if len(tags) >= 3 else 6 if tags else 0,
         "install": 20 if install_status == "known_good" else 8 if install_status == "unknown" else 0,
-        "security": 10 if security_status == "passed" else 4 if security_status == "unknown" else 0,
+        "security": 10 if security_status == "passed" else 0,
         "popularity": 10 if stars >= 1000 else 6 if stars >= 100 else 3 if stars > 0 else 0,
     }
     score = sum(components.values())
@@ -163,6 +163,18 @@ def score_skill_quality(skill: Dict[str, Any], install_status: str, security_sta
         "quality_grade": grade,
         "score_inputs": components,
     }
+
+
+def score_skill_trust(repo: str, path: str, install_status: str, security_status: str, stars: int) -> int:
+    """Compute trust score without treating missing security evidence as clean."""
+    return min(
+        100,
+        (30 if repo and "/" in repo else 0)
+        + (25 if has_install_location(path) else 0)
+        + (20 if install_status == "known_good" else 8 if install_status == "unknown" else 0)
+        + (15 if security_status == "passed" else 0)
+        + (10 if stars > 0 else 0),
+    )
 
 
 def scan_skills_v2(skills_dir: Path) -> List[Dict]:
@@ -336,14 +348,7 @@ def build_search_index(
         quality = score_skill_quality(skill, install_status, security_status)
         quality_score = quality["quality_score"]
         quality_grade = quality["quality_grade"]
-        trust_score = min(
-            100,
-            (30 if repo and "/" in repo else 0)
-            + (25 if has_install_location(path) else 0)
-            + (20 if install_status == "known_good" else 8 if install_status == "unknown" else 0)
-            + (15 if security_status != "failed" else 0)
-            + (10 if stars > 0 else 0),
-        )
+        trust_score = score_skill_trust(repo, path, install_status, security_status, stars)
 
         # Minimal record
         mini_record = {

--- a/tests/test_build_search_index.py
+++ b/tests/test_build_search_index.py
@@ -23,6 +23,7 @@ from build_search_index import (  # noqa: E402
     infer_install_status,
     is_root_mounted_path,
     score_skill_quality,
+    score_skill_trust,
 )
 
 
@@ -136,3 +137,34 @@ def test_quality_score_clears_visibility_threshold_for_root_mounted_skill():
     assert status == "known_good"
     assert quality["quality_score"] >= 70
     assert quality["quality_grade"] in {"A", "S"}
+
+
+def test_quality_security_component_only_rewards_passed_security():
+    skill = _skill()
+    install_status = infer_install_status(skill["repo"], skill["path"], skill["repo"])
+
+    passed = score_skill_quality(skill, install_status, "passed")
+    unknown = score_skill_quality(skill, install_status, "unknown")
+    failed = score_skill_quality(skill, install_status, "failed")
+
+    assert passed["score_inputs"]["security"] == 10
+    assert unknown["score_inputs"]["security"] == 0
+    assert failed["score_inputs"]["security"] == 0
+
+
+def test_trust_score_only_rewards_passed_security():
+    skill = _skill(stars=5)
+    install_status = infer_install_status(skill["repo"], skill["path"], skill["repo"])
+
+    passed = score_skill_trust(
+        skill["repo"], skill["path"], install_status, "passed", skill["stars"]
+    )
+    unknown = score_skill_trust(
+        skill["repo"], skill["path"], install_status, "unknown", skill["stars"]
+    )
+    failed = score_skill_trust(
+        skill["repo"], skill["path"], install_status, "failed", skill["stars"]
+    )
+
+    assert passed == unknown + 15
+    assert unknown == failed


### PR DESCRIPTION
## Summary

- remove positive security quality credit for `unknown` status
- factor trust scoring into a tested helper
- give trust security bonus only when `security_status == "passed"`
- keep failed security blocked behavior unchanged

Fixes #123
Related to #79

## Tests

- `python -m pytest tests/test_build_search_index.py -q`
- `python -m pytest tests/test_plugin_contract.py tests/test_build_search_index.py -q`
- `python -m pytest -q`