### PR TITLE
Build auditable other reclassification batches

### DIFF
--- a/docs/plan/canonical-taxonomy-governance-spec.md
+++ b/docs/plan/canonical-taxonomy-governance-spec.md
@@ -103,6 +103,37 @@ downstream migration stays fail-closed.
 Secrets must not be written to files or committed. Reports record the
 environment variable name, never the API key value.
 
+## Reclassification Batch Contract
+
+`scripts/build_current_other_reclassification_batch.py` cuts reviewable batches
+directly from the live archive instead of stale pre-migration rows. The default
+scope is current `other`, but the command accepts explicit current categories
+for targeted cleanup.
+
+Each batch writes:
+
+- `input.jsonl`: one SKILL.md-first work item per selected live archive skill.
+- `manifest.json`: batch id, source archive, selection policy, artifact paths,
+  summary counts, and the exact follow-up command sequence.
+
+Each input row includes the current archive path, semantic name, description,
+tags, semantic source map, content excerpt, and provenance hashes for
+`SKILL.md`, `metadata.json`, and the semantic text used for review.
+
+The manifest command sequence is:
+
+1. Run `scripts/classify_residual_workset_with_llm.py` against `input.jsonl`.
+2. Run `scripts/sample_category_classification_audit.py` to produce a
+   deterministic review sample from classification output plus source context.
+3. Run `scripts/apply_category_migration.py` in review-only mode to build a
+   high-confidence, active-category move plan.
+4. Run `scripts/audit_category_residuals.py` to explain what remains blocked
+   before the next batch starts.
+
+This contract is intentionally batch-first. Large `other` migrations must be
+split into reviewable chunks; a single blind mega-apply is not a valid publish
+path.
+
 ## Apply Contract
 
 `scripts/apply_category_migration.py` converts reviewed classification results
@@ -120,6 +151,9 @@ Defaults:
 - Default mode is dry-run. Only `--apply` mutates the archive.
 - `--movable-only` skips blocked duplicates and fills the requested `--limit`
   with apply-ready moves.
+- If classification rows include `source_sha256` or `metadata_sha256`, apply
+  planning recomputes the live archive hashes and rejects stale rows whose
+  source files changed since model review.
 
 Apply mode refuses blocked plans, moves only standard
 `<category>/<skill>/SKILL.md` directories, updates `metadata.json`, and never

--- a/scripts/apply_category_migration.py
+++ b/scripts/apply_category_migration.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 from collections import Counter, defaultdict
 from dataclasses import dataclass
@@ -34,6 +35,12 @@ class ClassificationRow:
     target_category: str
     confidence: float | None
     status: str
+    reason: str = ""
+    evidence: list[Any] | None = None
+    workset: str = ""
+    source_sha256: str = ""
+    metadata_sha256: str = ""
+    semantic_text_sha256: str = ""
 
 
 def load_classification_rows(path: Path) -> list[ClassificationRow]:
@@ -56,6 +63,12 @@ def load_classification_rows(path: Path) -> list[ClassificationRow]:
                     target_category=str(payload.get("llm_category") or ""),
                     confidence=parse_confidence(payload.get("confidence")),
                     status=str(payload.get("status") or ""),
+                    reason=str(payload.get("reason") or ""),
+                    evidence=payload.get("evidence") if isinstance(payload.get("evidence"), list) else [],
+                    workset=str(payload.get("workset") or ""),
+                    source_sha256=str(payload.get("source_sha256") or ""),
+                    metadata_sha256=str(payload.get("metadata_sha256") or ""),
+                    semantic_text_sha256=str(payload.get("semantic_text_sha256") or ""),
                 )
             )
     return rows
@@ -72,6 +85,24 @@ def parse_confidence(value: object) -> float | None:
     if isinstance(value, bool) or not isinstance(value, int | float):
         return None
     return float(value)
+
+
+def file_sha256(path: Path) -> str:
+    if not path.exists() or not path.is_file():
+        return ""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def source_hash_mismatch(row: ClassificationRow, source_dir: Path) -> str:
+    if row.source_sha256:
+        actual = file_sha256(source_dir / "SKILL.md")
+        if actual != row.source_sha256:
+            return "source SKILL.md sha256 changed since classification"
+    if row.metadata_sha256:
+        actual = file_sha256(source_dir / "metadata.json")
+        if actual != row.metadata_sha256:
+            return "source metadata.json sha256 changed since classification"
+    return ""
 
 
 def category_state(skills_dir: Path) -> dict[str, dict[str, Any]]:
@@ -209,6 +240,9 @@ def build_apply_plan(
         if not source_dir.exists():
             reject_reasons["source directory missing"] += 1
             continue
+        if reason := source_hash_mismatch(row, source_dir):
+            reject_reasons[reason] += 1
+            continue
         source_category = source_skill_rel.parts[0]
         target_category = taxonomy.resolve(row.target_category, allow_unknown=True)
         meta = load_metadata(source_dir)
@@ -242,6 +276,9 @@ def build_apply_plan(
             "key": key,
             "repo": repo,
             "reason": operation_reason,
+            "source_sha256": row.source_sha256,
+            "metadata_sha256": row.metadata_sha256,
+            "semantic_text_sha256": row.semantic_text_sha256,
         }
         moves.append(move)
         target_counts[target_category] += 1

--- a/scripts/build_current_other_reclassification_batch.py
+++ b/scripts/build_current_other_reclassification_batch.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Build an auditable live-archive reclassification batch for current categories."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from build_residual_category_worksets import (
+    SCHEMA_VERSION,
+    parse_csv,
+    sorted_counter,
+    work_item_for_skill,
+)
+from plan_category_migration import iter_skill_dirs
+
+
+def build_manifest(
+    *,
+    batch_id: str,
+    skills_dir: Path,
+    output_dir: Path,
+    input_jsonl: Path,
+    from_categories: set[str],
+    limit: int | None,
+    offset: int,
+    content_chars: int,
+    selected: list[dict[str, Any]],
+    matching_total_count: int,
+    archive_counts: Counter[str],
+) -> dict[str, Any]:
+    classify_output = output_dir / "classification.jsonl"
+    classify_report = output_dir / "classification-report.json"
+    checkpoint = output_dir / "checkpoint.jsonl"
+    apply_plan = output_dir / "apply-plan.json"
+    sample_audit = output_dir / "sample-audit.json"
+    residual_report = output_dir / "residual-report.json"
+    from_category_flags = " ".join(
+        f"--from-category {category}" for category in sorted(from_categories)
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "batch_id": batch_id,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "skills_dir": str(skills_dir),
+        "input_jsonl": str(input_jsonl),
+        "policy": {
+            "from_categories": sorted(from_categories),
+            "limit": limit,
+            "offset": offset,
+            "content_chars": content_chars,
+            "apply_mode": "review-only",
+        },
+        "summary": {
+            "archive_category_counts": sorted_counter(archive_counts),
+            "matching_category_skill_count": matching_total_count,
+            "selected_input_count": len(selected),
+            "selected_category_counts": sorted_counter(
+                Counter(str(item.get("current_category") or "") for item in selected)
+            ),
+        },
+        "artifacts": {
+            "input_jsonl": str(input_jsonl),
+            "classification_jsonl": str(classify_output),
+            "classification_report": str(classify_report),
+            "checkpoint_jsonl": str(checkpoint),
+            "apply_plan": str(apply_plan),
+            "sample_audit": str(sample_audit),
+            "residual_report": str(residual_report),
+        },
+        "commands": [
+            (
+                "python scripts/classify_residual_workset_with_llm.py "
+                f"--workset-jsonl {input_jsonl} "
+                f"--classification-output {classify_output} "
+                f"--output {classify_report} "
+                f"--checkpoint-jsonl {checkpoint} "
+                "--api-key-env MIMO_API_KEY "
+                "--base-url https://token-plan-sgp.xiaomimimo.com/v1 "
+                "--model mimo-v2.5-pro --temperature 0"
+            ),
+            (
+                "python scripts/sample_category_classification_audit.py "
+                f"--workset-jsonl {input_jsonl} "
+                f"--classification-jsonl {classify_output} "
+                f"--output {sample_audit}"
+            ),
+            (
+                "python scripts/apply_category_migration.py "
+                f"--skills-dir {skills_dir} "
+                f"--classification-jsonl {classify_output} "
+                f"{from_category_flags} --min-confidence 0.9 --movable-only "
+                f"--output {apply_plan}"
+            ),
+            (
+                "python scripts/audit_category_residuals.py "
+                f"--skills-dir {skills_dir} "
+                f"--classification-jsonl {classify_output} "
+                f"{from_category_flags} --min-confidence 0.9 "
+                f"--output {residual_report}"
+            ),
+        ],
+        "notes": [
+            "This manifest and its input JSONL do not modify archive files.",
+            "Each input row carries SKILL.md and metadata SHA-256 provenance.",
+            "Run the sample audit before applying any generated move plan.",
+            "The apply step refuses inactive categories and changed source hashes.",
+        ],
+    }
+
+
+def build_batch(
+    *,
+    skills_dir: Path,
+    output_dir: Path,
+    batch_id: str,
+    from_categories: set[str] | None = None,
+    limit: int | None = None,
+    offset: int = 0,
+    content_chars: int = 1600,
+) -> dict[str, Any]:
+    from_categories = from_categories or {"other"}
+    archive_counts: Counter[str] = Counter()
+    selected: list[dict[str, Any]] = []
+    matching_total_count = 0
+    safe_offset = max(offset, 0)
+    max_items = max(limit, 0) if limit is not None else None
+
+    for skill_dir, rel in iter_skill_dirs(skills_dir):
+        category = rel.parts[0] if rel.parts else "other"
+        archive_counts[category] += 1
+        if category not in from_categories:
+            continue
+        matching_total_count += 1
+        if matching_total_count <= safe_offset:
+            continue
+        if max_items is not None and len(selected) >= max_items:
+            continue
+        selected.append(
+            work_item_for_skill(
+                skills_dir=skills_dir,
+                skill_dir=skill_dir,
+                rel=rel,
+                workset="live_current_category",
+                reason="live archive skill selected from current category",
+                content_chars=content_chars,
+            )
+        )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    input_jsonl = output_dir / "input.jsonl"
+    with input_jsonl.open("w", encoding="utf-8") as handle:
+        for item in selected:
+            handle.write(json.dumps(item, ensure_ascii=False, sort_keys=True) + "\n")
+
+    manifest = build_manifest(
+        batch_id=batch_id,
+        skills_dir=skills_dir,
+        output_dir=output_dir,
+        input_jsonl=input_jsonl,
+        from_categories=from_categories,
+        limit=limit,
+        offset=safe_offset,
+        content_chars=content_chars,
+        selected=selected,
+        matching_total_count=matching_total_count,
+        archive_counts=archive_counts,
+    )
+    manifest_path = output_dir / "manifest.json"
+    manifest["manifest_json"] = str(manifest_path)
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def print_text_report(manifest: dict[str, Any]) -> None:
+    summary = manifest["summary"]
+    print("Current category reclassification batch")
+    print(f"Batch: {manifest['batch_id']}")
+    print(f"Inputs: {summary['selected_input_count']}")
+    print(f"Matching current categories: {summary['matching_category_skill_count']}")
+    print(f"Input JSONL: {manifest['input_jsonl']}")
+    print(f"Manifest: {manifest['manifest_json']}")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--skills-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--batch-id", required=True)
+    parser.add_argument("--from-category", action="append")
+    parser.add_argument("--limit", type=int)
+    parser.add_argument("--offset", type=int, default=0)
+    parser.add_argument("--content-chars", type=int, default=1600)
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if not args.skills_dir.exists():
+        raise SystemExit(f"Skills directory not found: {args.skills_dir}")
+    manifest = build_batch(
+        skills_dir=args.skills_dir,
+        output_dir=args.output_dir,
+        batch_id=args.batch_id,
+        from_categories=parse_csv(args.from_category) or {"other"},
+        limit=args.limit,
+        offset=args.offset,
+        content_chars=args.content_chars,
+    )
+    if args.json:
+        print(json.dumps(manifest, indent=2, ensure_ascii=False))
+    else:
+        print_text_report(manifest)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_residual_category_worksets.py
+++ b/scripts/build_residual_category_worksets.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 from collections import Counter
 from datetime import datetime, timezone
@@ -18,6 +19,18 @@ from plan_category_migration import iter_skill_dirs
 from utils import extract_frontmatter, load_metadata, skill_semantic_fields
 
 SCHEMA_VERSION = 1
+
+
+def file_sha256(path: Path) -> str:
+    if not path.exists() or not path.is_file():
+        return ""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def text_sha256(value: str) -> str:
+    if not value:
+        return ""
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
 def sorted_counter(counter: Counter[str]) -> dict[str, int]:
@@ -35,6 +48,8 @@ def work_item_for_skill(
     content_chars: int = 1600,
 ) -> dict[str, Any]:
     content = read_text_prefix(skill_dir / "SKILL.md", max_chars=max(content_chars, 8192))
+    source_sha256 = file_sha256(skill_dir / "SKILL.md")
+    metadata_sha256 = file_sha256(skill_dir / "metadata.json")
     metadata = load_metadata(skill_dir)
     frontmatter = extract_frontmatter(content)
     semantics = skill_semantic_fields(
@@ -62,6 +77,9 @@ def work_item_for_skill(
             "category": metadata.get("category", ""),
         },
         "semantic_sources": semantics["sources"],
+        "source_sha256": source_sha256,
+        "metadata_sha256": metadata_sha256,
+        "semantic_text_sha256": text_sha256(str(semantics.get("text") or "")),
         "content_excerpt": content[:content_chars],
     }
     if classification:

--- a/scripts/classify_residual_workset_with_llm.py
+++ b/scripts/classify_residual_workset_with_llm.py
@@ -67,6 +67,9 @@ def item_review_key(item: dict[str, Any]) -> str:
         "description": item.get("description", ""),
         "tags": item.get("tags", []),
         "previous_classification": item.get("previous_classification", {}),
+        "source_sha256": item.get("source_sha256", ""),
+        "metadata_sha256": item.get("metadata_sha256", ""),
+        "semantic_text_sha256": item.get("semantic_text_sha256", ""),
         "content_excerpt": item.get("content_excerpt", ""),
     }
     encoded = json.dumps(
@@ -127,6 +130,10 @@ def compact_candidate(item: dict[str, Any]) -> dict[str, Any]:
         "tags": item.get("tags", []),
         "current_category": item.get("current_category", ""),
         "metadata": item.get("metadata", {}),
+        "semantic_sources": item.get("semantic_sources", {}),
+        "source_sha256": item.get("source_sha256", ""),
+        "metadata_sha256": item.get("metadata_sha256", ""),
+        "semantic_text_sha256": item.get("semantic_text_sha256", ""),
         "previous_classification": item.get("previous_classification", {}),
         "content_excerpt": item.get("content_excerpt", ""),
     }
@@ -235,6 +242,9 @@ def build_result_entry(
         "evidence": evidence,
         "workset": item.get("workset", ""),
         "previous_classification": item.get("previous_classification", {}),
+        "source_sha256": item.get("source_sha256", ""),
+        "metadata_sha256": item.get("metadata_sha256", ""),
+        "semantic_text_sha256": item.get("semantic_text_sha256", ""),
         "input_index": item.get("_input_index"),
     }
 
@@ -414,6 +424,9 @@ def write_classification_jsonl(report: dict[str, Any], output: Path) -> None:
                 "reason": row.get("reason", ""),
                 "evidence": row.get("evidence", []),
                 "workset": row.get("workset", ""),
+                "source_sha256": row.get("source_sha256", ""),
+                "metadata_sha256": row.get("metadata_sha256", ""),
+                "semantic_text_sha256": row.get("semantic_text_sha256", ""),
             }
             handle.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
 

--- a/scripts/sample_category_classification_audit.py
+++ b/scripts/sample_category_classification_audit.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Build a deterministic review sample for category classification batches."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from apply_category_migration import load_classification_rows, parse_csv
+
+SCHEMA_VERSION = 1
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            payload = json.loads(line)
+            if not isinstance(payload, dict):
+                raise ValueError(f"JSONL row {line_number} must be an object")
+            rows.append(payload)
+    return rows
+
+
+def sample_key(row: dict[str, Any], *, seed: str) -> str:
+    payload = "|".join(
+        [
+            seed,
+            str(row.get("path") or ""),
+            str(row.get("llm_category") or ""),
+            str(row.get("source_sha256") or ""),
+        ]
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def build_report(
+    *,
+    workset_jsonl: Path,
+    classification_jsonl: Path,
+    output_sample_size: int = 50,
+    seed: str = "category-audit-v1",
+    statuses: set[str] | None = None,
+    min_confidence: float | None = None,
+) -> dict[str, Any]:
+    work_items = load_jsonl(workset_jsonl)
+    work_by_path = {str(item.get("path") or ""): item for item in work_items}
+    rows = load_classification_rows(classification_jsonl)
+    statuses = statuses or {"ok"}
+    status_counts = Counter(row.status for row in rows)
+    target_counts = Counter(row.target_category for row in rows)
+    matched_count = 0
+    candidates: list[dict[str, Any]] = []
+    missing_input_count = 0
+
+    for row in rows:
+        item = work_by_path.get(row.path)
+        if item is None:
+            missing_input_count += 1
+            continue
+        matched_count += 1
+        if statuses and row.status not in statuses:
+            continue
+        if min_confidence is not None and (
+            row.confidence is None or row.confidence < min_confidence
+        ):
+            continue
+        candidates.append(
+            {
+                "path": row.path,
+                "name": row.name,
+                "current_category": row.current_category,
+                "llm_category": row.target_category,
+                "confidence": row.confidence,
+                "status": row.status,
+                "reason": getattr(row, "reason", ""),
+                "evidence": getattr(row, "evidence", []),
+                "workset": getattr(row, "workset", ""),
+                "source_sha256": row.source_sha256,
+                "metadata_sha256": row.metadata_sha256,
+                "semantic_sources": item.get("semantic_sources", {}),
+                "description": item.get("description", ""),
+                "content_excerpt": item.get("content_excerpt", ""),
+            }
+        )
+
+    sample_size = max(output_sample_size, 0)
+    samples = sorted(candidates, key=lambda item: sample_key(item, seed=seed))[:sample_size]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "workset_jsonl": str(workset_jsonl),
+        "classification_jsonl": str(classification_jsonl),
+        "policy": {
+            "sample_size": output_sample_size,
+            "seed": seed,
+            "statuses": sorted(statuses),
+            "min_confidence": min_confidence,
+        },
+        "summary": {
+            "workset_row_count": len(work_items),
+            "classification_row_count": len(rows),
+            "matched_input_count": matched_count,
+            "missing_input_count": missing_input_count,
+            "candidate_count": len(candidates),
+            "sample_count": len(samples),
+            "status_counts": dict(sorted(status_counts.items())),
+            "target_category_counts": dict(sorted(target_counts.items())),
+        },
+        "samples": samples,
+        "notes": [
+            "Review sample rows against SKILL.md excerpts before applying a migration plan.",
+            "Sampling is deterministic for a fixed seed and classification input.",
+        ],
+    }
+
+
+def print_text_report(report: dict[str, Any], *, limit: int) -> None:
+    summary = report["summary"]
+    print("Category classification sample audit")
+    print(f"Classifications: {summary['classification_row_count']}")
+    print(f"Candidates: {summary['candidate_count']}")
+    print(f"Samples: {summary['sample_count']}")
+    for sample in report["samples"][: max(limit, 0)]:
+        print(
+            f"- {sample['path']}: {sample['current_category']} -> "
+            f"{sample['llm_category']} q={sample['confidence']}"
+        )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workset-jsonl", type=Path, required=True)
+    parser.add_argument("--classification-jsonl", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--sample-size", type=int, default=50)
+    parser.add_argument("--seed", default="category-audit-v1")
+    parser.add_argument("--status", action="append", default=["ok"])
+    parser.add_argument("--min-confidence", type=float)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--preview-limit", type=int, default=10)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if not args.workset_jsonl.exists():
+        raise SystemExit(f"Workset JSONL not found: {args.workset_jsonl}")
+    if not args.classification_jsonl.exists():
+        raise SystemExit(f"Classification JSONL not found: {args.classification_jsonl}")
+    report = build_report(
+        workset_jsonl=args.workset_jsonl,
+        classification_jsonl=args.classification_jsonl,
+        output_sample_size=args.sample_size,
+        seed=args.seed,
+        statuses=parse_csv(args.status),
+        min_confidence=args.min_confidence,
+    )
+    payload = json.dumps(report, indent=2, ensure_ascii=False)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload + "\n", encoding="utf-8")
+    if args.json:
+        print(payload)
+    else:
+        print_text_report(report, limit=args.preview_limit)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_apply_category_migration.py
+++ b/tests/test_apply_category_migration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import importlib
 import json
 import sys
@@ -177,6 +178,41 @@ def test_existing_target_key_is_blocked_not_deleted(tmp_path):
     assert (skills_dir / "development" / "already-there" / "SKILL.md").exists()
 
 
+def test_source_hash_mismatch_blocks_stale_classification(tmp_path):
+    migrator = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "other", "stale")
+    skill_path = skills_dir / "other" / "stale" / "SKILL.md"
+    original_hash = hashlib.sha256(skill_path.read_bytes()).hexdigest()
+    skill_path.write_text("---\nname: stale\n---\n\nchanged", encoding="utf-8")
+    classification = tmp_path / "classification.jsonl"
+    _write_classification(
+        classification,
+        [
+            {
+                "path": "other/stale/SKILL.md",
+                "name": "stale",
+                "current_category": "other",
+                "llm_category": "development",
+                "confidence": 0.95,
+                "status": "ok",
+                "source_sha256": original_hash,
+            }
+        ],
+    )
+
+    plan = migrator.build_apply_plan(
+        skills_dir=skills_dir,
+        classification_jsonl=classification,
+        from_categories={"other"},
+    )
+
+    assert plan["summary"]["planned_move_count"] == 0
+    assert plan["summary"]["reject_reasons"] == {
+        "source SKILL.md sha256 changed since classification": 1
+    }
+
+
 def test_movable_only_skips_blocked_moves_and_fills_limit(tmp_path):
     migrator = _load_module()
     skills_dir = tmp_path / "skills"
@@ -295,5 +331,5 @@ def test_filters_exclude_low_confidence_review_targets_and_other_targets(tmp_pat
     assert plan["summary"]["reject_reasons"] == {
         "classification target matches current category": 1,
         "confidence below threshold": 1,
-            "target category status 'legacy' excluded by filter": 1,
+        "target category status 'legacy' excluded by filter": 1,
     }

--- a/tests/test_build_current_other_reclassification_batch.py
+++ b/tests/test_build_current_other_reclassification_batch.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    return importlib.import_module("build_current_other_reclassification_batch")
+
+
+def _write_skill(root: Path, rel: str, *, body: str | None = None) -> None:
+    skill_dir = root / rel
+    skill_dir.mkdir(parents=True)
+    payload = {
+        "name": Path(rel).name,
+        "category": Path(rel).parts[0],
+        "dir_name": Path(rel).name,
+    }
+    (skill_dir / "metadata.json").write_text(
+        json.dumps(payload, indent=2),
+        encoding="utf-8",
+    )
+    (skill_dir / "SKILL.md").write_text(
+        body or f"---\nname: {Path(rel).name}\n---\n\nUse this skill.",
+        encoding="utf-8",
+    )
+
+
+def test_builds_current_other_input_and_manifest(tmp_path):
+    builder = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "other/alpha")
+    _write_skill(skills_dir, "other/beta")
+    _write_skill(skills_dir, "development/gamma")
+    output_dir = tmp_path / "batch"
+
+    manifest = builder.build_batch(
+        skills_dir=skills_dir,
+        output_dir=output_dir,
+        batch_id="other-001",
+        from_categories={"other"},
+        limit=1,
+        offset=1,
+        content_chars=120,
+    )
+
+    rows = [
+        json.loads(line)
+        for line in (output_dir / "input.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    saved_manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+
+    assert manifest["batch_id"] == "other-001"
+    assert saved_manifest["summary"]["archive_category_counts"] == {
+        "development": 1,
+        "other": 2,
+    }
+    assert saved_manifest["summary"]["matching_category_skill_count"] == 2
+    assert saved_manifest["summary"]["selected_input_count"] == 1
+    assert rows[0]["path"] == "other/beta/SKILL.md"
+    assert rows[0]["workset"] == "live_current_category"
+    assert rows[0]["source_sha256"]
+    assert rows[0]["metadata_sha256"]
+    assert rows[0]["semantic_text_sha256"]
+    assert "sample_category_classification_audit.py" in "\n".join(saved_manifest["commands"])

--- a/tests/test_build_residual_category_worksets.py
+++ b/tests/test_build_residual_category_worksets.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import importlib
 import json
 import sys
@@ -106,6 +107,14 @@ def test_builds_gap_low_confidence_review_and_target_other_worksets(tmp_path):
     assert report["summary"]["scoped_existing_classification_count"] == 3
     assert report["worksets"]["classification_gap"][0]["path"] == "other/gap/SKILL.md"
     assert report["worksets"]["classification_gap"][0]["skill_dir"] == "other/gap"
+    assert (
+        report["worksets"]["classification_gap"][0]["source_sha256"]
+        == hashlib.sha256(
+            (skills_dir / "other" / "gap" / "SKILL.md").read_bytes()
+        ).hexdigest()
+    )
+    assert report["worksets"]["classification_gap"][0]["metadata_sha256"]
+    assert report["worksets"]["classification_gap"][0]["semantic_text_sha256"]
     assert report["worksets"]["low_confidence"][0]["previous_classification"] == {
         "llm_category": "development",
         "confidence": 0.5,

--- a/tests/test_classify_residual_workset_with_llm.py
+++ b/tests/test_classify_residual_workset_with_llm.py
@@ -37,6 +37,9 @@ def _work_item(path: str, *, workset: str = "classification_gap") -> dict:
         "current_category": "other",
         "metadata": {"repo": "owner/repo", "path": ".claude/skills/test/SKILL.md"},
         "previous_classification": {},
+        "source_sha256": f"skill-{path}",
+        "metadata_sha256": f"metadata-{path}",
+        "semantic_text_sha256": f"semantic-{path}",
         "content_excerpt": "Use this skill for coding workflows and unit tests.",
     }
 
@@ -99,6 +102,9 @@ def test_batch_classification_accepts_json_array_and_writes_apply_rows(tmp_path)
     assert rows[0]["llm_category"] == "development"
     assert rows[0]["status"] == "ok"
     assert rows[0]["workset"] == "classification_gap"
+    assert rows[0]["source_sha256"] == "skill-other/dev"
+    assert rows[0]["metadata_sha256"] == "metadata-other/dev"
+    assert rows[0]["semantic_text_sha256"] == "semantic-other/dev"
 
 
 def test_batch_classification_accepts_fenced_json_array(tmp_path):

--- a/tests/test_sample_category_classification_audit.py
+++ b/tests/test_sample_category_classification_audit.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    return importlib.import_module("sample_category_classification_audit")
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def test_builds_deterministic_sample_with_input_context(tmp_path):
+    sampler = _load_module()
+    workset = tmp_path / "workset.jsonl"
+    classification = tmp_path / "classification.jsonl"
+    _write_jsonl(
+        workset,
+        [
+            {
+                "path": "other/a/SKILL.md",
+                "description": "A development helper",
+                "content_excerpt": "Use for coding.",
+                "semantic_sources": {"name": "frontmatter"},
+            },
+            {
+                "path": "other/b/SKILL.md",
+                "description": "A document helper",
+                "content_excerpt": "Use for docs.",
+                "semantic_sources": {"description": "body"},
+            },
+        ],
+    )
+    _write_jsonl(
+        classification,
+        [
+            {
+                "path": "other/a/SKILL.md",
+                "name": "a",
+                "current_category": "other",
+                "llm_category": "development",
+                "confidence": 0.95,
+                "status": "ok",
+                "reason": "code",
+                "evidence": ["coding"],
+                "source_sha256": "source-a",
+            },
+            {
+                "path": "other/b/SKILL.md",
+                "name": "b",
+                "current_category": "other",
+                "llm_category": "documents",
+                "confidence": 0.5,
+                "status": "ok",
+                "reason": "docs",
+                "evidence": ["document"],
+            },
+        ],
+    )
+
+    report = sampler.build_report(
+        workset_jsonl=workset,
+        classification_jsonl=classification,
+        output_sample_size=5,
+        seed="fixed",
+        statuses={"ok"},
+        min_confidence=0.9,
+    )
+
+    assert report["summary"]["classification_row_count"] == 2
+    assert report["summary"]["candidate_count"] == 1
+    assert report["summary"]["sample_count"] == 1
+    assert report["samples"][0]["path"] == "other/a/SKILL.md"
+    assert report["samples"][0]["source_sha256"] == "source-a"
+    assert report["samples"][0]["description"] == "A development helper"


### PR DESCRIPTION
## Summary
- add a live-archive batch builder for current other/category reclassification with manifest-driven follow-up commands
- carry SKILL.md, metadata, and semantic-text hashes through worksets, MiMo classification output, sample audits, and apply plans
- fail closed when apply planning sees a source hash drift after classification
- document the batch-first reclassification contract for taxonomy governance

Closes #146.

## Validation
- python -m ruff check scripts/build_residual_category_worksets.py scripts/build_current_other_reclassification_batch.py scripts/classify_residual_workset_with_llm.py scripts/apply_category_migration.py scripts/sample_category_classification_audit.py tests/test_build_residual_category_worksets.py tests/test_build_current_other_reclassification_batch.py tests/test_classify_residual_workset_with_llm.py tests/test_apply_category_migration.py tests/test_sample_category_classification_audit.py
- python -m pytest -q tests/test_build_residual_category_worksets.py tests/test_build_current_other_reclassification_batch.py tests/test_classify_residual_workset_with_llm.py tests/test_apply_category_migration.py tests/test_sample_category_classification_audit.py
- python -m pytest -q --cov-fail-under=50
- smoke: built /tmp/csr-other-batch-smoke from live data archive, ran MiMo classification for 5 inputs, sample audit, dry-run apply plan, and residual audit