### PR TITLE
Add residual other taxonomy audit report

### DIFF
--- a/docs/plan/taxonomy-v2-governance-spec.md
+++ b/docs/plan/taxonomy-v2-governance-spec.md
@@ -162,6 +162,34 @@ Apply mode:
 - updates `metadata.json` with the new `category` and `dir_name`;
 - never deletes or overwrites skills to resolve conflicts.
 
+## Residual Audit Contract
+
+`scripts/audit_category_residuals.py` explains what remains after an apply
+batch. It is report-only and must run before deciding whether another migration
+batch is safe.
+
+The residual report separates two views:
+
+- `same_policy_plan_summary`: recomputed by `apply_category_migration.py` with
+  the same flags, proving whether the selected policy still has apply-ready
+  moves or blocked duplicates.
+- current archive residuals: based on source paths that still exist in the
+  archive, so rows that point at old pre-migration paths are counted as source
+  missing instead of being treated as live `other` skills.
+
+The report records:
+
+- archive category counts and scoped archive counts;
+- source state counts (`exists`, `missing`, or non-standard path);
+- mutually exclusive primary reason counts;
+- overlapping blocker reason counts;
+- target category/status distributions and bounded representative examples.
+
+Residual reason buckets include low confidence, target category/status excluded
+by policy, target `other`, classification status/path failures, stable-key
+conflicts, source missing, current archive category filtered out, and movable
+candidates under the selected policy.
+
 ## Governance Gates
 
 Taxonomy gate:
@@ -188,8 +216,10 @@ Category artifact gate:
 3. Generate a review-only migration plan against the data archive.
 4. Review by action, confidence, and category pair.
 5. Apply only small, high-confidence batches in data PRs.
-6. Publish main from pinned core/data refs.
-7. Re-run audit and compare `other` share, category conflicts, and plan deltas.
+6. Run the residual audit with the same policy to prove what remains and why.
+7. Publish main from pinned core/data refs.
+8. Re-run audit and compare `other` share, category conflicts, residual
+   reasons, and plan deltas.
 
 ## Acceptance Criteria
 
@@ -199,5 +229,7 @@ Category artifact gate:
 - A migration plan can be generated without modifying the archive.
 - The plan reports deprecations, aliases, source conflicts, heuristic
   reclassifications, confidence bands, and category pair counts.
+- A residual audit can explain post-apply live leftovers separately from
+  already-moved classification rows.
 - Generated category artifacts are guarded so legacy category JSON files remain
   pointer-only.

--- a/scripts/audit_category_residuals.py
+++ b/scripts/audit_category_residuals.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Explain residual category migration blockers without modifying the archive."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from apply_category_migration import (
+    ClassificationRow,
+    build_apply_plan,
+    category_state,
+    load_classification_rows,
+    metadata_key,
+    parse_csv,
+    row_is_eligible,
+    select_unique_target,
+)
+from category_taxonomy import get_taxonomy
+from plan_category_migration import iter_skill_dirs
+from utils import load_metadata, normalize_name, normalize_repo
+
+SCHEMA_VERSION = 1
+MOVABLE_REASON = "movable candidate under selected policy"
+
+
+def count_archive_categories(skills_dir: Path) -> Counter[str]:
+    counts: Counter[str] = Counter()
+    for _skill_dir, rel in iter_skill_dirs(skills_dir):
+        category = rel.parts[0] if rel.parts else "other"
+        counts[category] += 1
+    return counts
+
+
+def standard_skill_rel(path: str) -> Path | None:
+    rel = Path(path)
+    if len(rel.parts) != 3 or rel.name != "SKILL.md":
+        return None
+    return rel
+
+
+def sorted_counter(counter: Counter[str]) -> dict[str, int]:
+    return dict(sorted(counter.items()))
+
+
+def sorted_largest(counter: Counter[str], *, limit: int) -> list[dict[str, Any]]:
+    return [
+        {"value": value, "count": count}
+        for value, count in sorted(counter.items(), key=lambda item: (-item[1], item[0]))[
+            : max(limit, 0)
+        ]
+    ]
+
+
+def row_example(
+    row: ClassificationRow,
+    *,
+    source_exists: bool,
+    source_category: str,
+    reason: str,
+    target_status: str,
+    target_path: str = "",
+) -> dict[str, Any]:
+    example = {
+        "path": row.path,
+        "name": row.name,
+        "source_exists": source_exists,
+        "source_category": source_category,
+        "classification_current_category": row.current_category,
+        "target_category": row.target_category,
+        "target_status": target_status,
+        "confidence": row.confidence,
+        "status": row.status,
+        "reason": reason,
+    }
+    if target_path:
+        example["target_path"] = target_path
+    return example
+
+
+def add_bucket_example(
+    examples: dict[str, list[dict[str, Any]]],
+    reason: str,
+    example: dict[str, Any],
+    *,
+    limit: int,
+) -> None:
+    bucket = examples[reason]
+    if len(bucket) < limit:
+        bucket.append(example)
+
+
+def blocker_reasons(
+    row: ClassificationRow,
+    *,
+    min_confidence: float,
+    from_categories: set[str],
+    to_categories: set[str],
+    target_statuses: set[str],
+    allow_target_other: bool,
+) -> list[str]:
+    taxonomy = get_taxonomy()
+    reasons: list[str] = []
+    if row.status != "ok":
+        reasons.append("classification status is not ok")
+    if not row.path or not row.path.endswith("/SKILL.md"):
+        reasons.append("classification path is not a SKILL.md path")
+    if row.confidence is None or row.confidence < min_confidence:
+        reasons.append("confidence below threshold")
+    if from_categories and row.current_category not in from_categories:
+        reasons.append("classification current category excluded by filter")
+    if to_categories and row.target_category not in to_categories:
+        reasons.append("target category excluded by filter")
+    if row.current_category == row.target_category:
+        reasons.append("classification target matches current category")
+    if row.target_category == "other" and not allow_target_other:
+        reasons.append("target category other requires --allow-target-other")
+    target_definition = taxonomy.categories.get(row.target_category)
+    target_status = target_definition.status if target_definition else "unknown"
+    if "any" not in target_statuses and target_status not in target_statuses:
+        reasons.append(f"target category status {target_status!r} excluded by filter")
+    return reasons
+
+
+def build_report(
+    *,
+    skills_dir: Path,
+    classification_jsonl: Path,
+    min_confidence: float = 0.9,
+    from_categories: set[str] | None = None,
+    to_categories: set[str] | None = None,
+    target_statuses: set[str] | None = None,
+    allow_target_other: bool = False,
+    limit_examples: int = 20,
+    top_targets: int = 20,
+) -> dict[str, Any]:
+    taxonomy = get_taxonomy()
+    from_categories = from_categories or set()
+    to_categories = to_categories or set()
+    target_statuses = target_statuses or {"active"}
+    rows = load_classification_rows(classification_jsonl)
+    archive_counts = count_archive_categories(skills_dir)
+    state = category_state(skills_dir)
+    same_policy_plan = build_apply_plan(
+        skills_dir=skills_dir,
+        classification_jsonl=classification_jsonl,
+        min_confidence=min_confidence,
+        from_categories=from_categories,
+        to_categories=to_categories,
+        target_statuses=target_statuses,
+        allow_target_other=allow_target_other,
+    )
+
+    classification_status_counts = Counter(row.status for row in rows)
+    target_category_counts = Counter(row.target_category for row in rows)
+    target_status_counts: Counter[str] = Counter()
+    source_state_counts: Counter[str] = Counter()
+    existing_source_category_counts: Counter[str] = Counter()
+    scoped_source_category_counts: Counter[str] = Counter()
+    primary_reason_counts: Counter[str] = Counter()
+    all_blocker_reason_counts: Counter[str] = Counter()
+    reason_target_counts: dict[str, Counter[str]] = defaultdict(Counter)
+    reason_target_status_counts: dict[str, Counter[str]] = defaultdict(Counter)
+    examples: dict[str, list[dict[str, Any]]] = defaultdict(list)
+
+    candidate_move_count = 0
+    blocked_existing_key_count = 0
+    scoped_existing_source_count = 0
+
+    for row in rows:
+        target_definition = taxonomy.categories.get(row.target_category)
+        target_status = target_definition.status if target_definition else "unknown"
+        target_status_counts[target_status] += 1
+        rel = standard_skill_rel(row.path)
+        if rel is None:
+            source_state_counts["non_standard_path"] += 1
+            reason = "source path is not standard <category>/<skill>/SKILL.md"
+            primary_reason_counts[reason] += 1
+            reason_target_counts[reason][row.target_category] += 1
+            reason_target_status_counts[reason][target_status] += 1
+            add_bucket_example(
+                examples,
+                reason,
+                row_example(
+                    row,
+                    source_exists=False,
+                    source_category="",
+                    reason=reason,
+                    target_status=target_status,
+                ),
+                limit=limit_examples,
+            )
+            continue
+
+        source_dir = skills_dir / rel.parent
+        source_category = rel.parts[0]
+        if not source_dir.exists():
+            source_state_counts["missing"] += 1
+            reason = "source directory missing"
+            primary_reason_counts[reason] += 1
+            reason_target_counts[reason][row.target_category] += 1
+            reason_target_status_counts[reason][target_status] += 1
+            add_bucket_example(
+                examples,
+                reason,
+                row_example(
+                    row,
+                    source_exists=False,
+                    source_category=source_category,
+                    reason=reason,
+                    target_status=target_status,
+                ),
+                limit=limit_examples,
+            )
+            continue
+
+        source_state_counts["exists"] += 1
+        existing_source_category_counts[source_category] += 1
+        if from_categories and source_category not in from_categories:
+            reason = "current archive category excluded by filter"
+            primary_reason_counts[reason] += 1
+            reason_target_counts[reason][row.target_category] += 1
+            reason_target_status_counts[reason][target_status] += 1
+            add_bucket_example(
+                examples,
+                reason,
+                row_example(
+                    row,
+                    source_exists=True,
+                    source_category=source_category,
+                    reason=reason,
+                    target_status=target_status,
+                ),
+                limit=limit_examples,
+            )
+            continue
+
+        scoped_existing_source_count += 1
+        scoped_source_category_counts[source_category] += 1
+        reasons = blocker_reasons(
+            row,
+            min_confidence=min_confidence,
+            from_categories=from_categories,
+            to_categories=to_categories,
+            target_statuses=target_statuses,
+            allow_target_other=allow_target_other,
+        )
+        for blocker in reasons:
+            all_blocker_reason_counts[blocker] += 1
+        eligible, reason = row_is_eligible(
+            row,
+            min_confidence=min_confidence,
+            from_categories=from_categories,
+            to_categories=to_categories,
+            target_statuses=target_statuses,
+            allow_target_other=allow_target_other,
+        )
+        target_path = ""
+        if eligible:
+            target_category = taxonomy.resolve(row.target_category, allow_unknown=True)
+            metadata = load_metadata(source_dir)
+            repo = normalize_repo(metadata.get("repo", ""))
+            name = row.name or metadata.get("name") or source_dir.name
+            key = metadata_key(source_dir, category=target_category, name=normalize_name(name))
+            operation, target_dir_rel, operation_reason = select_unique_target(
+                state=state,
+                source_dir_rel=rel.parent,
+                target_category=target_category,
+                base_name=source_dir.name,
+                key=key,
+                repo=repo,
+            )
+            target_path = str(target_dir_rel / "SKILL.md")
+            if operation == "move":
+                reason = MOVABLE_REASON
+                candidate_move_count += 1
+            else:
+                reason = operation_reason
+                if operation == "blocked_existing_key":
+                    blocked_existing_key_count += 1
+                all_blocker_reason_counts[reason] += 1
+
+        primary_reason_counts[reason] += 1
+        reason_target_counts[reason][row.target_category] += 1
+        reason_target_status_counts[reason][target_status] += 1
+        add_bucket_example(
+            examples,
+            reason,
+            row_example(
+                row,
+                source_exists=True,
+                source_category=source_category,
+                reason=reason,
+                target_status=target_status,
+                target_path=target_path,
+            ),
+            limit=limit_examples,
+        )
+
+    scoped_archive_skill_count = (
+        sum(archive_counts[category] for category in from_categories)
+        if from_categories
+        else sum(archive_counts.values())
+    )
+    scoped_archive_classification_gap = (
+        scoped_archive_skill_count - scoped_existing_source_count
+    )
+    buckets = [
+        {
+            "reason": reason,
+            "count": count,
+            "target_categories": sorted_largest(
+                reason_target_counts[reason],
+                limit=top_targets,
+            ),
+            "target_status_counts": sorted_counter(reason_target_status_counts[reason]),
+            "examples": examples.get(reason, []),
+        }
+        for reason, count in sorted(
+            primary_reason_counts.items(),
+            key=lambda item: (-item[1], item[0]),
+        )
+    ]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "skills_dir": str(skills_dir),
+        "classification_jsonl": str(classification_jsonl),
+        "policy": {
+            "min_confidence": min_confidence,
+            "from_categories": sorted(from_categories),
+            "to_categories": sorted(to_categories),
+            "target_statuses": sorted(target_statuses),
+            "allow_target_other": allow_target_other,
+            "apply_mode": "report-only",
+            "example_limit_per_reason": limit_examples,
+            "top_targets_per_reason": top_targets,
+        },
+        "summary": {
+            "classification_row_count": len(rows),
+            "archive_skill_count": sum(archive_counts.values()),
+            "scoped_archive_skill_count": scoped_archive_skill_count,
+            "scoped_archive_classification_gap": scoped_archive_classification_gap,
+            "classification_status_counts": sorted_counter(classification_status_counts),
+            "archive_category_counts": sorted_counter(archive_counts),
+            "source_state_counts": sorted_counter(source_state_counts),
+            "existing_source_category_counts": sorted_counter(existing_source_category_counts),
+            "scoped_source_category_counts": sorted_counter(scoped_source_category_counts),
+            "scoped_existing_source_count": scoped_existing_source_count,
+            "candidate_move_count": candidate_move_count,
+            "blocked_existing_key_count": blocked_existing_key_count,
+            "primary_reason_counts": sorted_counter(primary_reason_counts),
+            "all_blocker_reason_counts": sorted_counter(all_blocker_reason_counts),
+            "target_category_counts": sorted_counter(target_category_counts),
+            "target_status_counts": sorted_counter(target_status_counts),
+            "same_policy_plan_summary": same_policy_plan["summary"],
+        },
+        "buckets": buckets,
+        "notes": [
+            "This report is read-only and never moves, deletes, or rewrites skills.",
+            "same_policy_plan_summary is generated by apply_category_migration.py with the same flags.",
+            "primary_reason_counts are mutually exclusive and explain the current archive state first.",
+            "all_blocker_reason_counts can exceed scoped_existing_source_count because one row may have multiple blockers.",
+            "source directory missing usually means the classification row points at a pre-migration path that has already moved.",
+            "scoped_archive_classification_gap is scoped_archive_skill_count minus "
+            "scoped_existing_source_count; positive values indicate archive skills "
+            "not covered by the classification file or duplicate classification coverage.",
+        ],
+    }
+
+
+def print_text_report(report: dict[str, Any], *, limit: int) -> None:
+    summary = report["summary"]
+    print("Category residual audit")
+    print(f"Classification rows: {summary['classification_row_count']}")
+    print(f"Archive skills: {summary['archive_skill_count']}")
+    print(f"Scoped archive skills: {summary['scoped_archive_skill_count']}")
+    print(f"Scoped existing classified sources: {summary['scoped_existing_source_count']}")
+    print(f"Scoped archive/classification gap: {summary['scoped_archive_classification_gap']}")
+    print(f"Candidate moves: {summary['candidate_move_count']}")
+    print(f"Primary reasons: {summary['primary_reason_counts']}")
+    for bucket in report["buckets"][: max(limit, 0)]:
+        print(f"- {bucket['count']} {bucket['reason']}")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--skills-dir", type=Path, required=True)
+    parser.add_argument("--classification-jsonl", type=Path, required=True)
+    parser.add_argument("--min-confidence", type=float, default=0.9)
+    parser.add_argument("--from-category", action="append")
+    parser.add_argument("--to-category", action="append")
+    parser.add_argument(
+        "--target-status",
+        action="append",
+        choices=["active", "review", "deprecated", "unknown", "any"],
+        default=["active"],
+    )
+    parser.add_argument("--allow-target-other", action="store_true")
+    parser.add_argument("--limit-examples", type=int, default=20)
+    parser.add_argument("--top-targets", type=int, default=20)
+    parser.add_argument("--preview-limit", type=int, default=20)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if not args.skills_dir.exists():
+        raise SystemExit(f"Skills directory not found: {args.skills_dir}")
+    if not args.classification_jsonl.exists():
+        raise SystemExit(f"Classification JSONL not found: {args.classification_jsonl}")
+    report = build_report(
+        skills_dir=args.skills_dir,
+        classification_jsonl=args.classification_jsonl,
+        min_confidence=args.min_confidence,
+        from_categories=parse_csv(args.from_category),
+        to_categories=parse_csv(args.to_category),
+        target_statuses=set(args.target_status),
+        allow_target_other=args.allow_target_other,
+        limit_examples=args.limit_examples,
+        top_targets=args.top_targets,
+    )
+    payload = json.dumps(report, indent=2, ensure_ascii=False)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload + "\n", encoding="utf-8")
+    if args.json:
+        print(payload)
+    else:
+        print_text_report(report, limit=args.preview_limit)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_audit_category_residuals.py
+++ b/tests/test_audit_category_residuals.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    return importlib.import_module("audit_category_residuals")
+
+
+def _write_skill(
+    root: Path,
+    category: str,
+    dirname: str,
+    *,
+    name: str | None = None,
+    repo: str = "",
+    path: str = "",
+) -> None:
+    skill_dir = root / category / dirname
+    skill_dir.mkdir(parents=True)
+    metadata = {
+        "name": name or dirname,
+        "category": category,
+        "dir_name": dirname,
+    }
+    if repo:
+        metadata["repo"] = repo
+    if path:
+        metadata["path"] = path
+    (skill_dir / "metadata.json").write_text(
+        json.dumps(metadata, indent=2),
+        encoding="utf-8",
+    )
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name or dirname}\n---\n\n{dirname}",
+        encoding="utf-8",
+    )
+
+
+def _write_classification(path: Path, rows: list[dict]) -> None:
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def test_report_separates_missing_sources_from_current_residuals(tmp_path):
+    audit = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "other", "low-confidence")
+    classification = tmp_path / "classification.jsonl"
+    _write_classification(
+        classification,
+        [
+            {
+                "path": "other/low-confidence/SKILL.md",
+                "name": "low-confidence",
+                "current_category": "other",
+                "llm_category": "devops",
+                "confidence": 0.4,
+                "status": "ok",
+            },
+            {
+                "path": "other/already-moved/SKILL.md",
+                "name": "already-moved",
+                "current_category": "other",
+                "llm_category": "development",
+                "confidence": 0.95,
+                "status": "ok",
+            },
+        ],
+    )
+
+    report = audit.build_report(
+        skills_dir=skills_dir,
+        classification_jsonl=classification,
+        from_categories={"other"},
+    )
+
+    assert report["summary"]["scoped_archive_skill_count"] == 1
+    assert report["summary"]["source_state_counts"] == {"exists": 1, "missing": 1}
+    assert report["summary"]["scoped_existing_source_count"] == 1
+    assert report["summary"]["candidate_move_count"] == 0
+    assert report["summary"]["primary_reason_counts"] == {
+        "confidence below threshold": 1,
+        "source directory missing": 1,
+    }
+
+
+def test_report_counts_candidates_and_stable_key_conflicts(tmp_path):
+    audit = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "development",
+        "already-there",
+        name="duplicate",
+        repo="owner/repo",
+        path=".claude/skills/duplicate/SKILL.md",
+    )
+    _write_skill(
+        skills_dir,
+        "other",
+        "duplicate",
+        repo="owner/repo",
+        path=".claude/skills/duplicate/SKILL.md",
+    )
+    _write_skill(skills_dir, "other", "movable")
+    classification = tmp_path / "classification.jsonl"
+    _write_classification(
+        classification,
+        [
+            {
+                "path": "other/duplicate/SKILL.md",
+                "name": "duplicate",
+                "current_category": "other",
+                "llm_category": "development",
+                "confidence": 0.95,
+                "status": "ok",
+            },
+            {
+                "path": "other/movable/SKILL.md",
+                "name": "movable",
+                "current_category": "other",
+                "llm_category": "development",
+                "confidence": 0.95,
+                "status": "ok",
+            },
+        ],
+    )
+
+    report = audit.build_report(
+        skills_dir=skills_dir,
+        classification_jsonl=classification,
+        from_categories={"other"},
+    )
+
+    conflict = "target category already contains a skill with the same stable key"
+    assert report["summary"]["candidate_move_count"] == 1
+    assert report["summary"]["blocked_existing_key_count"] == 1
+    assert report["summary"]["primary_reason_counts"][audit.MOVABLE_REASON] == 1
+    assert report["summary"]["primary_reason_counts"][conflict] == 1
+    assert report["summary"]["same_policy_plan_summary"]["movable_count"] == 1
+    assert report["summary"]["same_policy_plan_summary"]["blocked_count"] == 1
+
+
+def test_report_limits_examples_for_excluded_target_category(tmp_path):
+    audit = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "other", "security-one")
+    _write_skill(skills_dir, "other", "security-two")
+    classification = tmp_path / "classification.jsonl"
+    _write_classification(
+        classification,
+        [
+            {
+                "path": "other/security-one/SKILL.md",
+                "name": "security-one",
+                "current_category": "other",
+                "llm_category": "security",
+                "confidence": 0.95,
+                "status": "ok",
+            },
+            {
+                "path": "other/security-two/SKILL.md",
+                "name": "security-two",
+                "current_category": "other",
+                "llm_category": "security",
+                "confidence": 0.96,
+                "status": "ok",
+            },
+        ],
+    )
+
+    report = audit.build_report(
+        skills_dir=skills_dir,
+        classification_jsonl=classification,
+        from_categories={"other"},
+        to_categories={"devops"},
+        limit_examples=1,
+    )
+
+    reason = "target category excluded by filter"
+    assert report["summary"]["primary_reason_counts"] == {reason: 2}
+    bucket = {item["reason"]: item for item in report["buckets"]}[reason]
+    assert bucket["target_categories"] == [{"value": "security", "count": 2}]
+    assert len(bucket["examples"]) == 1
+
+
+def test_report_blocks_review_target_status_by_default(tmp_path):
+    audit = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "other", "legacy-applied")
+    classification = tmp_path / "classification.jsonl"
+    _write_classification(
+        classification,
+        [
+            {
+                "path": "other/legacy-applied/SKILL.md",
+                "name": "legacy-applied",
+                "current_category": "other",
+                "llm_category": "applied",
+                "confidence": 0.95,
+                "status": "ok",
+            }
+        ],
+    )
+
+    report = audit.build_report(
+        skills_dir=skills_dir,
+        classification_jsonl=classification,
+        from_categories={"other"},
+    )
+
+    reason = "target category status 'review' excluded by filter"
+    assert report["summary"]["primary_reason_counts"] == {reason: 1}
+    assert report["buckets"][0]["target_status_counts"] == {"review": 1}


### PR DESCRIPTION
Closes #128.\n\n## Summary\n- Add a report-only residual category audit that separates same-policy apply-plan results from the current archive state.\n- Bucket residual rows by source missing, low confidence, target/status filters, stable-key conflicts, current-category filters, and movable candidates.\n- Document the residual audit as a taxonomy v2 governance gate and add focused tests.\n\n## Verification\n- python -m pytest\n- Real data report, all active targets: /tmp/category-full-rerun-a2777c79-20260521T120135Z/category-residual-other-report-active-q90.json\n- Real data report, previous core-target policy: /tmp/category-full-rerun-a2777c79-20260521T120135Z/category-residual-other-report-coretargets-q90.json\n\n## Real data findings\n- Latest data main at 6d47b07abc5 has 100,214 scoped other skills.\n- Previous core-target policy has 0 candidate moves remaining.\n- Expanding to all active target categories exposes 18,888 additional movable other candidates.\n- The classification coverage gap for scoped other is 5,061 skills.