### PR TITLE
Harden depth normalization duplicate handling

### DIFF
--- a/scripts/normalize_skill_depth.py
+++ b/scripts/normalize_skill_depth.py
@@ -10,6 +10,7 @@ and --apply only after reviewing the planned destinations.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import shutil
 from collections import defaultdict
@@ -31,6 +32,17 @@ from utils import (
 
 LAYOUT_EXPECTED = "<category>/<skill>/SKILL.md"
 SKILLS_PREFIX_NAMES = {"skill", "skills"}
+METADATA_IDENTITY_FIELDS = (
+    "name",
+    "repo",
+    "path",
+    "github_path",
+    "github_branch",
+    "branch",
+    "source_url",
+    "license",
+    "author",
+)
 
 
 def is_standard(rel_parts: tuple[str, ...]) -> bool:
@@ -113,6 +125,39 @@ def unique_dir_name(
     return candidate, False
 
 
+def file_sha256(path: Path) -> str:
+    if not path.exists() or not path.is_file():
+        return ""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def metadata_identity(metadata: dict[str, Any]) -> dict[str, Any]:
+    identity: dict[str, Any] = {}
+    for field in METADATA_IDENTITY_FIELDS:
+        value = metadata.get(field)
+        if value not in (None, ""):
+            identity[field] = value
+    return identity
+
+
+def duplicate_safety(skills_dir: Path, source_dir: Path, target_rel: Path) -> dict[str, Any]:
+    target_dir = skills_dir / target_rel
+    source_metadata = load_metadata(source_dir)
+    target_metadata = load_metadata(target_dir) if target_dir.exists() else {}
+    source_skill_hash = file_sha256(source_dir / "SKILL.md")
+    target_skill_hash = file_sha256(target_dir / "SKILL.md")
+    source_identity = metadata_identity(source_metadata)
+    target_identity = metadata_identity(target_metadata)
+    return {
+        "same_key_target_path": str(target_rel),
+        "same_key_target_exists": target_dir.exists(),
+        "skill_content_equal": bool(source_skill_hash and source_skill_hash == target_skill_hash),
+        "metadata_identity_equal": source_identity == target_identity,
+        "source_skill_sha256": source_skill_hash,
+        "target_skill_sha256": target_skill_hash,
+    }
+
+
 def build_depth_plan(skills_dir: Path) -> dict[str, Any]:
     state = existing_category_state(skills_dir)
     moves: list[dict[str, Any]] = []
@@ -126,18 +171,40 @@ def build_depth_plan(skills_dir: Path) -> dict[str, Any]:
         path = meta.get("github_path") or meta.get("path") or ""
         key = build_skill_key(repo, path, name=name, category=category)
         category_state = state[category]
-        target_name, reuses_existing_key = unique_dir_name(
-            category_state=category_state,
-            base_name=name,
-            repo=repo,
-            key=key or str(rel),
-        )
+        duplicate_info: dict[str, Any] = {}
+        operation = "move"
+
+        if key and key in category_state["key_to_name"]:
+            same_key_target_rel = Path(category) / category_state["key_to_name"][key]
+            duplicate_info = duplicate_safety(skills_dir, skill_dir, same_key_target_rel)
+            if (
+                duplicate_info["same_key_target_exists"]
+                and duplicate_info["skill_content_equal"]
+                and duplicate_info["metadata_identity_equal"]
+            ):
+                target_name = category_state["key_to_name"][key]
+                operation = "remove_duplicate"
+            else:
+                target_name, _reuses_existing_key = unique_dir_name(
+                    category_state=category_state,
+                    base_name=name,
+                    repo=repo,
+                    key=f"{key}:{rel}",
+                )
+        else:
+            target_name, _reuses_existing_key = unique_dir_name(
+                category_state=category_state,
+                base_name=name,
+                repo=repo,
+                key=key or str(rel),
+            )
+
         target_rel = Path(category) / target_name
         moves.append(
             {
                 "source_path": str(skill_dir.relative_to(skills_dir)),
                 "source_skill": str(rel),
-                "operation": "remove_duplicate" if reuses_existing_key else "move",
+                "operation": operation,
                 "target_path": str(target_rel),
                 "target_skill": str(target_rel / "SKILL.md"),
                 "category": category,
@@ -147,15 +214,24 @@ def build_depth_plan(skills_dir: Path) -> dict[str, Any]:
                 "metadata_category": meta.get("category", ""),
                 "layout_depth": len(rel.parts),
                 "expected_layout": LAYOUT_EXPECTED,
+                **duplicate_info,
             }
         )
 
     duplicate_count = sum(1 for move in moves if move["operation"] == "remove_duplicate")
+    same_key_conflict_count = sum(1 for move in moves if move.get("same_key_target_path"))
+    same_key_preserved_count = sum(
+        1
+        for move in moves
+        if move.get("same_key_target_path") and move["operation"] != "remove_duplicate"
+    )
     return {
         "skills_dir": str(skills_dir),
         "expected_layout": LAYOUT_EXPECTED,
         "move_count": len(moves),
         "duplicate_count": duplicate_count,
+        "same_key_conflict_count": same_key_conflict_count,
+        "same_key_preserved_count": same_key_preserved_count,
         "moves": moves,
     }
 
@@ -183,6 +259,9 @@ def apply_depth_plan(skills_dir: Path, plan: dict[str, Any]) -> None:
                 raise FileNotFoundError(f"Duplicate target does not exist: {target}")
             if skill_key_for_dir(target, str(move["category"])) != move.get("key"):
                 raise ValueError(f"Duplicate target key mismatch: {target}")
+            safety = duplicate_safety(skills_dir, source, Path(move["target_path"]))
+            if not safety["skill_content_equal"] or not safety["metadata_identity_equal"]:
+                raise ValueError(f"Duplicate target is not content/metadata identical: {target}")
             shutil.rmtree(source)
             continue
         if target.exists():

--- a/tests/test_normalize_skill_depth.py
+++ b/tests/test_normalize_skill_depth.py
@@ -24,6 +24,12 @@ def _write_skill(root: Path, rel_dir: str, metadata: dict) -> Path:
     return skill_dir
 
 
+def _write_skill_with_body(root: Path, rel_dir: str, metadata: dict, body: str) -> Path:
+    skill_dir = _write_skill(root, rel_dir, metadata)
+    (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
+    return skill_dir
+
+
 def test_depth_plan_uses_metadata_category_for_nested_skill(tmp_path):
     module = _load_module()
     skills_dir = tmp_path / "skills"
@@ -117,6 +123,8 @@ def test_depth_plan_reuses_existing_target_for_same_skill_key(tmp_path):
     assert plan["duplicate_count"] == 1
     assert plan["moves"][0]["operation"] == "remove_duplicate"
     assert plan["moves"][0]["target_path"] == "security/auth-audit"
+    assert plan["moves"][0]["skill_content_equal"] is True
+    assert plan["moves"][0]["metadata_identity_equal"] is True
 
 
 def test_apply_depth_plan_removes_nested_duplicate_for_same_skill_key(tmp_path):
@@ -137,6 +145,75 @@ def test_apply_depth_plan_removes_nested_duplicate_for_same_skill_key(tmp_path):
     assert (existing / "SKILL.md").exists()
     assert not (skills_dir / "other" / "other" / "auth-audit").exists()
     assert not (skills_dir / "security" / "auth-audit-acme-security-pack").exists()
+
+
+def test_depth_plan_preserves_same_key_when_skill_content_differs(tmp_path):
+    module = _load_module()
+    skills_dir = tmp_path / "skills"
+    metadata = {
+        "name": "auth-audit",
+        "category": "security",
+        "repo": "acme/security-pack",
+        "path": "skills/auth-audit",
+    }
+    existing = _write_skill_with_body(
+        skills_dir,
+        "security/auth-audit",
+        metadata,
+        "---\nname: auth-audit\n---\n\nExisting body\n",
+    )
+    _write_skill_with_body(
+        skills_dir,
+        "other/other/auth-audit",
+        metadata,
+        "---\nname: auth-audit\n---\n\nNested body changed\n",
+    )
+
+    plan = module.build_depth_plan(skills_dir)
+
+    assert plan["duplicate_count"] == 0
+    assert plan["same_key_conflict_count"] == 1
+    assert plan["same_key_preserved_count"] == 1
+    assert plan["moves"][0]["operation"] == "move"
+    assert plan["moves"][0]["target_path"] == "security/auth-audit-acme-security-pack"
+    assert plan["moves"][0]["same_key_target_path"] == "security/auth-audit"
+    assert plan["moves"][0]["skill_content_equal"] is False
+    assert plan["moves"][0]["metadata_identity_equal"] is True
+
+    module.apply_depth_plan(skills_dir, plan)
+
+    assert (existing / "SKILL.md").exists()
+    assert (skills_dir / "security" / "auth-audit-acme-security-pack" / "SKILL.md").exists()
+    assert not (skills_dir / "other" / "other" / "auth-audit").exists()
+
+
+def test_depth_plan_preserves_same_key_when_metadata_identity_differs(tmp_path):
+    module = _load_module()
+    skills_dir = tmp_path / "skills"
+    existing_metadata = {
+        "name": "auth-audit",
+        "category": "security",
+        "repo": "acme/security-pack",
+        "path": "skills/auth-audit",
+        "author": "Existing",
+    }
+    nested_metadata = {
+        "name": "auth-audit",
+        "category": "security",
+        "repo": "acme/security-pack",
+        "path": "skills/auth-audit",
+        "author": "Nested",
+    }
+    _write_skill(skills_dir, "security/auth-audit", existing_metadata)
+    _write_skill(skills_dir, "other/other/auth-audit", nested_metadata)
+
+    plan = module.build_depth_plan(skills_dir)
+
+    assert plan["duplicate_count"] == 0
+    assert plan["same_key_preserved_count"] == 1
+    assert plan["moves"][0]["operation"] == "move"
+    assert plan["moves"][0]["skill_content_equal"] is True
+    assert plan["moves"][0]["metadata_identity_equal"] is False
 
 
 def test_apply_depth_plan_moves_child_before_parent(tmp_path):


### PR DESCRIPTION
Closes #140.

This makes normalize_skill_depth.py fail closed for same stable-key nested paths.

Changes:
- Only plans remove_duplicate when SKILL.md content and metadata identity are both equal.
- Preserves same-key-but-different content/metadata by moving to a unique suffix path.
- Adds same_key_conflict_count and same_key_preserved_count to the plan.
- Re-checks duplicate safety during apply before deletion.
- Adds regression tests for content drift and metadata identity drift.

Validation:
- git diff --check
- python -m pytest tests/test_normalize_skill_depth.py tests/test_audit_category_residuals.py tests/test_plan_stable_key_duplicate_cleanup.py: 18 passed
- python -m pytest: 340 passed
- Dry-run against current data: 5,654 nested paths; 1,221 safe duplicate removals; 504 same-key drift cases preserved as moves.
