### PR TITLE
Gate sync-data archive layout normalization

### DIFF
--- a/.github/workflows/sync-data.yml
+++ b/.github/workflows/sync-data.yml
@@ -203,6 +203,54 @@ jobs:
       - name: Check archive categories are canonical
         run: python scripts/check_canonical_categories.py --skills-dir skills
 
+      - name: Normalize archive skill layout
+        run: |
+          python scripts/normalize_skill_depth.py \
+            --skills-dir skills \
+            --apply \
+            --json \
+            --output archive-depth-normalization-report.json
+
+          python scripts/normalize_skill_depth.py \
+            --skills-dir skills \
+            --json \
+            --output archive-depth-normalization-post-check.json
+
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = json.loads(Path("archive-depth-normalization-report.json").read_text())
+          post = json.loads(Path("archive-depth-normalization-post-check.json").read_text())
+          print(
+              "Archive layout normalization: "
+              f"planned={report.get('move_count', 0)} "
+              f"duplicates={report.get('duplicate_count', 0)} "
+              f"same_key_conflicts={report.get('same_key_conflict_count', 0)}"
+          )
+          remaining = {
+              key: int(post.get(key, 0) or 0)
+              for key in (
+                  "move_count",
+                  "duplicate_count",
+                  "same_key_conflict_count",
+                  "same_key_preserved_count",
+              )
+          }
+          if any(remaining.values()):
+              raise SystemExit(f"Archive layout normalization left non-standard paths: {remaining}")
+          PY
+
+      - name: Upload archive layout normalization report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: archive-depth-normalization-report
+          path: |
+            archive-depth-normalization-report.json
+            archive-depth-normalization-post-check.json
+          if-no-files-found: ignore
+
       - name: Upload download failure report
         if: always()
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
- Adds a `sync-data` workflow gate that normalizes archive skill directory depth before security/metadata scopes and before committing data repo changes.
- Runs a post-normalization check and fails if any non-standard paths remain.
- Uploads the pre-apply and post-check layout normalization reports for auditability.

Closes #177.

## Why
Data PR majiayu000/claude-skill-registry-data#49 fixed a regression where archive updates introduced 5,248 nested `other/other/<skill>/SKILL.md` paths. This core workflow change prevents future sync runs from committing the same layout regression again.

## Verification
- `python - <<'PY' ... yaml.safe_load('.github/workflows/sync-data.yml')`: workflow parsed, normalize/upload steps present
- `python -m py_compile scripts/normalize_skill_depth.py`
- `git diff --check`
