### PR TITLE
Add residual worksets and LLM reclassification

### DIFF
--- a/docs/plan/taxonomy-v2-governance-spec.md
+++ b/docs/plan/taxonomy-v2-governance-spec.md
@@ -198,6 +198,32 @@ enough to delete or merge archive entries; a follow-up cleanup must first prove
 whether the source and target SKILL bodies are identical or intentionally
 different.
 
+## Residual Workset Contract
+
+`scripts/build_residual_category_worksets.py` turns a residual state into
+explicit review queues before any new model pass. It is report-only and writes
+JSONL worksets that can be checkpointed, sampled, or fully reclassified.
+
+Worksets:
+
+- `classification_gap`: live archive skills without a live classification row.
+- `low_confidence`: live rows below the selected confidence threshold.
+- `review_target`: live rows whose previous target is a review taxonomy bucket.
+- `target_other`: live rows that the previous classifier kept in `other`.
+
+Each item records SKILL.md-first semantic inputs, metadata identity hints, the
+previous classification when present, and a bounded content excerpt. Conflict
+details, when supplied from the residual audit, are summarized by drift type
+only; this step does not modify or merge archive entries.
+
+`scripts/classify_residual_workset_with_llm.py` reclassifies a workset through
+an OpenAI-compatible chat API. It reads credentials only from an environment
+variable, supports bounded batch retries plus JSONL checkpoints for resume, and
+writes apply-compatible classification rows. Unknown, inactive, malformed, or
+missing model outputs are kept as non-`ok` rows so downstream migration stays
+fail-closed. Resume mode reuses only `ok` checkpoint rows by default so
+transient API or parsing failures are retried instead of being silently accepted.
+
 ## Stable-Key Duplicate Cleanup Contract
 
 `scripts/plan_stable_key_duplicate_cleanup.py` consumes a residual report that
@@ -244,8 +270,12 @@ Category artifact gate:
 4. Review by action, confidence, and category pair.
 5. Apply only small, high-confidence batches in data PRs.
 6. Run the residual audit with the same policy to prove what remains and why.
-7. Publish main from pinned core/data refs.
-8. Re-run audit and compare `other` share, category conflicts, residual
+7. Build residual worksets for gaps, low confidence rows, review targets, and
+   target-`other` rows before running another model pass.
+8. Reclassify worksets with checkpoints and apply only `ok`, active,
+   high-confidence rows through the existing migration planner.
+9. Publish main from pinned core/data refs.
+10. Re-run audit and compare `other` share, category conflicts, residual
    reasons, and plan deltas.
 
 ## Acceptance Criteria
@@ -258,5 +288,7 @@ Category artifact gate:
   reclassifications, confidence bands, and category pair counts.
 - A residual audit can explain post-apply live leftovers separately from
   already-moved classification rows.
+- Residual worksets can be generated without archive edits and reclassified
+  with resumable, fail-closed model output.
 - Generated category artifacts are guarded so legacy category JSON files remain
   pointer-only.

--- a/scripts/build_residual_category_worksets.py
+++ b/scripts/build_residual_category_worksets.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Build residual category cleanup worksets from current archive state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from apply_category_migration import ClassificationRow, load_classification_rows
+from audit_category_quality import read_text_prefix
+from audit_category_residuals import standard_skill_rel
+from category_taxonomy import get_taxonomy
+from plan_category_migration import iter_skill_dirs
+from utils import extract_frontmatter, load_metadata, skill_semantic_fields
+
+SCHEMA_VERSION = 1
+
+
+def sorted_counter(counter: Counter[str]) -> dict[str, int]:
+    return dict(sorted(counter.items()))
+
+
+def work_item_for_skill(
+    *,
+    skills_dir: Path,
+    skill_dir: Path,
+    rel: Path,
+    workset: str,
+    reason: str,
+    classification: ClassificationRow | None = None,
+    content_chars: int = 1600,
+) -> dict[str, Any]:
+    content = read_text_prefix(skill_dir / "SKILL.md", max_chars=max(content_chars, 8192))
+    metadata = load_metadata(skill_dir)
+    frontmatter = extract_frontmatter(content)
+    semantics = skill_semantic_fields(
+        skill_dir,
+        metadata=metadata,
+        frontmatter=frontmatter,
+        rel=rel,
+        content=content,
+        content_chars=content_chars,
+    )
+    item: dict[str, Any] = {
+        "workset": workset,
+        "reason": reason,
+        "path": str(rel),
+        "skill_dir": str(skill_dir.relative_to(skills_dir)),
+        "name": semantics["name"],
+        "description": semantics["description"],
+        "tags": semantics["tags"],
+        "current_category": rel.parts[0] if rel.parts else "other",
+        "metadata": {
+            "name": metadata.get("name", ""),
+            "repo": metadata.get("repo", ""),
+            "path": metadata.get("path") or metadata.get("github_path") or "",
+            "source_url": metadata.get("source_url", ""),
+            "category": metadata.get("category", ""),
+        },
+        "semantic_sources": semantics["sources"],
+        "content_excerpt": content[:content_chars],
+    }
+    if classification:
+        item["previous_classification"] = {
+            "llm_category": classification.target_category,
+            "confidence": classification.confidence,
+            "status": classification.status,
+            "current_category": classification.current_category,
+        }
+    return item
+
+
+def existing_scoped_rows(
+    *,
+    skills_dir: Path,
+    rows: list[ClassificationRow],
+    from_categories: set[str],
+) -> list[tuple[ClassificationRow, Path, Path]]:
+    existing: list[tuple[ClassificationRow, Path, Path]] = []
+    for row in rows:
+        rel = standard_skill_rel(row.path)
+        if rel is None:
+            continue
+        source_dir = skills_dir / rel.parent
+        if not source_dir.exists():
+            continue
+        source_category = rel.parts[0]
+        if from_categories and source_category not in from_categories:
+            continue
+        existing.append((row, rel, source_dir))
+    return existing
+
+
+def load_conflict_details(path: Path | None) -> list[dict[str, Any]]:
+    if path is None:
+        return []
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    details = payload.get("details", {}).get("stable_key_conflicts", [])
+    if not isinstance(details, list):
+        raise ValueError("conflict detail report has invalid details.stable_key_conflicts")
+    return [detail for detail in details if isinstance(detail, dict)]
+
+
+def conflict_cluster(detail: dict[str, Any]) -> str:
+    content_equal = bool(detail.get("skill_content_equal"))
+    metadata_equal = bool(detail.get("metadata_identity_equal"))
+    if content_equal and metadata_equal:
+        return "exact_duplicate"
+    if content_equal:
+        return "content_equal_metadata_drift"
+    if metadata_equal:
+        return "content_drift_metadata_equal"
+    return "content_and_metadata_drift"
+
+
+def build_worksets(
+    *,
+    skills_dir: Path,
+    classification_jsonl: Path,
+    from_categories: set[str] | None = None,
+    min_confidence: float = 0.9,
+    conflict_detail_report: Path | None = None,
+    content_chars: int = 1600,
+) -> dict[str, Any]:
+    taxonomy = get_taxonomy()
+    from_categories = from_categories or {"other"}
+    rows = load_classification_rows(classification_jsonl)
+    existing_rows = existing_scoped_rows(
+        skills_dir=skills_dir,
+        rows=rows,
+        from_categories=from_categories,
+    )
+    existing_paths = {str(rel) for _row, rel, _source_dir in existing_rows}
+
+    gap_items: list[dict[str, Any]] = []
+    archive_counts: Counter[str] = Counter()
+    for skill_dir, rel in iter_skill_dirs(skills_dir):
+        category = rel.parts[0] if rel.parts else "other"
+        archive_counts[category] += 1
+        if from_categories and category not in from_categories:
+            continue
+        if str(rel) not in existing_paths:
+            gap_items.append(
+                work_item_for_skill(
+                    skills_dir=skills_dir,
+                    skill_dir=skill_dir,
+                    rel=rel,
+                    workset="classification_gap",
+                    reason="current archive skill has no live classification row",
+                    content_chars=content_chars,
+                )
+            )
+
+    low_confidence_items: list[dict[str, Any]] = []
+    review_target_items: list[dict[str, Any]] = []
+    target_other_items: list[dict[str, Any]] = []
+    for row, rel, source_dir in existing_rows:
+        target_definition = taxonomy.categories.get(row.target_category)
+        target_status = target_definition.status if target_definition else "unknown"
+        if row.confidence is None or row.confidence < min_confidence:
+            low_confidence_items.append(
+                work_item_for_skill(
+                    skills_dir=skills_dir,
+                    skill_dir=source_dir,
+                    rel=rel,
+                    workset="low_confidence",
+                    reason="previous classification confidence below threshold",
+                    classification=row,
+                    content_chars=content_chars,
+                )
+            )
+            continue
+        if row.target_category == "other":
+            target_other_items.append(
+                work_item_for_skill(
+                    skills_dir=skills_dir,
+                    skill_dir=source_dir,
+                    rel=rel,
+                    workset="target_other",
+                    reason="previous classification target remained other",
+                    classification=row,
+                    content_chars=content_chars,
+                )
+            )
+            continue
+        if target_status == "review":
+            review_target_items.append(
+                work_item_for_skill(
+                    skills_dir=skills_dir,
+                    skill_dir=source_dir,
+                    rel=rel,
+                    workset="review_target",
+                    reason="previous classification target is a review taxonomy category",
+                    classification=row,
+                    content_chars=content_chars,
+                )
+            )
+
+    conflict_details = load_conflict_details(conflict_detail_report)
+    conflict_clusters = Counter(conflict_cluster(detail) for detail in conflict_details)
+    conflict_target_counts = Counter(
+        str(detail.get("target_category") or "") for detail in conflict_details
+    )
+
+    worksets = {
+        "classification_gap": gap_items,
+        "low_confidence": low_confidence_items,
+        "review_target": review_target_items,
+        "target_other": target_other_items,
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "skills_dir": str(skills_dir),
+        "classification_jsonl": str(classification_jsonl),
+        "policy": {
+            "from_categories": sorted(from_categories),
+            "min_confidence": min_confidence,
+            "content_chars": content_chars,
+            "apply_mode": "report-only",
+        },
+        "summary": {
+            "classification_row_count": len(rows),
+            "archive_category_counts": sorted_counter(archive_counts),
+            "scoped_existing_classification_count": len(existing_rows),
+            "workset_counts": {
+                name: len(items) for name, items in sorted(worksets.items())
+            },
+            "conflict_detail_count": len(conflict_details),
+            "conflict_clusters": sorted_counter(conflict_clusters),
+            "conflict_target_category_counts": sorted_counter(conflict_target_counts),
+        },
+        "worksets": worksets,
+        "notes": [
+            "This report does not modify archive files.",
+            "classification_gap contains live archive paths absent from the classification JSONL.",
+            "low_confidence and review_target rows should be reclassified before apply.",
+            "conflict clusters are diagnostic; content drift conflicts must not be auto-deleted.",
+        ],
+    }
+
+
+def write_workset_jsonl(report: dict[str, Any], output_dir: Path) -> dict[str, str]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    paths: dict[str, str] = {}
+    for name, items in report["worksets"].items():
+        path = output_dir / f"{name}.jsonl"
+        with path.open("w", encoding="utf-8") as handle:
+            for item in items:
+                handle.write(json.dumps(item, ensure_ascii=False, sort_keys=True) + "\n")
+        paths[name] = str(path)
+    return paths
+
+
+def print_text_report(report: dict[str, Any], *, limit: int) -> None:
+    summary = report["summary"]
+    print("Residual category worksets")
+    print(f"Classification rows: {summary['classification_row_count']}")
+    print(f"Scoped existing classifications: {summary['scoped_existing_classification_count']}")
+    print(f"Worksets: {summary['workset_counts']}")
+    print(f"Conflict clusters: {summary['conflict_clusters']}")
+    for name, items in report["worksets"].items():
+        for item in items[: max(limit, 0)]:
+            print(f"- {name} {item['path']}")
+
+
+def parse_csv(values: list[str] | None) -> set[str]:
+    if not values:
+        return set()
+    parsed: set[str] = set()
+    for value in values:
+        parsed.update(part.strip() for part in value.split(",") if part.strip())
+    return parsed
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--skills-dir", type=Path, required=True)
+    parser.add_argument("--classification-jsonl", type=Path, required=True)
+    parser.add_argument("--from-category", action="append")
+    parser.add_argument("--min-confidence", type=float, default=0.9)
+    parser.add_argument("--conflict-detail-report", type=Path)
+    parser.add_argument("--content-chars", type=int, default=1600)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--workset-output-dir", type=Path)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--preview-limit", type=int, default=3)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = build_worksets(
+        skills_dir=args.skills_dir,
+        classification_jsonl=args.classification_jsonl,
+        from_categories=parse_csv(args.from_category) or {"other"},
+        min_confidence=args.min_confidence,
+        conflict_detail_report=args.conflict_detail_report,
+        content_chars=args.content_chars,
+    )
+    if args.workset_output_dir:
+        report["workset_files"] = write_workset_jsonl(report, args.workset_output_dir)
+    payload = json.dumps(report, indent=2, ensure_ascii=False)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload + "\n", encoding="utf-8")
+    if args.json:
+        print(payload)
+    else:
+        print_text_report(report, limit=args.preview_limit)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/classify_residual_workset_with_llm.py
+++ b/scripts/classify_residual_workset_with_llm.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""Batch-classify residual category worksets with an OpenAI-compatible model."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import threading
+import time
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from category_taxonomy import get_taxonomy
+from review_category_plan_with_llm import (
+    DEFAULT_API_KEY_ENV,
+    DEFAULT_BASE_URL,
+    DEFAULT_MAX_COMPLETION_TOKENS,
+    DEFAULT_MODEL,
+    DEFAULT_THINKING,
+    LLMReviewError,
+    OpenAICompatibleClient,
+    parse_json_content,
+)
+
+CHECKPOINT_SCHEMA_VERSION = 1
+
+
+def active_category_payload() -> list[dict[str, str]]:
+    taxonomy = get_taxonomy()
+    return [
+        {
+            "slug": definition.slug,
+            "display_name": definition.display_name,
+            "description": definition.description,
+        }
+        for definition in sorted(taxonomy.categories.values(), key=lambda item: item.slug)
+        if definition.status == "active"
+    ]
+
+
+def load_work_items(path: Path, *, limit: int | None = None) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            payload = json.loads(line)
+            if not isinstance(payload, dict):
+                raise ValueError(f"work item row {line_number} must be an object")
+            payload["_input_index"] = len(items)
+            items.append(payload)
+            if limit is not None and len(items) >= max(limit, 0):
+                break
+    return items
+
+
+def item_review_key(item: dict[str, Any]) -> str:
+    payload = {
+        "workset": item.get("workset", ""),
+        "path": item.get("path", ""),
+        "name": item.get("name", ""),
+        "description": item.get("description", ""),
+        "tags": item.get("tags", []),
+        "previous_classification": item.get("previous_classification", {}),
+        "content_excerpt": item.get("content_excerpt", ""),
+    }
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def load_checkpoint(
+    path: Path | None,
+    *,
+    reusable_statuses: set[str] | None = None,
+) -> tuple[dict[str, dict[str, Any]], int, int]:
+    if path is None or not path.exists():
+        return {}, 0, 0
+    rows: dict[str, dict[str, Any]] = {}
+    malformed = 0
+    ignored = 0
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            if not line.strip():
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                malformed += 1
+                continue
+            if not isinstance(payload, dict) or not isinstance(payload.get("review_key"), str):
+                malformed += 1
+                continue
+            status = str(payload.get("status") or "")
+            if reusable_statuses is not None and status not in reusable_statuses:
+                ignored += 1
+                continue
+            rows[payload["review_key"]] = payload
+    return rows, malformed, ignored
+
+
+def append_checkpoint(path: Path, row: dict[str, Any], lock: threading.Lock) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with lock:
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
+            handle.flush()
+
+
+def compact_candidate(item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": item["_batch_id"],
+        "workset": item.get("workset", ""),
+        "reason": item.get("reason", ""),
+        "path": item.get("path", ""),
+        "name": item.get("name", ""),
+        "description": item.get("description", ""),
+        "tags": item.get("tags", []),
+        "current_category": item.get("current_category", ""),
+        "metadata": item.get("metadata", {}),
+        "previous_classification": item.get("previous_classification", {}),
+        "content_excerpt": item.get("content_excerpt", ""),
+    }
+
+
+def build_messages(items: list[dict[str, Any]]) -> list[dict[str, str]]:
+    categories = active_category_payload()
+    system_prompt = (
+        "You are classifying reusable AI skills into a registry taxonomy. "
+        "Use SKILL.md frontmatter/body semantics first, then metadata and path. "
+        "Choose one category slug from allowed_categories. Prefer a concrete active "
+        "category over 'other'. Use 'other' only when no active category is defensible, "
+        "and then set confidence <= 0.65. Do not choose review or deprecated categories. "
+        "Return only valid compact JSON: an array of objects with keys "
+        "id, category, confidence, reason, evidence. confidence must be 0..1."
+    )
+    payload = {
+        "allowed_categories": categories,
+        "candidates": [compact_candidate(item) for item in items],
+    }
+    return [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": json.dumps(payload, ensure_ascii=False)},
+    ]
+
+
+def parse_batch_content(content: str) -> tuple[list[dict[str, Any]] | None, str]:
+    parsed, status = parse_json_content(content)
+    if status == "ok" and isinstance(parsed, dict):
+        for key in ("classifications", "items", "results"):
+            value = parsed.get(key)
+            if isinstance(value, list):
+                return [item for item in value if isinstance(item, dict)], "ok"
+        return None, "invalid_json"
+    if status == "ok" and isinstance(parsed, list):
+        return [item for item in parsed if isinstance(item, dict)], "ok"
+    stripped = strip_json_fence(content)
+    if stripped.startswith("["):
+        try:
+            value = json.loads(stripped)
+        except json.JSONDecodeError:
+            return None, "invalid_json"
+        if isinstance(value, list):
+            return [item for item in value if isinstance(item, dict)], "ok"
+    return None, status
+
+
+def strip_json_fence(content: str) -> str:
+    stripped = content.strip()
+    if not stripped.startswith("```"):
+        return stripped
+    lines = stripped.splitlines()
+    if lines and lines[0].startswith("```"):
+        lines = lines[1:]
+    if lines and lines[-1].strip() == "```":
+        lines = lines[:-1]
+    return "\n".join(lines).strip()
+
+
+def normalized_confidence(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        confidence = float(value)
+        if 0.0 <= confidence <= 1.0:
+            return confidence
+    return None
+
+
+def build_result_entry(
+    item: dict[str, Any],
+    *,
+    review_key: str,
+    model_payload: dict[str, Any] | None,
+    parse_status: str,
+    raw_error: str = "",
+) -> dict[str, Any]:
+    taxonomy = get_taxonomy()
+    category = ""
+    confidence = None
+    reason = raw_error
+    evidence: list[Any] = []
+    status = parse_status
+    if model_payload:
+        raw_category = str(model_payload.get("category") or "")
+        category = taxonomy.resolve(raw_category, allow_unknown=True) if raw_category else ""
+        confidence = normalized_confidence(model_payload.get("confidence"))
+        reason = str(model_payload.get("reason") or "")
+        raw_evidence = model_payload.get("evidence")
+        evidence = raw_evidence if isinstance(raw_evidence, list) else []
+        definition = taxonomy.categories.get(category)
+        if status == "ok" and (not definition or definition.status != "active"):
+            status = "unknown_or_inactive_category"
+        if status == "ok" and confidence is None:
+            status = "invalid_confidence"
+    return {
+        "checkpoint_schema_version": CHECKPOINT_SCHEMA_VERSION,
+        "review_key": review_key,
+        "path": item.get("path", ""),
+        "name": item.get("name", ""),
+        "current_category": item.get("current_category", ""),
+        "llm_category": category,
+        "confidence": confidence,
+        "status": status,
+        "reason": reason,
+        "evidence": evidence,
+        "workset": item.get("workset", ""),
+        "previous_classification": item.get("previous_classification", {}),
+        "input_index": item.get("_input_index"),
+    }
+
+
+def classify_batch(
+    batch: list[dict[str, Any]],
+    *,
+    client: OpenAICompatibleClient,
+    retries: int = 0,
+    retry_sleep_seconds: float = 2.0,
+) -> list[dict[str, Any]]:
+    for index, item in enumerate(batch):
+        item["_batch_id"] = str(index)
+    keys = [item_review_key(item) for item in batch]
+    last_error = ""
+    for attempt in range(max(retries, 0) + 1):
+        try:
+            content = client.complete(build_messages(batch))
+            parsed, parse_status = parse_batch_content(content)
+            break
+        except LLMReviewError as exc:
+            last_error = str(exc)
+            if attempt >= max(retries, 0):
+                return [
+                    build_result_entry(
+                        item,
+                        review_key=key,
+                        model_payload=None,
+                        parse_status="api_error",
+                        raw_error=last_error,
+                    )
+                    for item, key in zip(batch, keys, strict=True)
+                ]
+            if retry_sleep_seconds > 0:
+                time.sleep(retry_sleep_seconds * (attempt + 1))
+    parsed_items = parsed or []
+    payload_by_id = {
+        str(payload.get("id")): payload for payload in parsed_items if "id" in payload
+    }
+    payload_by_path = {
+        str(payload.get("path")): payload
+        for payload in parsed_items
+        if isinstance(payload.get("path"), str)
+    }
+    payload_by_position = (
+        {str(index): payload for index, payload in enumerate(parsed_items)}
+        if parse_status == "ok" and len(parsed_items) == len(batch)
+        else {}
+    )
+    entries: list[dict[str, Any]] = []
+    for item, key in zip(batch, keys, strict=True):
+        payload = (
+            payload_by_id.get(str(item["_batch_id"]))
+            or payload_by_path.get(str(item.get("path", "")))
+            or payload_by_position.get(str(item["_batch_id"]))
+        )
+        status = parse_status if payload is not None else "missing_result"
+        entries.append(
+            build_result_entry(
+                item,
+                review_key=key,
+                model_payload=payload,
+                parse_status=status,
+            )
+        )
+    return entries
+
+
+def chunks(items: list[dict[str, Any]], size: int) -> list[list[dict[str, Any]]]:
+    return [items[index : index + size] for index in range(0, len(items), size)]
+
+
+def run_classification(
+    *,
+    workset_jsonl: Path,
+    client: OpenAICompatibleClient,
+    checkpoint_jsonl: Path | None,
+    resume: bool,
+    limit: int | None,
+    batch_size: int,
+    workers: int,
+    sleep_seconds: float,
+    retries: int = 0,
+    retry_sleep_seconds: float = 2.0,
+    checkpoint_reuse_statuses: set[str] | None = None,
+) -> dict[str, Any]:
+    items = load_work_items(workset_jsonl, limit=limit)
+    checkpoint_rows, malformed, ignored = load_checkpoint(
+        checkpoint_jsonl if resume else None,
+        reusable_statuses=checkpoint_reuse_statuses if resume else None,
+    )
+    checkpoint_lock = threading.Lock()
+    selected: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
+    skipped = 0
+    for item in items:
+        key = item_review_key(item)
+        if key in checkpoint_rows:
+            results.append(checkpoint_rows[key])
+            skipped += 1
+        else:
+            selected.append(item)
+
+    batches = chunks(selected, max(batch_size, 1))
+    if workers <= 1:
+        for batch_number, batch in enumerate(batches):
+            if batch_number and sleep_seconds > 0:
+                time.sleep(sleep_seconds)
+            entries = classify_batch(
+                batch,
+                client=client,
+                retries=retries,
+                retry_sleep_seconds=retry_sleep_seconds,
+            )
+            for entry in entries:
+                if checkpoint_jsonl:
+                    append_checkpoint(checkpoint_jsonl, entry, checkpoint_lock)
+                results.append(entry)
+    else:
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = {
+                executor.submit(
+                    classify_batch,
+                    batch,
+                    client=client,
+                    retries=retries,
+                    retry_sleep_seconds=retry_sleep_seconds,
+                ): batch
+                for batch in batches
+            }
+            for future in as_completed(futures):
+                entries = future.result()
+                for entry in entries:
+                    if checkpoint_jsonl:
+                        append_checkpoint(checkpoint_jsonl, entry, checkpoint_lock)
+                    results.append(entry)
+                if sleep_seconds > 0:
+                    time.sleep(sleep_seconds)
+
+    results.sort(key=lambda row: int(row.get("input_index") or 0))
+    status_counts = Counter(str(row.get("status") or "") for row in results)
+    category_counts = Counter(str(row.get("llm_category") or "") for row in results)
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "workset_jsonl": str(workset_jsonl),
+        "summary": {
+            "input_count": len(items),
+            "reviewed_count": len(results),
+            "new_review_count": len(selected),
+            "skipped_checkpoint_count": skipped,
+            "malformed_checkpoint_row_count": malformed,
+            "ignored_checkpoint_row_count": ignored,
+            "status_counts": dict(sorted(status_counts.items())),
+            "category_counts": dict(sorted(category_counts.items())),
+        },
+        "rows": results,
+        "notes": [
+            "This report does not modify archive files.",
+            "Rows with status ok are compatible with apply_category_migration.py classification input.",
+            "API credentials are read from the selected environment variable and are not written to output.",
+        ],
+    }
+
+
+def write_classification_jsonl(report: dict[str, Any], output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8") as handle:
+        for row in report["rows"]:
+            payload = {
+                "path": row.get("path", ""),
+                "name": row.get("name", ""),
+                "current_category": row.get("current_category", ""),
+                "llm_category": row.get("llm_category", ""),
+                "confidence": row.get("confidence"),
+                "status": row.get("status", ""),
+                "reason": row.get("reason", ""),
+                "evidence": row.get("evidence", []),
+                "workset": row.get("workset", ""),
+            }
+            handle.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def print_text_report(report: dict[str, Any], *, limit: int) -> None:
+    summary = report["summary"]
+    print("Residual LLM classification")
+    print(f"Inputs: {summary['input_count']}")
+    print(f"Reviewed: {summary['reviewed_count']}")
+    print(f"New reviews: {summary['new_review_count']}")
+    print(f"Status: {summary['status_counts']}")
+    print(f"Categories: {summary['category_counts']}")
+    for row in report["rows"][: max(limit, 0)]:
+        print(
+            f"- {row.get('status')} {row.get('path')}: "
+            f"{row.get('llm_category')} q={row.get('confidence')}"
+        )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workset-jsonl", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--classification-output", type=Path)
+    parser.add_argument("--checkpoint-jsonl", type=Path)
+    parser.add_argument("--resume", action="store_true")
+    parser.add_argument(
+        "--reuse-status",
+        action="append",
+        default=["ok"],
+        help="checkpoint status to reuse during --resume; repeat for more statuses",
+    )
+    parser.add_argument("--limit", type=int)
+    parser.add_argument("--batch-size", type=int, default=5)
+    parser.add_argument("--workers", type=int, default=1)
+    parser.add_argument("--sleep-seconds", type=float, default=0.0)
+    parser.add_argument("--retries", type=int, default=2)
+    parser.add_argument("--retry-sleep-seconds", type=float, default=2.0)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    parser.add_argument("--api-key-env", default=DEFAULT_API_KEY_ENV)
+    parser.add_argument("--timeout", type=int, default=60)
+    parser.add_argument("--max-completion-tokens", type=int, default=DEFAULT_MAX_COMPLETION_TOKENS)
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--thinking", choices=["disabled", "default"], default=DEFAULT_THINKING)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--print-limit", type=int, default=20)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    api_key = os.environ.get(args.api_key_env)
+    if not api_key:
+        raise SystemExit(f"Missing API key environment variable: {args.api_key_env}")
+    if args.resume and not args.checkpoint_jsonl:
+        raise SystemExit("--resume requires --checkpoint-jsonl")
+    client = OpenAICompatibleClient(
+        api_key=api_key,
+        base_url=args.base_url,
+        model=args.model,
+        timeout=args.timeout,
+        max_completion_tokens=args.max_completion_tokens,
+        temperature=args.temperature,
+        thinking=args.thinking,
+    )
+    report = run_classification(
+        workset_jsonl=args.workset_jsonl,
+        client=client,
+        checkpoint_jsonl=args.checkpoint_jsonl,
+        resume=args.resume,
+        limit=args.limit,
+        batch_size=args.batch_size,
+        workers=args.workers,
+        sleep_seconds=args.sleep_seconds,
+        retries=args.retries,
+        retry_sleep_seconds=args.retry_sleep_seconds,
+        checkpoint_reuse_statuses=set(args.reuse_status),
+    )
+    payload = json.dumps(report, indent=2, ensure_ascii=False)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload + "\n", encoding="utf-8")
+    if args.classification_output:
+        write_classification_jsonl(report, args.classification_output)
+    if args.json:
+        print(payload)
+    else:
+        print_text_report(report, limit=args.print_limit)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_residual_category_worksets.py
+++ b/tests/test_build_residual_category_worksets.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    return importlib.import_module("build_residual_category_worksets")
+
+
+def _write_skill(
+    root: Path,
+    rel: str,
+    *,
+    body: str = "---\nname: sample skill\ndescription: Sample description\n---\n\nBody",
+    metadata: dict | None = None,
+) -> None:
+    skill_dir = root / rel
+    skill_dir.mkdir(parents=True)
+    payload = {
+        "name": Path(rel).name,
+        "category": Path(rel).parts[0],
+        "dir_name": Path(rel).name,
+    }
+    payload.update(metadata or {})
+    (skill_dir / "metadata.json").write_text(
+        json.dumps(payload, indent=2),
+        encoding="utf-8",
+    )
+    (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
+
+
+def _write_classification(path: Path, rows: list[dict]) -> None:
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def test_builds_gap_low_confidence_review_and_target_other_worksets(tmp_path):
+    worksets = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "other/gap")
+    _write_skill(skills_dir, "other/low-confidence")
+    _write_skill(skills_dir, "other/review-target")
+    _write_skill(skills_dir, "other/target-other")
+    _write_skill(skills_dir, "development/already-classified")
+    classification = tmp_path / "classification.jsonl"
+    _write_classification(
+        classification,
+        [
+            {
+                "path": "other/low-confidence/SKILL.md",
+                "name": "low-confidence",
+                "current_category": "other",
+                "llm_category": "development",
+                "confidence": 0.5,
+                "status": "ok",
+            },
+            {
+                "path": "other/review-target/SKILL.md",
+                "name": "review-target",
+                "current_category": "other",
+                "llm_category": "applied",
+                "confidence": 0.95,
+                "status": "ok",
+            },
+            {
+                "path": "other/target-other/SKILL.md",
+                "name": "target-other",
+                "current_category": "other",
+                "llm_category": "other",
+                "confidence": 0.95,
+                "status": "ok",
+            },
+            {
+                "path": "development/already-classified/SKILL.md",
+                "name": "already-classified",
+                "current_category": "development",
+                "llm_category": "development",
+                "confidence": 0.95,
+                "status": "ok",
+            },
+        ],
+    )
+
+    report = worksets.build_worksets(
+        skills_dir=skills_dir,
+        classification_jsonl=classification,
+        from_categories={"other"},
+        min_confidence=0.9,
+    )
+
+    assert report["summary"]["workset_counts"] == {
+        "classification_gap": 1,
+        "low_confidence": 1,
+        "review_target": 1,
+        "target_other": 1,
+    }
+    assert report["summary"]["archive_category_counts"]["other"] == 4
+    assert report["summary"]["scoped_existing_classification_count"] == 3
+    assert report["worksets"]["classification_gap"][0]["path"] == "other/gap/SKILL.md"
+    assert report["worksets"]["classification_gap"][0]["skill_dir"] == "other/gap"
+    assert report["worksets"]["low_confidence"][0]["previous_classification"] == {
+        "llm_category": "development",
+        "confidence": 0.5,
+        "status": "ok",
+        "current_category": "other",
+    }
+
+
+def test_summarizes_conflict_detail_clusters(tmp_path):
+    worksets = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "other/gap")
+    classification = tmp_path / "classification.jsonl"
+    _write_classification(classification, [])
+    conflict_report = tmp_path / "conflicts.json"
+    conflict_report.write_text(
+        json.dumps(
+            {
+                "details": {
+                    "stable_key_conflicts": [
+                        {
+                            "target_category": "development",
+                            "skill_content_equal": True,
+                            "metadata_identity_equal": True,
+                        },
+                        {
+                            "target_category": "development",
+                            "skill_content_equal": True,
+                            "metadata_identity_equal": False,
+                        },
+                        {
+                            "target_category": "data",
+                            "skill_content_equal": False,
+                            "metadata_identity_equal": True,
+                        },
+                        {
+                            "target_category": "data",
+                            "skill_content_equal": False,
+                            "metadata_identity_equal": False,
+                        },
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = worksets.build_worksets(
+        skills_dir=skills_dir,
+        classification_jsonl=classification,
+        conflict_detail_report=conflict_report,
+    )
+
+    assert report["summary"]["conflict_detail_count"] == 4
+    assert report["summary"]["conflict_clusters"] == {
+        "content_and_metadata_drift": 1,
+        "content_drift_metadata_equal": 1,
+        "content_equal_metadata_drift": 1,
+        "exact_duplicate": 1,
+    }
+    assert report["summary"]["conflict_target_category_counts"] == {
+        "data": 2,
+        "development": 2,
+    }
+
+
+def test_writes_each_workset_as_jsonl(tmp_path):
+    worksets = _load_module()
+    report = {
+        "worksets": {
+            "classification_gap": [{"path": "other/a"}],
+            "low_confidence": [],
+            "review_target": [{"path": "other/b"}],
+            "target_other": [],
+        }
+    }
+
+    paths = worksets.write_workset_jsonl(report, tmp_path / "out")
+
+    assert set(paths) == {
+        "classification_gap",
+        "low_confidence",
+        "review_target",
+        "target_other",
+    }
+    gap_rows = (tmp_path / "out" / "classification_gap.jsonl").read_text(
+        encoding="utf-8"
+    )
+    assert json.loads(gap_rows)["path"] == "other/a"

--- a/tests/test_classify_residual_workset_with_llm.py
+++ b/tests/test_classify_residual_workset_with_llm.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    return importlib.import_module("classify_residual_workset_with_llm")
+
+
+class FakeClient:
+    def __init__(self, responses: list[str | Exception]):
+        self.responses = responses
+        self.messages: list[list[dict[str, str]]] = []
+
+    def complete(self, messages: list[dict[str, str]]) -> str:
+        self.messages.append(messages)
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+def _work_item(path: str, *, workset: str = "classification_gap") -> dict:
+    return {
+        "workset": workset,
+        "reason": "test",
+        "path": path,
+        "name": path.split("/")[-1],
+        "description": "Build and test source code",
+        "tags": ["code", "test"],
+        "current_category": "other",
+        "metadata": {"repo": "owner/repo", "path": ".claude/skills/test/SKILL.md"},
+        "previous_classification": {},
+        "content_excerpt": "Use this skill for coding workflows and unit tests.",
+    }
+
+
+def _write_workset(path: Path, rows: list[dict]) -> None:
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def test_batch_classification_accepts_json_array_and_writes_apply_rows(tmp_path):
+    classifier = _load_module()
+    workset = tmp_path / "workset.jsonl"
+    _write_workset(workset, [_work_item("other/dev"), _work_item("other/docs")])
+    client = FakeClient(
+        [
+            json.dumps(
+                [
+                    {
+                        "id": "0",
+                        "category": "development",
+                        "confidence": 0.94,
+                        "reason": "coding workflow",
+                        "evidence": ["unit tests"],
+                    },
+                    {
+                        "id": "1",
+                        "category": "documents",
+                        "confidence": 0.91,
+                        "reason": "document workflow",
+                        "evidence": ["docs"],
+                    },
+                ]
+            )
+        ]
+    )
+
+    report = classifier.run_classification(
+        workset_jsonl=workset,
+        client=client,
+        checkpoint_jsonl=tmp_path / "checkpoint.jsonl",
+        resume=False,
+        limit=None,
+        batch_size=2,
+        workers=1,
+        sleep_seconds=0,
+    )
+    output = tmp_path / "classification.jsonl"
+    classifier.write_classification_jsonl(report, output)
+    rows = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
+
+    assert len(client.messages) == 1
+    assert report["summary"]["status_counts"] == {"ok": 2}
+    assert report["summary"]["category_counts"] == {
+        "development": 1,
+        "documents": 1,
+    }
+    assert rows[0]["path"] == "other/dev"
+    assert rows[0]["llm_category"] == "development"
+    assert rows[0]["status"] == "ok"
+    assert rows[0]["workset"] == "classification_gap"
+
+
+def test_batch_classification_accepts_fenced_json_array(tmp_path):
+    classifier = _load_module()
+    workset = tmp_path / "workset.jsonl"
+    _write_workset(workset, [_work_item("other/research")])
+    client = FakeClient(
+        [
+            """```json
+[
+  {
+    "id": "0",
+    "category": "research-analysis",
+    "confidence": 0.92,
+    "reason": "research workflow",
+    "evidence": ["analysis"]
+  }
+]
+```"""
+        ]
+    )
+
+    report = classifier.run_classification(
+        workset_jsonl=workset,
+        client=client,
+        checkpoint_jsonl=None,
+        resume=False,
+        limit=None,
+        batch_size=1,
+        workers=1,
+        sleep_seconds=0,
+    )
+
+    assert report["summary"]["status_counts"] == {"ok": 1}
+    assert report["rows"][0]["llm_category"] == "research-analysis"
+
+
+def test_resume_uses_checkpoint_without_calling_client(tmp_path):
+    classifier = _load_module()
+    item = _work_item("other/reused")
+    workset = tmp_path / "workset.jsonl"
+    _write_workset(workset, [item])
+    key = classifier.item_review_key({**item, "_input_index": 0})
+    checkpoint = tmp_path / "checkpoint.jsonl"
+    checkpoint.write_text(
+        json.dumps(
+            {
+                "review_key": key,
+                "path": "other/reused",
+                "name": "reused",
+                "current_category": "other",
+                "llm_category": "development",
+                "confidence": 0.93,
+                "status": "ok",
+                "reason": "checkpoint",
+                "evidence": [],
+                "workset": "classification_gap",
+                "input_index": 0,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    client = FakeClient([])
+
+    report = classifier.run_classification(
+        workset_jsonl=workset,
+        client=client,
+        checkpoint_jsonl=checkpoint,
+        resume=True,
+        limit=None,
+        batch_size=1,
+        workers=1,
+        sleep_seconds=0,
+    )
+
+    assert client.messages == []
+    assert report["summary"]["skipped_checkpoint_count"] == 1
+    assert report["summary"]["ignored_checkpoint_row_count"] == 0
+    assert report["summary"]["new_review_count"] == 0
+    assert report["rows"][0]["reason"] == "checkpoint"
+
+
+def test_resume_retries_non_ok_checkpoint_rows(tmp_path):
+    classifier = _load_module()
+    item = _work_item("other/retry-checkpoint")
+    workset = tmp_path / "workset.jsonl"
+    _write_workset(workset, [item])
+    key = classifier.item_review_key({**item, "_input_index": 0})
+    checkpoint = tmp_path / "checkpoint.jsonl"
+    checkpoint.write_text(
+        json.dumps(
+            {
+                "review_key": key,
+                "path": "other/retry-checkpoint",
+                "name": "retry-checkpoint",
+                "current_category": "other",
+                "llm_category": "",
+                "confidence": None,
+                "status": "api_error",
+                "reason": "rate limited",
+                "evidence": [],
+                "workset": "classification_gap",
+                "input_index": 0,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    client = FakeClient(
+        [
+            json.dumps(
+                [
+                    {
+                        "id": "0",
+                        "category": "development",
+                        "confidence": 0.91,
+                        "reason": "retried",
+                        "evidence": ["code"],
+                    }
+                ]
+            )
+        ]
+    )
+
+    report = classifier.run_classification(
+        workset_jsonl=workset,
+        client=client,
+        checkpoint_jsonl=checkpoint,
+        resume=True,
+        limit=None,
+        batch_size=1,
+        workers=1,
+        sleep_seconds=0,
+        checkpoint_reuse_statuses={"ok"},
+    )
+
+    assert len(client.messages) == 1
+    assert report["summary"]["ignored_checkpoint_row_count"] == 1
+    assert report["summary"]["status_counts"] == {"ok": 1}
+    assert report["rows"][0]["reason"] == "retried"
+
+
+def test_batch_classification_can_match_by_path_or_position(tmp_path):
+    classifier = _load_module()
+    workset = tmp_path / "workset.jsonl"
+    _write_workset(workset, [_work_item("other/by-path"), _work_item("other/by-position")])
+    client = FakeClient(
+        [
+            json.dumps(
+                [
+                    {
+                        "path": "other/by-path",
+                        "category": "development",
+                        "confidence": 0.91,
+                        "reason": "path match",
+                        "evidence": ["code"],
+                    },
+                    {
+                        "category": "documents",
+                        "confidence": 0.92,
+                        "reason": "position match",
+                        "evidence": ["docs"],
+                    },
+                ]
+            )
+        ]
+    )
+
+    report = classifier.run_classification(
+        workset_jsonl=workset,
+        client=client,
+        checkpoint_jsonl=None,
+        resume=False,
+        limit=None,
+        batch_size=2,
+        workers=1,
+        sleep_seconds=0,
+    )
+
+    assert report["summary"]["status_counts"] == {"ok": 2}
+    assert [row["llm_category"] for row in report["rows"]] == [
+        "development",
+        "documents",
+    ]
+
+
+def test_invalid_model_category_fails_closed(tmp_path):
+    classifier = _load_module()
+    workset = tmp_path / "workset.jsonl"
+    _write_workset(workset, [_work_item("other/bad")])
+    client = FakeClient(
+        [
+            json.dumps(
+                [
+                    {
+                        "id": "0",
+                        "category": "not-a-real-category",
+                        "confidence": 0.99,
+                        "reason": "bad",
+                        "evidence": [],
+                    }
+                ]
+            )
+        ]
+    )
+
+    report = classifier.run_classification(
+        workset_jsonl=workset,
+        client=client,
+        checkpoint_jsonl=None,
+        resume=False,
+        limit=None,
+        batch_size=1,
+        workers=1,
+        sleep_seconds=0,
+    )
+
+    assert report["summary"]["status_counts"] == {"unknown_or_inactive_category": 1}
+    assert report["rows"][0]["llm_category"] == "not-a-real-category"
+
+
+def test_api_errors_are_retried_before_fail_closed(tmp_path):
+    classifier = _load_module()
+    workset = tmp_path / "workset.jsonl"
+    _write_workset(workset, [_work_item("other/retry")])
+    client = FakeClient(
+        [
+            classifier.LLMReviewError("rate limited"),
+            json.dumps(
+                [
+                    {
+                        "id": "0",
+                        "category": "development",
+                        "confidence": 0.91,
+                        "reason": "coding",
+                        "evidence": ["tests"],
+                    }
+                ]
+            ),
+        ]
+    )
+
+    report = classifier.run_classification(
+        workset_jsonl=workset,
+        client=client,
+        checkpoint_jsonl=None,
+        resume=False,
+        limit=None,
+        batch_size=1,
+        workers=1,
+        sleep_seconds=0,
+        retries=1,
+        retry_sleep_seconds=0,
+    )
+
+    assert len(client.messages) == 2
+    assert report["summary"]["status_counts"] == {"ok": 1}
+    assert report["rows"][0]["llm_category"] == "development"


### PR DESCRIPTION
Closes #135.

## Summary
- add report-only residual workset builder for classification gaps, low confidence rows, review targets, and target-other rows
- add OpenAI-compatible residual workset classifier with fenced JSON parsing, retries, checkpoint resume, and fail-closed non-ok statuses
- document the residual workset contract in the taxonomy v2 governance spec

## Verification
- python -m pytest
- git diff --check
- generated current residual worksets from latest data archive
- ran MiMo reclassification for all 59,005 residual workset rows
