### PR TITLE
Make Pages skill counts stats-driven

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Claude Skills Registry - Search 67,000+ Skills</title>
-    <meta name="description" content="Search and discover Claude Code skills. Browse 67,000+ skills for Claude Code, Codex CLI, and ChatGPT.">
+    <title>Claude Skills Registry - Search Skills</title>
+    <meta name="description" content="Search and discover Claude Code skills for Claude Code, Codex CLI, and ChatGPT.">
     <link rel="stylesheet" href="css/style.css">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🎯</text></svg>">
 </head>
@@ -21,7 +21,7 @@
                     <span class="theme-icon" id="theme-icon">🌙</span>
                 </button>
             </div>
-            <p class="tagline">Search <span id="total-count">67,000+</span> skills for Claude Code</p>
+            <p class="tagline">Search <span id="total-count">skills</span> for Claude Code</p>
         </header>
 
         <!-- Search Box -->

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -1,6 +1,6 @@
 /**
  * Claude Skills Registry - Search Application
- * Fast client-side search for 67,000+ skills
+ * Fast client-side search for Claude Code skills
  * v2.0 - Added Leaderboard, Stats, Favorites, Random Discovery
  */
 
@@ -92,6 +92,7 @@ let state = {
 // DOM Elements
 const elements = {
     searchInput: document.getElementById('search-input'),
+    metaDescription: document.querySelector('meta[name="description"]'),
     categoryFilter: document.getElementById('category-filter'),
     sortFilter: document.getElementById('sort-filter'),
     totalCount: document.getElementById('total-count'),
@@ -237,6 +238,55 @@ function formatResultCount(count) {
     return base;
 }
 
+function readNumericStat(key, fallback = 0) {
+    const rawValue = state.stats?.[key];
+    if (rawValue === null || rawValue === undefined || rawValue === '') {
+        return fallback;
+    }
+
+    const value = Number(rawValue);
+    return Number.isFinite(value) ? value : fallback;
+}
+
+function getDisplaySkillCount() {
+    return readNumericStat(
+        'registry_skill_count_dedup',
+        Number(state.index?.t || state.index?.s?.length || 0)
+    );
+}
+
+function updateRegistryCountDisplay() {
+    const dedupedCount = getDisplaySkillCount();
+    if (!Number.isFinite(dedupedCount) || dedupedCount <= 0) {
+        elements.totalCount.textContent = 'skills';
+        elements.totalCount.removeAttribute('title');
+        return;
+    }
+
+    const formattedDeduped = dedupedCount.toLocaleString();
+    const rawArchiveCount = readNumericStat('archive_skill_md_count_raw', 0);
+    const includedCount = Number(state.index?.includedCount || 0);
+
+    elements.totalCount.textContent = formattedDeduped;
+
+    const titleParts = [`${formattedDeduped} deduplicated skills`];
+    if (rawArchiveCount > 0) {
+        titleParts.push(`${rawArchiveCount.toLocaleString()} archived SKILL.md files`);
+    }
+    if (state.index?.isLite && includedCount > 0 && includedCount < dedupedCount) {
+        titleParts.push(`${includedCount.toLocaleString()} highlighted skills loaded for first paint`);
+    }
+    elements.totalCount.title = titleParts.join(' · ');
+
+    document.title = `Claude Skills Registry - Search ${formattedDeduped} Skills`;
+    if (elements.metaDescription) {
+        elements.metaDescription.setAttribute(
+            'content',
+            `Search and discover ${formattedDeduped} Claude Code skills for Claude Code, Codex CLI, and ChatGPT.`
+        );
+    }
+}
+
 // Initialize
 async function init() {
     try {
@@ -259,10 +309,7 @@ async function init() {
         state.fuse = new Fuse(state.index.s, CONFIG.FUSE_OPTIONS);
 
         // Update UI
-        elements.totalCount.textContent = state.index.t.toLocaleString();
-        if (state.index.isLite && state.index.includedCount < state.index.t) {
-            elements.totalCount.title = `Searching ${state.index.includedCount.toLocaleString()} highlighted skills out of ${state.index.t.toLocaleString()} total`;
-        }
+        updateRegistryCountDisplay();
         elements.lastUpdated.textContent = `Updated: ${state.index.v}`;
 
         // Populate category filters

--- a/tests/test_pages_stats_counts.py
+++ b/tests/test_pages_stats_counts.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STALE_DISPLAY_COUNT = "67" + ",000"
+STALE_PLAIN_COUNT = "67" + "000"
+
+
+def test_pages_shell_does_not_hardcode_stale_skill_count():
+    pages_files = [
+        ROOT / "docs" / "index.html",
+        ROOT / "docs" / "js" / "app.js",
+    ]
+
+    for path in pages_files:
+        text = path.read_text(encoding="utf-8")
+        assert STALE_DISPLAY_COUNT not in text
+        assert STALE_PLAIN_COUNT not in text
+
+
+def test_homepage_uses_neutral_count_fallback_until_stats_loads():
+    html = (ROOT / "docs" / "index.html").read_text(encoding="utf-8")
+
+    assert "Search <span id=\"total-count\">skills</span> for Claude Code" in html
+    assert "Search and discover Claude Code skills" in html
+
+
+def test_pages_app_renders_visible_count_from_stats_json():
+    app_js = (ROOT / "docs" / "js" / "app.js").read_text(encoding="utf-8")
+
+    assert "registry_skill_count_dedup" in app_js
+    assert "archive_skill_md_count_raw" in app_js
+    assert "updateRegistryCountDisplay" in app_js
+    assert "document.title" in app_js
+    assert "metaDescription" in app_js


### PR DESCRIPTION
Closes #138.

This removes stale hardcoded Pages count copy and renders the visible count from docs/stats.json instead.

Changes:
- Replace static 67,000+ title/meta/tagline fallback with neutral copy.
- Update the header count, document title, and meta description from registry_skill_count_dedup after stats.json loads.
- Keep archive_skill_md_count_raw and lite-index included count in the tooltip for context.
- Add regression tests preventing stale fixed counts from returning.

Validation:
- rg -n "67,000|67000" docs/index.html docs/js/app.js tests/test_pages_stats_counts.py: no matches
- node --check docs/js/app.js && node --check docs/js/app-render.js
- git diff --check
- python -m pytest tests/test_pages_stats_counts.py tests/test_build_search_index.py: 14 passed
- python -m pytest: 338 passed
