### PR TITLE
Finish canonical taxonomy issue gates

### DIFF
--- a/docs/plan/canonical-taxonomy-governance-spec.md
+++ b/docs/plan/canonical-taxonomy-governance-spec.md
@@ -40,6 +40,9 @@ Each category declares:
 - `keywords`: deterministic text signals used for audit scoring.
 - `status`: `active`; missing status is `active`.
 - `description`: inclusion rule or migration context.
+- `inclusion_rule`: required user-facing boundary for active categories.
+- `exclusion_rule`: required neighboring-category boundary for active categories.
+- `examples`: required concrete examples for active categories.
 - `parent`: optional reporting relationship.
 
 Only `active` categories are publishable. `other` is an active fallback bucket,
@@ -129,6 +132,9 @@ The manifest command sequence is:
    high-confidence, active-category move plan.
 4. Run `scripts/audit_category_residuals.py` to explain what remains blocked
    before the next batch starts.
+5. Run `scripts/build_residual_category_worksets.py` to split classification
+   gaps, low-confidence rows, target-`other` rows, and inactive targets into
+   explicit next-batch inputs.
 
 This contract is intentionally batch-first. Large `other` migrations must be
 split into reviewable chunks; a single blind mega-apply is not a valid publish
@@ -186,6 +192,8 @@ Taxonomy gate:
 - `--strict-canonical` fails if taxonomy definitions still contain non-active
   transitional categories, inbound aliases, or category-level migration targets.
 - `--publish-category <slug>` fails when a publish target is unknown or legacy.
+- Active categories must declare `inclusion_rule`, `exclusion_rule`, and at
+  least one example.
 - The default report includes canonical and noncanonical category counts so
   category cleanup progress is visible.
 
@@ -206,6 +214,9 @@ Category artifact gate:
 - `scripts/check_canonical_categories.py` verifies archive directories,
   metadata categories, registry shards, search docs, stats, and category
   artifacts use only active canonical categories and category codes.
+- It also checks category count consistency across
+  `docs/categories/index.json`, category pointers, category manifests, manifest
+  part counts, category parts, and `docs/stats.json`.
 
 ## Operating Flow
 

--- a/scripts/build_current_other_reclassification_batch.py
+++ b/scripts/build_current_other_reclassification_batch.py
@@ -39,6 +39,8 @@ def build_manifest(
     apply_plan = output_dir / "apply-plan.json"
     sample_audit = output_dir / "sample-audit.json"
     residual_report = output_dir / "residual-report.json"
+    residual_worksets_report = output_dir / "residual-worksets.json"
+    residual_worksets_dir = output_dir / "residual-worksets"
     from_category_flags = " ".join(
         f"--from-category {category}" for category in sorted(from_categories)
     )
@@ -71,6 +73,8 @@ def build_manifest(
             "apply_plan": str(apply_plan),
             "sample_audit": str(sample_audit),
             "residual_report": str(residual_report),
+            "residual_worksets_report": str(residual_worksets_report),
+            "residual_worksets_dir": str(residual_worksets_dir),
         },
         "commands": [
             (
@@ -103,12 +107,21 @@ def build_manifest(
                 f"{from_category_flags} --min-confidence 0.9 "
                 f"--output {residual_report}"
             ),
+            (
+                "python scripts/build_residual_category_worksets.py "
+                f"--skills-dir {skills_dir} "
+                f"--classification-jsonl {classify_output} "
+                f"{from_category_flags} --min-confidence 0.9 "
+                f"--output {residual_worksets_report} "
+                f"--workset-output-dir {residual_worksets_dir}"
+            ),
         ],
         "notes": [
             "This manifest and its input JSONL do not modify archive files.",
             "Each input row carries SKILL.md and metadata SHA-256 provenance.",
             "Run the sample audit before applying any generated move plan.",
             "The apply step refuses inactive categories and changed source hashes.",
+            "Residual worksets explain classification gaps, low-confidence rows, target-other rows, and inactive targets before the next batch.",
         ],
     }
 

--- a/scripts/category_taxonomy.py
+++ b/scripts/category_taxonomy.py
@@ -28,6 +28,9 @@ class CategoryDefinition:
     keywords: tuple[str, ...]
     status: str = "active"
     description: str = ""
+    inclusion_rule: str = ""
+    exclusion_rule: str = ""
+    examples: tuple[str, ...] = ()
     parent: str = ""
     migrate_to: str = ""
 
@@ -135,6 +138,14 @@ def _as_string_list(value: Any) -> tuple[str, ...]:
     return tuple(category_slug(item) for item in value if category_slug(item))
 
 
+def _as_plain_string_list(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise ValueError("taxonomy examples must be lists")
+    return tuple(str(item).strip() for item in value if str(item).strip())
+
+
 def _as_optional_slug(value: Any) -> str:
     if value is None:
         return ""
@@ -188,6 +199,9 @@ def load_taxonomy(path: Path = DEFAULT_TAXONOMY_PATH) -> CategoryTaxonomy:
                 f"taxonomy category {slug!r} has invalid status {status!r}"
             )
         description = str(entry.get("description") or "").strip()
+        inclusion_rule = str(entry.get("inclusion_rule") or "").strip()
+        exclusion_rule = str(entry.get("exclusion_rule") or "").strip()
+        examples = _as_plain_string_list(entry.get("examples"))
         parent = _as_optional_slug(entry.get("parent"))
         migrate_to = _as_optional_slug(entry.get("migrate_to"))
         categories[slug] = CategoryDefinition(
@@ -198,6 +212,9 @@ def load_taxonomy(path: Path = DEFAULT_TAXONOMY_PATH) -> CategoryTaxonomy:
             keywords=keywords,
             status=status,
             description=description,
+            inclusion_rule=inclusion_rule,
+            exclusion_rule=exclusion_rule,
+            examples=examples,
             parent=parent,
             migrate_to=migrate_to,
         )

--- a/scripts/check_canonical_categories.py
+++ b/scripts/check_canonical_categories.py
@@ -135,6 +135,93 @@ def _check_skill_record(
     gate.check_category(record.get("category"), path=path, field="skill.category", issues=issues)
 
 
+def _count_value(
+    value: Any,
+    *,
+    path: str,
+    field: str,
+    issues: list[CategoryIssue],
+) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        issues.append(
+            CategoryIssue(
+                "category-count-invalid",
+                path,
+                f"{field} must be a non-negative integer",
+            )
+        )
+        return None
+    return value
+
+
+def _record_count(
+    counts: dict[str, int],
+    *,
+    slug: str | None,
+    count: int | None,
+    label: str,
+    path: str,
+    issues: list[CategoryIssue],
+) -> None:
+    if slug is None or count is None:
+        return
+    previous = counts.get(slug)
+    if previous is not None and previous != count:
+        issues.append(
+            CategoryIssue(
+                "category-count-mismatch",
+                path,
+                f"{label} count for {slug!r} changed within the same artifact "
+                f"({previous} != {count})",
+            )
+        )
+        return
+    counts[slug] = count
+
+
+def _compare_count_maps(
+    issues: list[CategoryIssue],
+    *,
+    expected: dict[str, int],
+    expected_label: str,
+    actual: dict[str, int],
+    actual_label: str,
+    path: str,
+) -> None:
+    if not expected or not actual:
+        return
+    for slug in sorted(set(expected) | set(actual)):
+        if slug not in expected:
+            issues.append(
+                CategoryIssue(
+                    "category-count-missing",
+                    path,
+                    f"{actual_label} has {slug!r} but {expected_label} does not",
+                )
+            )
+            continue
+        if slug not in actual:
+            issues.append(
+                CategoryIssue(
+                    "category-count-missing",
+                    path,
+                    f"{expected_label} has {slug!r} but {actual_label} does not",
+                )
+            )
+            continue
+        if expected[slug] != actual[slug]:
+            issues.append(
+                CategoryIssue(
+                    "category-count-mismatch",
+                    path,
+                    f"{expected_label} count for {slug!r} does not match "
+                    f"{actual_label} ({expected[slug]} != {actual[slug]})",
+                )
+            )
+
+
 def check_skills_dir(skills_dir: Path, gate: CategoryGate) -> list[CategoryIssue]:
     issues: list[CategoryIssue] = []
     if not skills_dir.exists():
@@ -246,13 +333,14 @@ def _check_category_entry(
     path: str,
     gate: CategoryGate,
     issues: list[CategoryIssue],
-) -> None:
+) -> str | None:
     if not isinstance(entry, dict):
         issues.append(CategoryIssue("category-entry-shape", path, "category entry must be an object"))
-        return
-    gate.check_category(entry.get("name"), path=path, field="category.name", issues=issues)
+        return None
+    slug = gate.check_category(entry.get("name"), path=path, field="category.name", issues=issues)
     if "code" in entry:
         gate.check_code(entry.get("code"), path=path, field="category.code", issues=issues)
+    return slug
 
 
 def _check_category_payload(
@@ -261,11 +349,11 @@ def _check_category_payload(
     path: str,
     gate: CategoryGate,
     issues: list[CategoryIssue],
-) -> None:
+) -> str | None:
     if not isinstance(payload, dict):
         issues.append(CategoryIssue("artifact-shape", path, "category artifact must be an object"))
-        return
-    gate.check_category(payload.get("category"), path=path, field="category", issues=issues)
+        return None
+    slug = gate.check_category(payload.get("category"), path=path, field="category", issues=issues)
     if "code" in payload:
         gate.check_code(payload.get("code"), path=path, field="code", issues=issues)
     for index, record in enumerate(_iter_skill_records_from_json(payload)):
@@ -275,6 +363,7 @@ def _check_category_payload(
             gate=gate,
             issues=issues,
         )
+    return slug
 
 
 def _check_search_records(
@@ -313,15 +402,36 @@ def check_docs_dir(docs_dir: Path, gate: CategoryGate) -> list[CategoryIssue]:
         return [CategoryIssue("docs-dir-missing", str(docs_dir), "docs directory missing")]
 
     categories_dir = docs_dir / "categories"
+    index_counts: dict[str, int] = {}
+    pointer_counts: dict[str, int] = {}
+    manifest_counts: dict[str, int] = {}
+    manifest_part_counts: dict[str, int] = {}
+    stats_counts: dict[str, int] = {}
+
     index_path = categories_dir / "index.json"
     if index_path.exists():
         index_payload = _load_json(index_path, issues)
         if isinstance(index_payload, dict):
             for index, entry in enumerate(index_payload.get("categories") or []):
-                _check_category_entry(
+                entry_path = _record_path(index_path, docs_dir, f"categories[{index}]")
+                slug = _check_category_entry(
                     entry,
-                    path=_record_path(index_path, docs_dir, f"categories[{index}]"),
+                    path=entry_path,
                     gate=gate,
+                    issues=issues,
+                )
+                count = _count_value(
+                    entry.get("count") if isinstance(entry, dict) else None,
+                    path=entry_path,
+                    field="category.count",
+                    issues=issues,
+                )
+                _record_count(
+                    index_counts,
+                    slug=slug,
+                    count=count,
+                    label="category index",
+                    path=entry_path,
                     issues=issues,
                 )
 
@@ -329,7 +439,7 @@ def check_docs_dir(docs_dir: Path, gate: CategoryGate) -> list[CategoryIssue]:
         for pointer_path in sorted(categories_dir.glob("*.json")):
             if pointer_path.name == "index.json":
                 continue
-            gate.check_category(
+            filename_slug = gate.check_category(
                 pointer_path.stem,
                 path=_record_path(pointer_path, docs_dir),
                 field="category pointer filename",
@@ -337,15 +447,30 @@ def check_docs_dir(docs_dir: Path, gate: CategoryGate) -> list[CategoryIssue]:
             )
             payload = _load_json(pointer_path, issues)
             if payload is not None:
-                _check_category_payload(
+                payload_path = _record_path(pointer_path, docs_dir)
+                payload_slug = _check_category_payload(
                     payload,
-                    path=_record_path(pointer_path, docs_dir),
+                    path=payload_path,
                     gate=gate,
+                    issues=issues,
+                )
+                count = _count_value(
+                    payload.get("count") if isinstance(payload, dict) else None,
+                    path=payload_path,
+                    field="count",
+                    issues=issues,
+                )
+                _record_count(
+                    pointer_counts,
+                    slug=payload_slug or filename_slug,
+                    count=count,
+                    label="category pointer",
+                    path=payload_path,
                     issues=issues,
                 )
 
         for manifest_path in sorted(categories_dir.glob("*/manifest.json")):
-            gate.check_category(
+            directory_slug = gate.check_category(
                 manifest_path.parent.name,
                 path=_record_path(manifest_path, docs_dir),
                 field="category manifest directory",
@@ -353,22 +478,115 @@ def check_docs_dir(docs_dir: Path, gate: CategoryGate) -> list[CategoryIssue]:
             )
             payload = _load_json(manifest_path, issues)
             if payload is not None:
-                _check_category_payload(
+                manifest_label = _record_path(manifest_path, docs_dir)
+                payload_slug = _check_category_payload(
                     payload,
-                    path=_record_path(manifest_path, docs_dir),
+                    path=manifest_label,
                     gate=gate,
                     issues=issues,
                 )
+                slug = payload_slug or directory_slug
+                count = _count_value(
+                    payload.get("count") if isinstance(payload, dict) else None,
+                    path=manifest_label,
+                    field="count",
+                    issues=issues,
+                )
+                _record_count(
+                    manifest_counts,
+                    slug=slug,
+                    count=count,
+                    label="category manifest",
+                    path=manifest_label,
+                    issues=issues,
+                )
+                parts = payload.get("parts") if isinstance(payload, dict) else None
+                if isinstance(parts, list):
+                    part_count = _count_value(
+                        payload.get("part_count"),
+                        path=manifest_label,
+                        field="part_count",
+                        issues=issues,
+                    )
+                    if part_count is not None and part_count != len(parts):
+                        issues.append(
+                            CategoryIssue(
+                                "category-count-mismatch",
+                                manifest_label,
+                                "part_count does not match the number of manifest parts "
+                                f"({part_count} != {len(parts)})",
+                            )
+                        )
+                    part_total = 0
+                    valid_part_counts = True
+                    for part_index, part in enumerate(parts):
+                        part_label = f"{manifest_label} parts[{part_index}]"
+                        if not isinstance(part, dict):
+                            issues.append(
+                                CategoryIssue(
+                                    "category-part-entry-shape",
+                                    part_label,
+                                    "category manifest part entry must be an object",
+                                )
+                            )
+                            valid_part_counts = False
+                            continue
+                        part_entry_count = _count_value(
+                            part.get("count"),
+                            path=part_label,
+                            field="parts[].count",
+                            issues=issues,
+                        )
+                        if part_entry_count is None:
+                            valid_part_counts = False
+                        else:
+                            part_total += part_entry_count
+                    if valid_part_counts:
+                        _record_count(
+                            manifest_part_counts,
+                            slug=slug,
+                            count=part_total,
+                            label="category manifest parts",
+                            path=manifest_label,
+                            issues=issues,
+                        )
+                        if count is not None and count != part_total:
+                            issues.append(
+                                CategoryIssue(
+                                    "category-count-mismatch",
+                                    manifest_label,
+                                    "manifest count does not match manifest part counts "
+                                    f"({count} != {part_total})",
+                                )
+                            )
 
         for part_path in sorted(categories_dir.glob("*/part-*.json")):
             payload = _load_json(part_path, issues)
             if payload is not None:
+                part_label = _record_path(part_path, docs_dir)
+                records = _iter_skill_records_from_json(payload)
                 _check_category_payload(
                     payload,
-                    path=_record_path(part_path, docs_dir),
+                    path=part_label,
                     gate=gate,
                     issues=issues,
                 )
+                if isinstance(payload, dict):
+                    part_payload_count = _count_value(
+                        payload.get("count"),
+                        path=part_label,
+                        field="count",
+                        issues=issues,
+                    )
+                    if part_payload_count is not None and part_payload_count != len(records):
+                        issues.append(
+                            CategoryIssue(
+                                "category-count-mismatch",
+                                part_label,
+                                "part count does not match the number of skill records "
+                                f"({part_payload_count} != {len(records)})",
+                            )
+                        )
 
     for path in (docs_dir / "search-index-lite.json", docs_dir / "featured.json"):
         if path.exists():
@@ -399,12 +617,60 @@ def check_docs_dir(docs_dir: Path, gate: CategoryGate) -> list[CategoryIssue]:
                 values = stats_payload.get(key)
                 if isinstance(values, list):
                     for index, entry in enumerate(values):
-                        _check_category_entry(
+                        entry_path = _record_path(stats_path, docs_dir, f"{key}[{index}]")
+                        slug = _check_category_entry(
                             entry,
-                            path=_record_path(stats_path, docs_dir, f"{key}[{index}]"),
+                            path=entry_path,
                             gate=gate,
                             issues=issues,
                         )
+                        count = _count_value(
+                            entry.get("count") if isinstance(entry, dict) else None,
+                            path=entry_path,
+                            field="category.count",
+                            issues=issues,
+                        )
+                        _record_count(
+                            stats_counts,
+                            slug=slug,
+                            count=count,
+                            label="stats category counts",
+                            path=entry_path,
+                            issues=issues,
+                        )
+
+    _compare_count_maps(
+        issues,
+        expected=index_counts,
+        expected_label="categories/index.json",
+        actual=pointer_counts,
+        actual_label="category pointers",
+        path=_record_path(categories_dir / "index.json", docs_dir),
+    )
+    _compare_count_maps(
+        issues,
+        expected=index_counts,
+        expected_label="categories/index.json",
+        actual=manifest_counts,
+        actual_label="category manifests",
+        path=_record_path(categories_dir / "index.json", docs_dir),
+    )
+    _compare_count_maps(
+        issues,
+        expected=manifest_counts,
+        expected_label="category manifests",
+        actual=manifest_part_counts,
+        actual_label="category manifest parts",
+        path=_record_path(categories_dir / "index.json", docs_dir),
+    )
+    _compare_count_maps(
+        issues,
+        expected=index_counts,
+        expected_label="categories/index.json",
+        actual=stats_counts,
+        actual_label="stats category_counts",
+        path=_record_path(stats_path, docs_dir),
+    )
 
     return issues
 

--- a/scripts/check_taxonomy_governance.py
+++ b/scripts/check_taxonomy_governance.py
@@ -148,8 +148,39 @@ def build_report(
                     message="canonical category definitions must not carry migration targets",
                 )
             )
+        if definition.status == "active" and not definition.inclusion_rule:
+            issues.append(
+                GovernanceIssue(
+                    severity="error",
+                    code="missing-inclusion-rule",
+                    category=slug,
+                    message="active canonical category must declare an inclusion_rule",
+                )
+            )
+        if definition.status == "active" and not definition.exclusion_rule:
+            issues.append(
+                GovernanceIssue(
+                    severity="error",
+                    code="missing-exclusion-rule",
+                    category=slug,
+                    message="active canonical category must declare an exclusion_rule",
+                )
+            )
+        if definition.status == "active" and not definition.examples:
+            issues.append(
+                GovernanceIssue(
+                    severity="error",
+                    code="missing-examples",
+                    category=slug,
+                    message="active canonical category must declare at least one example",
+                )
+            )
         broad_name = bool(_slug_tokens(slug) & REVIEW_NAME_TOKENS)
-        if definition.status == "active" and broad_name and not definition.description:
+        if (
+            definition.status == "active"
+            and broad_name
+            and not (definition.description or definition.inclusion_rule)
+        ):
             issues.append(
                 GovernanceIssue(
                     severity="warning",

--- a/taxonomy/categories.yaml
+++ b/taxonomy/categories.yaml
@@ -142,161 +142,287 @@ categories:
   - slug: agent
     code: agent
     display_name: Agent
+    inclusion_rule: "Single-agent behavior, role design, agent instructions, or agent runtime helpers."
+    exclusion_rule: "Multi-agent scheduling belongs in `orchestration`; general LLM prompting belongs in `ai-llm`."
+    examples: ["agent role templates", "agent memory helpers"]
   - slug: ai-llm
     code: ai-llm
     display_name: AI / LLM
+    inclusion_rule: "LLM prompting, model use, assistants, chat workflows, and language-model evaluation."
+    exclusion_rule: "Model training or ML pipelines belong in `ai-ml`; agent orchestration belongs in `orchestration`."
+    examples: ["prompt engineering", "LLM eval", "chat assistants"]
     keywords: [ai, llm, language-model, prompt, prompting]
   - slug: ai-ml
     code: ai-ml
     display_name: AI / ML
+    inclusion_rule: "Machine learning, model training, inference infrastructure, datasets, and ML experiments."
+    exclusion_rule: "Pure LLM prompt usage belongs in `ai-llm`; local runtime setup belongs in `local-ai-infrastructure`."
+    examples: ["model training", "embeddings", "ML datasets"]
     keywords: [ai, ml, machine-learning, model, training]
   - slug: analysis
     code: analysis
     display_name: Analysis
+    inclusion_rule: "Analysis, synthesis, inspection, reporting, and evidence extraction workflows."
+    exclusion_rule: "Data pipelines belong in `data`; product analytics tied to PRDs can use `product`."
+    examples: ["research analysis", "codebase analysis", "story analysis"]
     keywords: [analysis, analyze, insights]
   - slug: api
     code: api
     display_name: API
+    inclusion_rule: "API design, SDK usage, endpoint work, schema contracts, and OpenAPI-like tasks."
+    exclusion_rule: "Cross-product connector workflows belong in `integration`."
+    examples: ["REST API helpers", "SDK wrappers"]
     keywords: [api, sdk, endpoint, openapi]
   - slug: bash
     code: bash
     display_name: Bash
+    inclusion_rule: "Shell scripting, command-line automation, POSIX tooling, and terminal workflows."
+    exclusion_rule: "Application build/debug tasks belong in `development`; deployment automation belongs in `devops`."
+    examples: ["shell scripts", "CLI helpers"]
     keywords: [bash, shell, script, cli]
   - slug: business
     code: business
     display_name: Business
+    inclusion_rule: "Business operations, monetization, strategy, revenue, sales, and company workflows."
+    exclusion_rule: "Personal workflow tools belong in `productivity`; product requirements belong in `product`."
+    examples: ["pricing", "GTM", "monetization"]
     keywords: [business, operations, strategy]
   - slug: c-level
     code: c-level
     display_name: C-Level
+    inclusion_rule: "Executive communication, board-level summaries, leadership decisions, and strategic briefs."
+    exclusion_rule: "General business process work belongs in `business`."
+    examples: ["CEO memo", "board update"]
   - slug: communication
     code: communication
     display_name: Communication
+    inclusion_rule: "Human communication workflows including email, messaging, announcements, and conversation drafting."
+    exclusion_rule: "Marketing campaigns belong in `marketing`; writing craft belongs in `writing`."
+    examples: ["email reply", "Slack message", "announcement"]
     keywords: [communication, messaging, email, chat]
   - slug: context-management
     code: context-management
     display_name: Context Management
+    inclusion_rule: "Context packing, memory, retrieval context, prompt context, and agent state handling."
+    exclusion_rule: "General productivity memory tools belong in `productivity`."
+    examples: ["context compaction", "memory search"]
   - slug: creative
     code: creative
     display_name: Creative
+    inclusion_rule: "Ideation, storytelling, creative direction, and generative creative workflows."
+    exclusion_rule: "Finished prose editing belongs in `writing`; visual UI design belongs in `design`."
+    examples: ["story ideation", "campaign concepts"]
     keywords: [creative, ideation, story, writing]
   - slug: data
     code: dat
     display_name: Data
+    inclusion_rule: "Data engineering, analytics, databases, ETL, SQL, and visualization workflows."
+    exclusion_rule: "Analysis without data plumbing belongs in `analysis`."
+    examples: ["SQL", "ETL", "dashboards"]
     description: "Data engineering, analytics, databases, ETL, SQL, and visualization workflows."
     keywords: [data, analytics, sql, database, etl, pipeline, visualization]
   - slug: design
     code: des
     display_name: Design
+    inclusion_rule: "UI, UX, visual design, Figma, interaction design, and design-system work."
+    exclusion_rule: "Frontend code implementation belongs in `development`."
+    examples: ["Figma extraction", "UI audit"]
     description: "UI, UX, visual design, frontend styling, Figma, components, and interaction design."
     keywords: [design, ui, ux, css, frontend, component, tailwind, figma, animation]
   - slug: development
     code: dev
     display_name: Development
+    inclusion_rule: "Software development workflows, coding, frameworks, builds, debugging, and refactoring."
+    exclusion_rule: "CI/CD and infrastructure belong in `devops`; security review belongs in `security`."
+    examples: ["code generation", "refactor", "framework setup"]
     description: "Software development workflows, coding, frameworks, builds, debugging, and refactoring."
     keywords: [dev, code, programming, framework, build, software, compile, debug, refactor]
   - slug: devops
     code: ops
     display_name: DevOps
+    inclusion_rule: "CI/CD, deployment, infrastructure, containers, Kubernetes, and operational automation."
+    exclusion_rule: "Security incident investigation belongs in `security`; platform integrations belong in `integration`."
+    examples: ["Docker deploy", "GitHub Actions", "Kubernetes"]
     description: "CI/CD, infrastructure, Docker, Kubernetes, deployment, and operational automation."
     keywords: [devops, ci, cd, docker, kubernetes, deploy, infra, infrastructure]
   - slug: documents
     code: doc
     display_name: Documents
+    inclusion_rule: "Document creation, conversion, summarization, office formats, markdown, and PDFs."
+    exclusion_rule: "General writing craft belongs in `writing`; document data extraction can use `data` when data pipeline work dominates."
+    examples: ["PDF conversion", "DOCX editing"]
     description: "Document creation, conversion, summarization, office formats, markdown, and PDFs."
     keywords: [doc, docs, pdf, word, excel, pptx, xlsx, docx, markdown, documentation]
   - slug: domains
     code: domains
     display_name: Domains
+    inclusion_rule: "Domain-specific workflows that are not better represented by a capability category."
+    exclusion_rule: "If a clear capability exists, use that capability instead."
+    examples: ["legal workflow", "recruiting workflow"]
   - slug: examples
     code: examples
     display_name: Examples
+    inclusion_rule: "Example packs, demos, sample projects, and reusable reference implementations."
+    exclusion_rule: "Production development workflows belong in `development`; documentation belongs in `documents`."
+    examples: ["sample app", "demo skill"]
   - slug: forensics
     code: forensics
     display_name: Forensics
+    inclusion_rule: "Investigation, evidence preservation, incident reconstruction, and forensic analysis."
+    exclusion_rule: "Preventive security hardening belongs in `security`."
+    examples: ["artifact triage", "incident evidence"]
   - slug: gaming
     code: gaming
     display_name: Gaming
+    inclusion_rule: "Game design, gameplay systems, game assets, and game-related automation."
+    exclusion_rule: "General UI or creative work should use `design` or `creative`."
+    examples: ["game mechanics", "game prompts"]
   - slug: generation
     code: generation
     display_name: Generation
+    inclusion_rule: "Generating artifacts, media, structured outputs, or reusable content assets."
+    exclusion_rule: "Writing-focused prose belongs in `writing`; UI design artifacts belong in `design`."
+    examples: ["image prompt", "report artifact", "media generation"]
   - slug: integration
     code: integration
     display_name: Integration
+    inclusion_rule: "Cross-system connectors, service integrations, API composition, and platform bridges."
+    exclusion_rule: "Single API usage belongs in `api`; deployment operations belong in `devops`."
+    examples: ["GitHub connector", "Wix extension", "webhook"]
     description: "Cross-system connectors, service integrations, API composition, and platform bridges."
   - slug: language
     code: language
     display_name: Language
+    inclusion_rule: "Translation, localization, grammar, linguistics, and language learning workflows."
+    exclusion_rule: "Long-form authoring belongs in `writing`; LLM mechanics belong in `ai-llm`."
+    examples: ["translation", "grammar checking"]
   - slug: local-ai-infrastructure
     code: local-ai-infrastructure
     display_name: Local AI Infrastructure
+    inclusion_rule: "Local model runtimes, GPU setup, inference servers, and AI workstation infrastructure."
+    exclusion_rule: "Cloud deployment belongs in `devops`; ML modeling belongs in `ai-ml`."
+    examples: ["local LLM runtime", "GPU inference"]
   - slug: marketing
     code: mkt
     display_name: Marketing
+    inclusion_rule: "Campaigns, SEO, social content, brand positioning, and growth workflows."
+    exclusion_rule: "Product planning belongs in `product`; general business strategy belongs in `business`."
+    examples: ["SEO brief", "social campaign"]
     keywords: [marketing, seo, content, social, campaign, brand]
   - slug: orchestration
     code: orchestration
     display_name: Orchestration
+    inclusion_rule: "Multi-step or multi-agent coordination, scheduling, routing, and workflow control."
+    exclusion_rule: "Simple productivity automations belong in `workflow` or `productivity`."
+    examples: ["multi-agent pipeline", "task router"]
     keywords: [orchestration, orchestrator, coordination, multi-agent]
   - slug: other
     code: oth
     display_name: Other
+    inclusion_rule: "Temporary fallback for genuinely unclassifiable skills."
+    exclusion_rule: "Do not use when a specific canonical category applies."
+    examples: ["audit leftovers"]
     description: "Fallback bucket for unclassified skills; should shrink through reviewed migrations."
   - slug: performance
     code: performance
     display_name: Performance
+    inclusion_rule: "Speed, latency, benchmarking, profiling, and optimization workflows."
+    exclusion_rule: "General code cleanup belongs in `development`."
+    examples: ["benchmark", "latency audit"]
     keywords: [performance, optimize, latency, speed, benchmark]
   - slug: personal-development
     code: personal-development
     display_name: Personal Development
+    inclusion_rule: "Learning, coaching, habit change, self-review, and personal growth workflows."
+    exclusion_rule: "Team productivity tools belong in `productivity`."
+    examples: ["learning plan", "coaching prompts"]
   - slug: planning
     code: planning
     display_name: Planning
+    inclusion_rule: "Planning, roadmaps, schedules, project sequencing, and task breakdown workflows."
+    exclusion_rule: "Product requirements belong in `product`; executive strategy belongs in `business`."
+    examples: ["roadmap planning", "task plan"]
     keywords: [planning, plan, roadmap]
   - slug: platform
     code: platform
     display_name: Platform
+    inclusion_rule: "Platform-specific operations, device/platform automation, and platform administration."
+    exclusion_rule: "Cross-system connectors belong in `integration`; deployment belongs in `devops`."
+    examples: ["device automation", "platform admin"]
   - slug: product
     code: prd
     display_name: Product
+    inclusion_rule: "Product management, PRDs, roadmaps, backlog work, user research, and metrics."
+    exclusion_rule: "General business work belongs in `business`; technical implementation belongs in `development`."
+    examples: ["PRD", "backlog", "product metrics"]
     description: "Product management, PRDs, roadmaps, backlog work, user research, and metrics."
     keywords: [product, prd, roadmap, feature, backlog, user-research, metrics]
   - slug: productivity
     code: pro
     display_name: Productivity
+    inclusion_rule: "Personal or team workflow automation, task management, memory utilities, and work aids."
+    exclusion_rule: "CI/CD automation belongs in `devops`; orchestration engines belong in `orchestration`."
+    examples: ["task helper", "note workflow"]
     description: "Personal/team workflow automation, task management, planning aids, and memory utilities."
     keywords: [productivity, automation, workflow, task, planning, memory]
   - slug: quality
     code: quality
     display_name: Quality
+    inclusion_rule: "Linting, review, validation, QA process, and quality gates."
+    exclusion_rule: "Test implementation belongs in `testing`; security review belongs in `security`."
+    examples: ["code review", "quality gate"]
     keywords: [quality, lint, review, validate]
   - slug: security
     code: sec
     display_name: Security
+    inclusion_rule: "Security review, authentication, cryptography, compliance, operations, vulnerabilities, OWASP, pentesting, and fuzzing."
+    exclusion_rule: "General reliability or quality work belongs in `quality`."
+    examples: ["auth audit", "vulnerability scan"]
     description: "Security review, authentication, cryptography, vulnerabilities, OWASP, pentesting, and fuzzing."
     keywords: [security, auth, crypto, vulnerability, audit, owasp, pentest, fuzzing]
   - slug: skills
     code: skills
     display_name: Skills
+    inclusion_rule: "Skill authoring, registry maintenance, skill packaging, and skill ecosystem workflows."
+    exclusion_rule: "General coding belongs in `development`; docs belong in `documents`."
+    examples: ["SKILL.md authoring", "skill registry tooling"]
   - slug: system
     code: system
     display_name: System
+    inclusion_rule: "Operating-system, local machine, environment, process, and hardware workflows."
+    exclusion_rule: "Infrastructure deployment belongs in `devops`; security hardening belongs in `security`."
+    examples: ["system diagnosis", "process inspection"]
   - slug: testing
     code: tst
     display_name: Testing
+    inclusion_rule: "Testing, QA, TDD, unit/integration/e2e testing, browser automation, and test tooling."
+    exclusion_rule: "Static quality review belongs in `quality`; security testing belongs in `security`."
+    examples: ["pytest", "Playwright", "test harness"]
     description: "Testing, QA, TDD, unit/integration/e2e testing, browser automation, and test tooling."
     keywords: [test, qa, tdd, jest, pytest, unittest, integration, e2e, playwright, cypress]
   - slug: travel
     code: travel
     display_name: Travel
+    inclusion_rule: "Trip planning, itineraries, logistics, bookings, and destination research."
+    exclusion_rule: "General planning without travel belongs in `planning`."
+    examples: ["itinerary", "flight plan"]
   - slug: war-room
     code: war-room
     display_name: War Room
+    inclusion_rule: "Incident response rooms, crisis coordination, launch rooms, and high-urgency operations."
+    exclusion_rule: "Normal project planning belongs in `planning`; security incidents can use `security` if security dominates."
+    examples: ["incident room", "launch room"]
   - slug: workflow
     code: workflow
     display_name: Workflow
+    inclusion_rule: "Repeatable process automation, operating procedures, workflow design, and non-CI pipelines."
+    exclusion_rule: "CI/CD belongs in `devops`; personal task aids belong in `productivity`."
+    examples: ["SOP", "workflow pipeline"]
     keywords: [workflow, process, automation, pipeline]
   - slug: writing
     code: writing
     display_name: Writing
+    inclusion_rule: "Writing, editing, copy, blogs, articles, prose polish, and narrative composition."
+    exclusion_rule: "Marketing distribution belongs in `marketing`; document format conversion belongs in `documents`."
+    examples: ["blog draft", "copy edit"]
     keywords: [writing, writer, copy, blog, article]

--- a/tests/test_build_current_other_reclassification_batch.py
+++ b/tests/test_build_current_other_reclassification_batch.py
@@ -67,4 +67,8 @@ def test_builds_current_other_input_and_manifest(tmp_path):
     assert rows[0]["source_sha256"]
     assert rows[0]["metadata_sha256"]
     assert rows[0]["semantic_text_sha256"]
-    assert "sample_category_classification_audit.py" in "\n".join(saved_manifest["commands"])
+    commands = "\n".join(saved_manifest["commands"])
+    assert "sample_category_classification_audit.py" in commands
+    assert "build_residual_category_worksets.py" in commands
+    assert "residual_worksets_report" in saved_manifest["artifacts"]
+    assert "residual_worksets_dir" in saved_manifest["artifacts"]

--- a/tests/test_category_taxonomy.py
+++ b/tests/test_category_taxonomy.py
@@ -21,6 +21,9 @@ def test_taxonomy_loads_current_category_set():
     assert loaded.default_category == "other"
     assert "development" in loaded.categories
     assert "other" in loaded.categories
+    assert loaded.categories["development"].inclusion_rule
+    assert loaded.categories["development"].exclusion_rule
+    assert loaded.categories["development"].examples
     assert len(loaded.categories) >= 42
     assert "docs" not in loaded.categories
     assert loaded.migration_target("docs") == "documents"

--- a/tests/test_check_canonical_categories.py
+++ b/tests/test_check_canonical_categories.py
@@ -117,6 +117,51 @@ def test_docs_gate_rejects_legacy_category_artifacts_and_search_codes(tmp_path):
     assert report["error_count"] >= 8
 
 
+def test_docs_gate_rejects_category_count_drift(tmp_path):
+    gate = _load_module()
+    docs_dir = tmp_path / "docs"
+    _write_json(
+        docs_dir / "categories" / "index.json",
+        {
+            "categories": [
+                {
+                    "name": "documents",
+                    "code": "doc",
+                    "count": 2,
+                    "manifest": "categories/documents/manifest.json",
+                }
+            ]
+        },
+    )
+    _write_json(
+        docs_dir / "categories" / "documents.json",
+        {"category": "documents", "code": "doc", "count": 1},
+    )
+    _write_json(
+        docs_dir / "categories" / "documents" / "manifest.json",
+        {
+            "category": "documents",
+            "code": "doc",
+            "count": 1,
+            "part_count": 1,
+            "parts": [{"path": "categories/documents/part-000.json", "count": 1}],
+        },
+    )
+    _write_json(
+        docs_dir / "categories" / "documents" / "part-000.json",
+        {"category": "documents", "code": "doc", "count": 1, "skills": []},
+    )
+    _write_json(
+        docs_dir / "stats.json",
+        {"category_counts": [{"name": "documents", "code": "doc", "count": 1}]},
+    )
+
+    report = gate.build_report(docs_dirs=[docs_dir])
+    codes = [item["code"] for item in report["errors"]]
+
+    assert "category-count-mismatch" in codes
+
+
 def test_publish_gate_accepts_canonical_shapes(tmp_path):
     gate = _load_module()
     skills_dir = tmp_path / "skills"
@@ -133,17 +178,29 @@ def test_publish_gate_accepts_canonical_shapes(tmp_path):
         {
             "category": "documents",
             "code": "doc",
+            "count": 1,
             "deprecated_full_payload": True,
             "manifest": "categories/documents/manifest.json",
         },
     )
     _write_json(
         docs_dir / "categories" / "documents" / "manifest.json",
-        {"category": "documents", "code": "doc", "parts": []},
+        {
+            "category": "documents",
+            "code": "doc",
+            "count": 1,
+            "part_count": 1,
+            "parts": [{"path": "categories/documents/part-000.json", "count": 1}],
+        },
     )
     _write_json(
         docs_dir / "categories" / "documents" / "part-000.json",
-        {"category": "documents", "code": "doc", "skills": [{"category": "documents"}]},
+        {
+            "category": "documents",
+            "code": "doc",
+            "count": 1,
+            "skills": [{"category": "documents"}],
+        },
     )
     _write_json(docs_dir / "search-index-lite.json", {"skills": [{"category": "documents"}]})
     _write_json(docs_dir / "search-shards" / "part-000.json", {"s": [{"c": "doc"}]})

--- a/tests/test_check_taxonomy_governance.py
+++ b/tests/test_check_taxonomy_governance.py
@@ -51,8 +51,9 @@ categories:
 
     report = governance.build_report(taxonomy_module.load_taxonomy(taxonomy_file))
 
-    assert report["error_count"] == 1
-    assert report["errors"][0]["code"] == "schema-version"
+    codes = {error["code"] for error in report["errors"]}
+    assert "schema-version" in codes
+    assert "missing-inclusion-rule" in codes
 
 
 def test_governance_rejects_noncanonical_publish_targets():
@@ -69,6 +70,32 @@ def test_governance_rejects_noncanonical_publish_targets():
     assert codes["applied"] == "unknown-publish-category"
     assert codes["engineering"] == "unknown-publish-category"
     assert "development" not in codes
+
+
+def test_governance_requires_active_category_rules(tmp_path):
+    governance = _load_module()
+    taxonomy_module = _taxonomy_module()
+    taxonomy_file = tmp_path / "categories.yaml"
+    taxonomy_file.write_text(
+        """
+schema_version: 2
+default_category: other
+categories:
+  - slug: other
+    code: oth
+    display_name: Other
+""",
+        encoding="utf-8",
+    )
+
+    report = governance.build_report(taxonomy_module.load_taxonomy(taxonomy_file))
+
+    codes = {error["code"] for error in report["errors"]}
+    assert codes == {
+        "missing-inclusion-rule",
+        "missing-exclusion-rule",
+        "missing-examples",
+    }
 
 
 def test_governance_strict_canonical_accepts_current_taxonomy():


### PR DESCRIPTION
## Summary
- add explicit inclusion/exclusion/example rules to every active canonical category and enforce them in taxonomy governance
- extend the canonical publish gate with count consistency checks across category index, pointers, manifests, parts, and stats
- extend current-`other` reclassification batch manifests with residual workset generation so follow-up batches are auditable

Closes #145.
Closes #146.
Closes #148.

## Verification
- python -m ruff check scripts/category_taxonomy.py scripts/check_taxonomy_governance.py scripts/check_canonical_categories.py scripts/build_current_other_reclassification_batch.py tests/test_category_taxonomy.py tests/test_check_taxonomy_governance.py tests/test_check_canonical_categories.py tests/test_build_current_other_reclassification_batch.py
- python scripts/check_taxonomy_governance.py --strict-canonical --fail-on-warnings --limit 80
- python scripts/validate_sources.py --sources-dir sources
- python scripts/report_canonical_category_targets.py --registry-shards registry-shards --output-json /tmp/csr-canonical-target-counts.json
- python scripts/build_current_other_reclassification_batch.py --skills-dir /Users/lifcc/Desktop/code/AI/tools/claude-skill-registry-data --output-dir /tmp/csr-other-batch-smoke --batch-id smoke-other-001 --from-category other --limit 5 --content-chars 400 --json
- python -m pytest -q --cov-fail-under=50
- git diff --check