### PR TITLE
Prevent repo-only stable key collisions

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -254,8 +254,14 @@ def build_skill_key(repo: str = "", path: str = "", name: str = "", category: st
     """Build a stable key for a skill to detect duplicates."""
     repo = _skill_key_text(repo).strip()
     path = _normalize_skill_key_path(path)
+    name = _skill_key_text(name).strip()
+    category = _skill_key_text(category).strip()
     if repo and path:
         return f"{repo}:{path}"
+    if repo and name:
+        return f"{repo}:{name}"
+    if repo and category:
+        return f"{repo}:{category}"
     if repo:
         return repo
     if category or name:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -323,12 +323,13 @@ def test_build_dir_name_uses_repo_suffix(utils):
 
 
 def test_build_skill_key_priority(utils):
-    # Per implementation: repo+path > repo > category:name > "".
+    # Per implementation: repo+path > repo+name > repo+category > repo > category:name > "".
     assert utils.build_skill_key(repo="o/r", path="x/y") == "o/r:x/y"
     assert utils.build_skill_key(repo="o/r") == "o/r"
-    assert utils.build_skill_key(repo="o/r", path=".") == "o/r"
-    assert utils.build_skill_key(repo="o/r", path="SKILL.md") == "o/r"
-    assert utils.build_skill_key(repo="o/r", path="./SKILL.md") == "o/r"
+    assert utils.build_skill_key(repo="o/r", path=".", name="foo") == "o/r:foo"
+    assert utils.build_skill_key(repo="o/r", path="SKILL.md", name="foo") == "o/r:foo"
+    assert utils.build_skill_key(repo="o/r", path="./SKILL.md", name="foo") == "o/r:foo"
+    assert utils.build_skill_key(repo="o/r", category="dev") == "o/r:dev"
     assert utils.build_skill_key(category="dev", name="foo") == "dev:foo"
     assert utils.build_skill_key() == ""
     # path alone is ignored once repo is missing — the category:name fallback wins.
@@ -344,6 +345,7 @@ def test_build_skill_key_coerces_non_string_repo_and_path(utils):
 def test_build_skill_key_treats_boolean_repo_and_path_as_missing(utils):
     assert utils.build_skill_key(repo="o/r", path=False) == "o/r"
     assert utils.build_skill_key(repo="o/r", path=True) == "o/r"
+    assert utils.build_skill_key(repo="o/r", path=False, name="foo") == "o/r:foo"
     assert utils.build_skill_key(repo=False, path="x/y", category="dev", name="foo") == "dev:foo"
 
 


### PR DESCRIPTION
## Summary\n\n- Fix stable key fallback so repo-only metadata no longer collapses named skills into one key\n- Use repo+name, then repo+category, before falling back to bare repo\n- Add tests for missing/root path cases and boolean path handling\n\nFixes #154.\n\n## Verification\n\n- python -m pytest tests/test_utils.py tests/test_apply_category_migration.py tests/test_audit_category_residuals.py -q\n- python -m ruff check scripts/utils.py tests/test_utils.py\n- git diff --check\n- python -m pytest -q --cov-fail-under=50\n\n## Data Impact\n\nReplanning the current data legacy semantic batch after this fix unlocks 4 previously false-blocked moves.