### PR TITLE
Generate security evidence during main publish

### DIFF
--- a/scripts/sync_main_repo.sh
+++ b/scripts/sync_main_repo.sh
@@ -65,6 +65,12 @@ if [[ "$rebuild" -eq 1 ]]; then
     --categories-dir "$main_dir/docs/categories" \
     --compat-manifest-pointer
   python "$main_dir/scripts/build_registry_summary.py" --registry "$main_dir/registry.json" --plugins "$main_dir/sources/plugins.json" --output "$main_dir/registry_summary.json"
+  echo "Generating required security evidence..."
+  mkdir -p "$main_dir/docs"
+  python "$main_dir/scripts/security_scanner.py" \
+    "$main_dir/skills" \
+    --quiet \
+    --output "$main_dir/docs/security-report.json"
   python "$main_dir/scripts/build_search_index.py" --skills-dir "$main_dir/skills" --output "$main_dir/docs"
   python "$main_dir/scripts/check_canonical_categories.py" \
     --skills-dir "$main_dir/skills" \

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -95,12 +95,15 @@ def test_pages_leaderboard_loads_full_data_before_ranking():
 def test_publish_sync_runs_generated_size_guard_after_rebuild():
     sync_script = read_repo_file("scripts/sync_main_repo.sh")
 
+    security_pos = sync_script.index("scripts/security_scanner.py")
     rebuild_pos = sync_script.index("scripts/build_search_index.py")
     canonical_pos = sync_script.index("scripts/check_canonical_categories.py")
     guard_pos = sync_script.index("scripts/check_generated_file_sizes.py")
     category_guard_pos = sync_script.index("scripts/check_category_artifacts.py")
 
-    assert category_guard_pos > guard_pos > canonical_pos > rebuild_pos
+    assert category_guard_pos > guard_pos > canonical_pos > rebuild_pos > security_pos
+    assert "--output \"$main_dir/docs/security-report.json\"" in sync_script
+    assert "--allow-missing-security-evidence" not in sync_script
     assert "--include registry.json" in sync_script
     assert "--include registry-shards" in sync_script
     assert "--include docs" in sync_script


### PR DESCRIPTION
## Summary

- generate `docs/security-report.json` during `sync_main_repo.sh` before `build_search_index.py` runs
- keep publish fail-closed by not using `--allow-missing-security-evidence`
- extend pipeline contract test to enforce security evidence ordering

Closes #165.

## Verification

- `bash -n scripts/sync_main_repo.sh`
- `pytest tests/test_pipeline_contracts.py tests/test_build_search_index.py tests/test_check_sync_pipeline_health.py` -> 35 passed
- `pytest` -> 372 passed