### PR TITLE
Add exact stable-key duplicate cleanup planner

### DIFF
--- a/docs/plan/taxonomy-v2-governance-spec.md
+++ b/docs/plan/taxonomy-v2-governance-spec.md
@@ -198,6 +198,25 @@ enough to delete or merge archive entries; a follow-up cleanup must first prove
 whether the source and target SKILL bodies are identical or intentionally
 different.
 
+## Stable-Key Duplicate Cleanup Contract
+
+`scripts/plan_stable_key_duplicate_cleanup.py` consumes a residual report that
+was generated with `--conflict-detail-limit`. It is the only approved automatic
+cleanup path for stable-key conflicts.
+
+Defaults:
+
+- Input is a residual report with `details.stable_key_conflicts`.
+- Default mode is dry-run. Only `--apply` removes source directories.
+- Source and target `SKILL.md` hashes must match.
+- Metadata identity fields must match unless
+  `--allow-metadata-identity-drift` is explicitly passed after review.
+- Apply mode re-reads the source and target hashes before deleting anything.
+
+The cleanup plan records `remove_duplicate` operations only. It never rewrites,
+renames, merges, or overwrites skills. Non-identical conflicts remain residuals
+for manual or model-assisted review.
+
 ## Governance Gates
 
 Taxonomy gate:

--- a/scripts/plan_stable_key_duplicate_cleanup.py
+++ b/scripts/plan_stable_key_duplicate_cleanup.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Plan or apply exact duplicate removals for category stable-key conflicts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from audit_category_residuals import file_sha256, metadata_identity
+from apply_category_migration import parse_csv
+from utils import load_metadata
+
+SCHEMA_VERSION = 1
+
+
+def sorted_counter(counter: Counter[str]) -> dict[str, int]:
+    return dict(sorted(counter.items()))
+
+
+def load_report(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("residual report must be a JSON object")
+    details = payload.get("details")
+    if not isinstance(details, dict) or not isinstance(
+        details.get("stable_key_conflicts"), list
+    ):
+        raise ValueError(
+            "residual report must include details.stable_key_conflicts; "
+            "rerun audit_category_residuals.py with --conflict-detail-limit"
+        )
+    return payload
+
+
+def source_category(detail: dict[str, Any]) -> str:
+    source_path = Path(str(detail.get("source_path") or ""))
+    return source_path.parts[0] if source_path.parts else ""
+
+
+def detail_is_removable(
+    detail: dict[str, Any],
+    *,
+    from_categories: set[str],
+    require_metadata_identity: bool,
+) -> tuple[bool, str]:
+    if from_categories and source_category(detail) not in from_categories:
+        return False, "source category excluded by filter"
+    if not detail.get("target_exists"):
+        return False, "target path missing"
+    if not detail.get("skill_content_equal"):
+        return False, "SKILL content differs"
+    if require_metadata_identity and not detail.get("metadata_identity_equal"):
+        return False, "metadata identity differs"
+    return True, "exact duplicate"
+
+
+def build_cleanup_plan(
+    *,
+    residual_report: Path,
+    skills_dir: Path | None = None,
+    from_categories: set[str] | None = None,
+    require_metadata_identity: bool = True,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    report = load_report(residual_report)
+    from_categories = from_categories or set()
+    details = report["details"]["stable_key_conflicts"]
+    selected_skills_dir = skills_dir or Path(str(report.get("skills_dir") or ""))
+    max_removals = max(limit, 0) if limit is not None else None
+
+    removals: list[dict[str, Any]] = []
+    skipped_reasons: Counter[str] = Counter()
+    source_counts: Counter[str] = Counter()
+    target_counts: Counter[str] = Counter()
+    if max_removals == 0:
+        details = []
+
+    for detail in details:
+        removable, reason = detail_is_removable(
+            detail,
+            from_categories=from_categories,
+            require_metadata_identity=require_metadata_identity,
+        )
+        if not removable:
+            skipped_reasons[reason] += 1
+            continue
+        source = str(detail["source_path"])
+        target = str(detail["target_path"])
+        removal = {
+            "operation": "remove_duplicate",
+            "source_path": source,
+            "source_skill": str(detail.get("source_skill") or f"{source}/SKILL.md"),
+            "target_path": target,
+            "target_skill": str(detail.get("target_skill") or f"{target}/SKILL.md"),
+            "target_category": str(detail.get("target_category") or ""),
+            "target_status": str(detail.get("target_status") or ""),
+            "key": str(detail.get("key") or ""),
+            "source_skill_sha256": str(detail.get("source_skill_sha256") or ""),
+            "target_skill_sha256": str(detail.get("target_skill_sha256") or ""),
+            "metadata_identity_equal": bool(detail.get("metadata_identity_equal")),
+            "skill_content_equal": bool(detail.get("skill_content_equal")),
+            "reason": reason,
+        }
+        removals.append(removal)
+        source_counts[source_category(detail)] += 1
+        target_counts[removal["target_category"]] += 1
+        if max_removals is not None and len(removals) >= max_removals:
+            break
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "skills_dir": str(selected_skills_dir),
+        "residual_report": str(residual_report),
+        "policy": {
+            "from_categories": sorted(from_categories),
+            "require_metadata_identity": require_metadata_identity,
+            "limit": limit,
+            "apply_mode": "review-only",
+        },
+        "summary": {
+            "conflict_detail_count": len(report["details"]["stable_key_conflicts"]),
+            "planned_remove_count": len(removals),
+            "skipped_reasons": sorted_counter(skipped_reasons),
+            "source_category_counts": sorted_counter(source_counts),
+            "target_category_counts": sorted_counter(target_counts),
+        },
+        "removals": removals,
+        "notes": [
+            "Default mode is review-only and does not modify files.",
+            "Apply mode re-verifies source and target SKILL hashes before removal.",
+            "Metadata identity must match by default; use --allow-metadata-identity-drift only after review.",
+        ],
+    }
+
+
+def apply_cleanup_plan(skills_dir: Path, plan: dict[str, Any]) -> None:
+    require_metadata_identity = bool(plan.get("policy", {}).get("require_metadata_identity", True))
+    for removal in plan["removals"]:
+        if removal.get("operation") != "remove_duplicate":
+            raise ValueError(f"unsupported operation: {removal.get('operation')}")
+        source = skills_dir / removal["source_path"]
+        target = skills_dir / removal["target_path"]
+        if source == target:
+            raise ValueError(f"source and target are identical: {source}")
+        if not source.exists():
+            raise FileNotFoundError(f"planned source does not exist: {source}")
+        if not target.exists():
+            raise FileNotFoundError(f"planned target does not exist: {target}")
+        source_hash = file_sha256(source / "SKILL.md")
+        target_hash = file_sha256(target / "SKILL.md")
+        if source_hash != removal.get("source_skill_sha256"):
+            raise ValueError(f"source SKILL hash changed: {source}")
+        if target_hash != removal.get("target_skill_sha256"):
+            raise ValueError(f"target SKILL hash changed: {target}")
+        if not source_hash or source_hash != target_hash:
+            raise ValueError(f"source and target SKILL content differs: {source}")
+        if require_metadata_identity:
+            source_identity = metadata_identity(load_metadata(source))
+            target_identity = metadata_identity(load_metadata(target))
+            if source_identity != target_identity:
+                raise ValueError(f"metadata identity changed or differs: {source}")
+        shutil.rmtree(source)
+
+
+def print_text_report(plan: dict[str, Any], *, limit: int) -> None:
+    summary = plan["summary"]
+    print("Stable-key duplicate cleanup plan")
+    print(f"Conflict details: {summary['conflict_detail_count']}")
+    print(f"Planned removals: {summary['planned_remove_count']}")
+    print(f"Skipped reasons: {summary['skipped_reasons']}")
+    print(f"Targets: {summary['target_category_counts']}")
+    for removal in plan["removals"][:limit]:
+        print(
+            f"- remove {removal['source_path']} "
+            f"(duplicate of {removal['target_path']})"
+        )
+    if len(plan["removals"]) > limit:
+        print("  ...")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--residual-report", type=Path, required=True)
+    parser.add_argument("--skills-dir", type=Path)
+    parser.add_argument("--from-category", action="append")
+    parser.add_argument("--allow-metadata-identity-drift", action="store_true")
+    parser.add_argument("--limit", type=int)
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--preview-limit", type=int, default=20)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    plan = build_cleanup_plan(
+        residual_report=args.residual_report,
+        skills_dir=args.skills_dir,
+        from_categories=parse_csv(args.from_category),
+        require_metadata_identity=not args.allow_metadata_identity_drift,
+        limit=args.limit,
+    )
+    skills_dir = Path(plan["skills_dir"])
+    if args.apply:
+        if not skills_dir.exists():
+            raise SystemExit(f"Skills directory not found: {skills_dir}")
+        apply_cleanup_plan(skills_dir, plan)
+        plan["policy"]["apply_mode"] = "apply"
+        plan["applied_at"] = datetime.now(timezone.utc).isoformat()
+
+    payload = json.dumps(plan, indent=2, ensure_ascii=False)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload + "\n", encoding="utf-8")
+    if args.json:
+        print(payload)
+    else:
+        print_text_report(plan, limit=args.preview_limit)
+        if args.apply:
+            print("Stable-key duplicate cleanup complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_plan_stable_key_duplicate_cleanup.py
+++ b/tests/test_plan_stable_key_duplicate_cleanup.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    return importlib.import_module("plan_stable_key_duplicate_cleanup")
+
+
+def _write_skill(
+    root: Path,
+    rel: str,
+    *,
+    body: str,
+    name: str = "duplicate",
+    repo: str = "owner/repo",
+    path: str = ".claude/skills/duplicate/SKILL.md",
+) -> None:
+    skill_dir = root / rel
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
+    (skill_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "name": name,
+                "repo": repo,
+                "path": path,
+                "category": Path(rel).parts[0],
+                "dir_name": Path(rel).name,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _sha(path: Path) -> str:
+    cleanup = _load_module()
+    return cleanup.file_sha256(path)
+
+
+def _detail(
+    root: Path,
+    *,
+    source_path: str,
+    target_path: str,
+    skill_content_equal: bool = True,
+    metadata_identity_equal: bool = True,
+    target_exists: bool = True,
+) -> dict:
+    return {
+        "source_path": source_path,
+        "source_skill": f"{source_path}/SKILL.md",
+        "target_path": target_path,
+        "target_skill": f"{target_path}/SKILL.md",
+        "target_exists": target_exists,
+        "target_category": target_path.split("/", 1)[0],
+        "target_status": "active",
+        "classification_name": "duplicate",
+        "confidence": 0.95,
+        "key": "owner/repo:.claude/skills/duplicate/SKILL.md",
+        "source_skill_sha256": _sha(root / source_path / "SKILL.md"),
+        "target_skill_sha256": _sha(root / target_path / "SKILL.md")
+        if target_exists
+        else "",
+        "metadata_identity_equal": metadata_identity_equal,
+        "skill_content_equal": skill_content_equal,
+    }
+
+
+def _write_report(root: Path, report_path: Path, details: list[dict]) -> None:
+    report_path.write_text(
+        json.dumps(
+            {
+                "skills_dir": str(root),
+                "details": {"stable_key_conflicts": details},
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_plan_filters_to_exact_duplicates(tmp_path):
+    cleanup = _load_module()
+    root = tmp_path / "skills"
+    _write_skill(root, "other/exact", body="same")
+    _write_skill(root, "development/exact", body="same")
+    _write_skill(root, "other/content-drift", body="source")
+    _write_skill(root, "development/content-drift", body="target")
+    _write_skill(root, "other/meta-drift", body="same")
+    _write_skill(root, "development/meta-drift", body="same")
+    report_path = tmp_path / "report.json"
+    _write_report(
+        root,
+        report_path,
+        [
+            _detail(root, source_path="other/exact", target_path="development/exact"),
+            _detail(
+                root,
+                source_path="other/content-drift",
+                target_path="development/content-drift",
+                skill_content_equal=False,
+            ),
+            _detail(
+                root,
+                source_path="other/meta-drift",
+                target_path="development/meta-drift",
+                metadata_identity_equal=False,
+            ),
+        ],
+    )
+
+    plan = cleanup.build_cleanup_plan(
+        residual_report=report_path,
+        from_categories={"other"},
+    )
+
+    assert plan["summary"]["planned_remove_count"] == 1
+    assert plan["removals"][0]["source_path"] == "other/exact"
+    assert plan["summary"]["skipped_reasons"] == {
+        "SKILL content differs": 1,
+        "metadata identity differs": 1,
+    }
+
+
+def test_apply_removes_only_verified_duplicate(tmp_path):
+    cleanup = _load_module()
+    root = tmp_path / "skills"
+    _write_skill(root, "other/exact", body="same")
+    _write_skill(root, "development/exact", body="same")
+    report_path = tmp_path / "report.json"
+    _write_report(
+        root,
+        report_path,
+        [_detail(root, source_path="other/exact", target_path="development/exact")],
+    )
+    plan = cleanup.build_cleanup_plan(residual_report=report_path)
+
+    cleanup.apply_cleanup_plan(root, plan)
+
+    assert not (root / "other" / "exact").exists()
+    assert (root / "development" / "exact" / "SKILL.md").exists()
+
+
+def test_apply_fails_closed_when_source_hash_changes(tmp_path):
+    cleanup = _load_module()
+    root = tmp_path / "skills"
+    _write_skill(root, "other/exact", body="same")
+    _write_skill(root, "development/exact", body="same")
+    report_path = tmp_path / "report.json"
+    _write_report(
+        root,
+        report_path,
+        [_detail(root, source_path="other/exact", target_path="development/exact")],
+    )
+    plan = cleanup.build_cleanup_plan(residual_report=report_path)
+    (root / "other" / "exact" / "SKILL.md").write_text("changed", encoding="utf-8")
+
+    try:
+        cleanup.apply_cleanup_plan(root, plan)
+    except ValueError as exc:
+        assert "source SKILL hash changed" in str(exc)
+    else:
+        raise AssertionError("expected stale cleanup plan to fail closed")
+
+    assert (root / "other" / "exact" / "SKILL.md").exists()
+
+
+def test_plan_can_allow_metadata_identity_drift_after_review(tmp_path):
+    cleanup = _load_module()
+    root = tmp_path / "skills"
+    _write_skill(root, "other/meta-drift", body="same")
+    _write_skill(root, "development/meta-drift", body="same")
+    report_path = tmp_path / "report.json"
+    _write_report(
+        root,
+        report_path,
+        [
+            _detail(
+                root,
+                source_path="other/meta-drift",
+                target_path="development/meta-drift",
+                metadata_identity_equal=False,
+            )
+        ],
+    )
+
+    plan = cleanup.build_cleanup_plan(
+        residual_report=report_path,
+        require_metadata_identity=False,
+    )
+
+    assert plan["summary"]["planned_remove_count"] == 1


### PR DESCRIPTION
Closes #133.

## Summary
- Add `scripts/plan_stable_key_duplicate_cleanup.py` for audited stable-key duplicate removals.
- Consume residual reports generated with `--conflict-detail-limit`.
- Plan only explicit `remove_duplicate` operations where source/target SKILL hashes match and metadata identity matches by default.
- Apply mode re-verifies source and target hashes, target existence, and metadata identity before deleting a source directory.
- Document the safe flow in the taxonomy v2 governance spec.

## Why
After the safe active migration, the remaining `other` residuals include 22,914 stable-key conflicts. The conflict detail report shows 12,739 entries satisfy the conservative exact-duplicate rule and can be removed from `other` without using classification confidence alone.

## Verification
- `python -m pytest tests/test_plan_stable_key_duplicate_cleanup.py tests/test_audit_category_residuals.py`
- `python -m pytest`
- `git diff --check`
- `python scripts/plan_stable_key_duplicate_cleanup.py --help`

## Data probe
Generated a dry-run cleanup plan against current data:
- conflict details: 22,914
- planned removals: 12,739
- skipped content drift: 3,086
- skipped metadata identity drift: 7,089
