### PR TITLE
Drop publish security report intermediate

### DIFF
--- a/scripts/sync_main_repo.sh
+++ b/scripts/sync_main_repo.sh
@@ -73,6 +73,7 @@ if [[ "$rebuild" -eq 1 ]]; then
     --report-only \
     --output "$main_dir/docs/security-report.json"
   python "$main_dir/scripts/build_search_index.py" --skills-dir "$main_dir/skills" --output "$main_dir/docs"
+  rm -f "$main_dir/docs/security-report.json"
   python "$main_dir/scripts/check_canonical_categories.py" \
     --skills-dir "$main_dir/skills" \
     --registry-shards "$main_dir/registry-shards" \

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -97,11 +97,12 @@ def test_publish_sync_runs_generated_size_guard_after_rebuild():
 
     security_pos = sync_script.index("scripts/security_scanner.py")
     rebuild_pos = sync_script.index("scripts/build_search_index.py")
+    cleanup_pos = sync_script.index("rm -f \"$main_dir/docs/security-report.json\"")
     canonical_pos = sync_script.index("scripts/check_canonical_categories.py")
     guard_pos = sync_script.index("scripts/check_generated_file_sizes.py")
     category_guard_pos = sync_script.index("scripts/check_category_artifacts.py")
 
-    assert category_guard_pos > guard_pos > canonical_pos > rebuild_pos > security_pos
+    assert category_guard_pos > guard_pos > canonical_pos > cleanup_pos > rebuild_pos > security_pos
     assert "--output \"$main_dir/docs/security-report.json\"" in sync_script
     assert "--report-only" in sync_script[sync_script.index("scripts/security_scanner.py") : rebuild_pos]
     assert "--allow-missing-security-evidence" not in sync_script


### PR DESCRIPTION
## Summary

- remove the build-only `docs/security-report.json` after search index generation
- keep fail-closed security evidence generation before `build_search_index.py`
- keep published security data in sharded `security-index` artifacts and `stats.json`
- assert cleanup happens before generated file size guards

Closes #173.

## Verification

- `bash -n scripts/sync_main_repo.sh`
- `pytest tests/test_pipeline_contracts.py tests/test_build_search_index.py tests/test_check_generated_file_sizes.py`
- `pytest`
