### PR TITLE
Add auditable stable-key conflict details

### DIFF
--- a/docs/plan/taxonomy-v2-governance-spec.md
+++ b/docs/plan/taxonomy-v2-governance-spec.md
@@ -184,11 +184,19 @@ The report records:
 - mutually exclusive primary reason counts;
 - overlapping blocker reason counts;
 - target category/status distributions and bounded representative examples.
+- optional stable-key conflict details via `--conflict-detail-limit`, including
+  source/target paths, metadata identity fields, SKILL content hashes, and
+  equality flags.
 
 Residual reason buckets include low confidence, target category/status excluded
 by policy, target `other`, classification status/path failures, stable-key
 conflicts, source missing, current archive category filtered out, and movable
 candidates under the selected policy.
+
+Stable-key conflict details are diagnostic only. Matching stable keys are not
+enough to delete or merge archive entries; a follow-up cleanup must first prove
+whether the source and target SKILL bodies are identical or intentionally
+different.
 
 ## Governance Gates
 

--- a/scripts/audit_category_residuals.py
+++ b/scripts/audit_category_residuals.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 from collections import Counter, defaultdict
 from datetime import datetime, timezone
@@ -26,6 +27,17 @@ from utils import load_metadata, normalize_name, normalize_repo
 
 SCHEMA_VERSION = 1
 MOVABLE_REASON = "movable candidate under selected policy"
+CONFLICT_METADATA_IDENTITY_FIELDS = (
+    "name",
+    "repo",
+    "path",
+    "github_path",
+    "github_branch",
+    "branch",
+    "source_url",
+    "license",
+    "author",
+)
 
 
 def count_archive_categories(skills_dir: Path) -> Counter[str]:
@@ -94,6 +106,58 @@ def add_bucket_example(
         bucket.append(example)
 
 
+def file_sha256(path: Path) -> str:
+    if not path.exists() or not path.is_file():
+        return ""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def metadata_identity(metadata: dict[str, Any]) -> dict[str, Any]:
+    identity: dict[str, Any] = {}
+    for field in CONFLICT_METADATA_IDENTITY_FIELDS:
+        value = metadata.get(field)
+        if value not in (None, ""):
+            identity[field] = value
+    return identity
+
+
+def stable_key_conflict_detail(
+    *,
+    skills_dir: Path,
+    row: ClassificationRow,
+    source_dir: Path,
+    target_dir_rel: Path,
+    target_category: str,
+    target_status: str,
+    key: str,
+) -> dict[str, Any]:
+    target_dir = skills_dir / target_dir_rel
+    source_metadata = load_metadata(source_dir)
+    target_metadata = load_metadata(target_dir) if target_dir.exists() else {}
+    source_identity = metadata_identity(source_metadata)
+    target_identity = metadata_identity(target_metadata)
+    source_skill_hash = file_sha256(source_dir / "SKILL.md")
+    target_skill_hash = file_sha256(target_dir / "SKILL.md")
+    return {
+        "source_path": str(source_dir.relative_to(skills_dir)),
+        "source_skill": str(source_dir.relative_to(skills_dir) / "SKILL.md"),
+        "target_path": str(target_dir_rel),
+        "target_skill": str(target_dir_rel / "SKILL.md"),
+        "target_exists": target_dir.exists(),
+        "target_category": target_category,
+        "target_status": target_status,
+        "classification_name": row.name,
+        "confidence": row.confidence,
+        "key": key,
+        "source_metadata_identity": source_identity,
+        "target_metadata_identity": target_identity,
+        "metadata_identity_equal": source_identity == target_identity,
+        "source_skill_sha256": source_skill_hash,
+        "target_skill_sha256": target_skill_hash,
+        "skill_content_equal": bool(source_skill_hash and source_skill_hash == target_skill_hash),
+    }
+
+
 def blocker_reasons(
     row: ClassificationRow,
     *,
@@ -137,6 +201,7 @@ def build_report(
     allow_target_other: bool = False,
     limit_examples: int = 20,
     top_targets: int = 20,
+    conflict_detail_limit: int = 0,
 ) -> dict[str, Any]:
     taxonomy = get_taxonomy()
     from_categories = from_categories or set()
@@ -166,6 +231,8 @@ def build_report(
     reason_target_counts: dict[str, Counter[str]] = defaultdict(Counter)
     reason_target_status_counts: dict[str, Counter[str]] = defaultdict(Counter)
     examples: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    conflict_details: list[dict[str, Any]] = []
+    conflict_detail_summary: Counter[str] = Counter()
 
     candidate_move_count = 0
     blocked_existing_key_count = 0
@@ -282,6 +349,23 @@ def build_report(
                 reason = operation_reason
                 if operation == "blocked_existing_key":
                     blocked_existing_key_count += 1
+                    if len(conflict_details) < max(conflict_detail_limit, 0):
+                        detail = stable_key_conflict_detail(
+                            skills_dir=skills_dir,
+                            row=row,
+                            source_dir=source_dir,
+                            target_dir_rel=target_dir_rel,
+                            target_category=target_category,
+                            target_status=target_status,
+                            key=key,
+                        )
+                        conflict_details.append(detail)
+                        if detail["skill_content_equal"]:
+                            conflict_detail_summary["skill_content_equal"] += 1
+                        if detail["metadata_identity_equal"]:
+                            conflict_detail_summary["metadata_identity_equal"] += 1
+                        if not detail["target_exists"]:
+                            conflict_detail_summary["target_missing"] += 1
                 all_blocker_reason_counts[reason] += 1
 
         primary_reason_counts[reason] += 1
@@ -340,6 +424,7 @@ def build_report(
             "apply_mode": "report-only",
             "example_limit_per_reason": limit_examples,
             "top_targets_per_reason": top_targets,
+            "conflict_detail_limit": conflict_detail_limit,
         },
         "summary": {
             "classification_row_count": len(rows),
@@ -354,6 +439,8 @@ def build_report(
             "scoped_existing_source_count": scoped_existing_source_count,
             "candidate_move_count": candidate_move_count,
             "blocked_existing_key_count": blocked_existing_key_count,
+            "stable_key_conflict_detail_count": len(conflict_details),
+            "stable_key_conflict_detail_summary": sorted_counter(conflict_detail_summary),
             "primary_reason_counts": sorted_counter(primary_reason_counts),
             "all_blocker_reason_counts": sorted_counter(all_blocker_reason_counts),
             "target_category_counts": sorted_counter(target_category_counts),
@@ -361,6 +448,9 @@ def build_report(
             "same_policy_plan_summary": same_policy_plan["summary"],
         },
         "buckets": buckets,
+        "details": {
+            "stable_key_conflicts": conflict_details,
+        },
         "notes": [
             "This report is read-only and never moves, deletes, or rewrites skills.",
             "same_policy_plan_summary is generated by apply_category_migration.py with the same flags.",
@@ -370,6 +460,8 @@ def build_report(
             "scoped_archive_classification_gap is scoped_archive_skill_count minus "
             "scoped_existing_source_count; positive values indicate archive skills "
             "not covered by the classification file or duplicate classification coverage.",
+            "stable_key_conflicts detail is bounded by --conflict-detail-limit and includes "
+            "content hashes so duplicate removal is not inferred from the stable key alone.",
         ],
     }
 
@@ -404,6 +496,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--allow-target-other", action="store_true")
     parser.add_argument("--limit-examples", type=int, default=20)
     parser.add_argument("--top-targets", type=int, default=20)
+    parser.add_argument(
+        "--conflict-detail-limit",
+        type=int,
+        default=0,
+        help="Emit up to N stable-key conflict details with source/target hashes",
+    )
     parser.add_argument("--preview-limit", type=int, default=20)
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--output", type=Path)
@@ -426,6 +524,7 @@ def main(argv: list[str] | None = None) -> int:
         allow_target_other=args.allow_target_other,
         limit_examples=args.limit_examples,
         top_targets=args.top_targets,
+        conflict_detail_limit=args.conflict_detail_limit,
     )
     payload = json.dumps(report, indent=2, ensure_ascii=False)
     if args.output:

--- a/tests/test_audit_category_residuals.py
+++ b/tests/test_audit_category_residuals.py
@@ -21,6 +21,7 @@ def _write_skill(
     name: str | None = None,
     repo: str = "",
     path: str = "",
+    body: str | None = None,
 ) -> None:
     skill_dir = root / category / dirname
     skill_dir.mkdir(parents=True)
@@ -38,7 +39,7 @@ def _write_skill(
         encoding="utf-8",
     )
     (skill_dir / "SKILL.md").write_text(
-        f"---\nname: {name or dirname}\n---\n\n{dirname}",
+        body if body is not None else f"---\nname: {name or dirname}\n---\n\n{dirname}",
         encoding="utf-8",
     )
 
@@ -148,6 +149,140 @@ def test_report_counts_candidates_and_stable_key_conflicts(tmp_path):
     assert report["summary"]["primary_reason_counts"][conflict] == 1
     assert report["summary"]["same_policy_plan_summary"]["movable_count"] == 1
     assert report["summary"]["same_policy_plan_summary"]["blocked_count"] == 1
+
+
+def test_report_can_emit_stable_key_conflict_details(tmp_path):
+    audit = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "development",
+        "already-there",
+        name="duplicate",
+        repo="owner/repo",
+        path=".claude/skills/duplicate/SKILL.md",
+        body="same skill body",
+    )
+    _write_skill(
+        skills_dir,
+        "other",
+        "duplicate",
+        repo="owner/repo",
+        path=".claude/skills/duplicate/SKILL.md",
+        body="same skill body",
+    )
+    _write_skill(
+        skills_dir,
+        "development",
+        "already-there-different",
+        name="different",
+        repo="owner/different",
+        path=".claude/skills/different/SKILL.md",
+        body="target body",
+    )
+    _write_skill(
+        skills_dir,
+        "other",
+        "different",
+        repo="owner/different",
+        path=".claude/skills/different/SKILL.md",
+        body="source body",
+    )
+    classification = tmp_path / "classification.jsonl"
+    _write_classification(
+        classification,
+        [
+            {
+                "path": "other/duplicate/SKILL.md",
+                "name": "duplicate",
+                "current_category": "other",
+                "llm_category": "development",
+                "confidence": 0.95,
+                "status": "ok",
+            },
+            {
+                "path": "other/different/SKILL.md",
+                "name": "different",
+                "current_category": "other",
+                "llm_category": "development",
+                "confidence": 0.95,
+                "status": "ok",
+            },
+        ],
+    )
+
+    report = audit.build_report(
+        skills_dir=skills_dir,
+        classification_jsonl=classification,
+        from_categories={"other"},
+        conflict_detail_limit=10,
+    )
+
+    details = report["details"]["stable_key_conflicts"]
+    assert len(details) == 2
+    by_name = {detail["classification_name"]: detail for detail in details}
+    duplicate = by_name["duplicate"]
+    different = by_name["different"]
+    assert duplicate["source_path"] == "other/duplicate"
+    assert duplicate["target_path"] == "development/already-there"
+    assert duplicate["skill_content_equal"] is True
+    assert duplicate["metadata_identity_equal"] is True
+    assert duplicate["source_skill_sha256"] == duplicate["target_skill_sha256"]
+    assert different["target_path"] == "development/already-there-different"
+    assert different["skill_content_equal"] is False
+    assert different["metadata_identity_equal"] is True
+    assert report["summary"]["stable_key_conflict_detail_count"] == 2
+    assert report["summary"]["stable_key_conflict_detail_summary"] == {
+        "metadata_identity_equal": 2,
+        "skill_content_equal": 1,
+    }
+
+
+def test_report_conflict_detail_limit_is_bounded(tmp_path):
+    audit = _load_module()
+    skills_dir = tmp_path / "skills"
+    for name in ("one", "two"):
+        _write_skill(
+            skills_dir,
+            "development",
+            f"target-{name}",
+            name=name,
+            repo=f"owner/{name}",
+            path=f".claude/skills/{name}/SKILL.md",
+        )
+        _write_skill(
+            skills_dir,
+            "other",
+            name,
+            repo=f"owner/{name}",
+            path=f".claude/skills/{name}/SKILL.md",
+        )
+    classification = tmp_path / "classification.jsonl"
+    _write_classification(
+        classification,
+        [
+            {
+                "path": f"other/{name}/SKILL.md",
+                "name": name,
+                "current_category": "other",
+                "llm_category": "development",
+                "confidence": 0.95,
+                "status": "ok",
+            }
+            for name in ("one", "two")
+        ],
+    )
+
+    report = audit.build_report(
+        skills_dir=skills_dir,
+        classification_jsonl=classification,
+        from_categories={"other"},
+        conflict_detail_limit=1,
+    )
+
+    assert report["summary"]["blocked_existing_key_count"] == 2
+    assert report["summary"]["stable_key_conflict_detail_count"] == 1
+    assert len(report["details"]["stable_key_conflicts"]) == 1
 
 
 def test_report_limits_examples_for_excluded_target_category(tmp_path):


### PR DESCRIPTION
Closes #131.

## Summary
- Add optional stable-key conflict details to `audit_category_residuals.py` via `--conflict-detail-limit`.
- Include source/target paths, target status, stable key, metadata identity fields, SKILL SHA-256 hashes, and equality flags.
- Document that conflict details are diagnostic only and matching stable keys are not enough to delete or merge entries.

## Why
After all safe automatic active moves were applied, the remaining `other` residuals include 22,914 stable-key target conflicts. The next cleanup phase needs auditable source/target evidence before any duplicate removal or merge planning.

## Verification
- `python -m pytest tests/test_audit_category_residuals.py tests/test_apply_category_migration.py`
- `python -m pytest`
- `git diff --check`
- `python scripts/audit_category_residuals.py --help`

## Data probe
Using this branch locally against the current data worktree:
- sampled 1,000 stable-key conflict details
- 893/1,000 had identical SKILL content
- 620/1,000 had matching metadata identity fields

A full conflict detail report is being generated locally for the next data cleanup issue.
