### PR TITLE
Make residual classification follow taxonomy rules

### DIFF
--- a/docs/plan/canonical-taxonomy-governance-spec.md
+++ b/docs/plan/canonical-taxonomy-governance-spec.md
@@ -62,6 +62,32 @@ the result review-only.
 - Model output is accepted only when it names an active canonical category.
 - Legacy categories may appear in reports, but they are not valid publish targets.
 
+## Model-Facing Classification Contract
+
+The residual classifier prompt treats the taxonomy file as the model's category
+rulebook, not just a list of names. Its payload must include every active
+category's slug, display name, inclusion rule, exclusion rule, examples, and
+keywords. The model must use those boundaries before choosing a category.
+
+The only valid model output category is a slug present in the active
+`allowed_categories` payload. Broad natural labels that are not canonical
+categories are invalid even when they look useful. Current blocked labels and
+their canonical routing hints are:
+
+- `automation`: route by outcome to `workflow`, `productivity`, `devops`,
+  `orchestration`, `integration`, or `platform`.
+- `research`: route by method or domain to `analysis`, `domains`, `product`, or
+  `ai-ml`.
+- `education`: route by artifact or learning outcome to
+  `personal-development`, `documents`, or `domains`.
+- `content`: route by content job to `writing`, `marketing`, `generation`, or
+  `documents`.
+
+If none of the canonical targets is defensible, the model may choose `other`
+only as a last-resort fallback with confidence `<= 0.65`. The apply step still
+rejects `other` by default, so this preserves fail-closed behavior instead of
+turning uncertainty into a migration.
+
 ## Migration Plan Contract
 
 `scripts/plan_category_migration.py` emits JSON with:
@@ -102,6 +128,10 @@ Defaults:
 The allowed category payload contains only active canonical categories. Unknown,
 inactive, malformed, or missing model outputs are kept as non-`ok` rows so
 downstream migration stays fail-closed.
+
+For residual classification, the allowed category payload also includes
+inclusion rules, exclusion rules, examples, keywords, and blocked-label guidance
+so MiMo is choosing from the same current category contract operators review.
 
 Secrets must not be written to files or committed. Reports record the
 environment variable name, never the API key value.
@@ -242,5 +272,7 @@ Category artifact gate:
   categories.
 - Publish target validation fails on unknown or legacy categories.
 - Model review accepts only active canonical categories.
+- Residual model classification prompts include taxonomy inclusion/exclusion
+  boundaries and blocked-label guidance for common noncanonical proposals.
 - Migration planning still produces audited review queues for unknown and legacy
   inputs.

--- a/scripts/classify_residual_workset_with_llm.py
+++ b/scripts/classify_residual_workset_with_llm.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from category_taxonomy import get_taxonomy
+from category_taxonomy import category_slug, get_taxonomy
 from review_category_plan_with_llm import (
     DEFAULT_API_KEY_ENV,
     DEFAULT_BASE_URL,
@@ -29,18 +29,127 @@ from review_category_plan_with_llm import (
 
 CHECKPOINT_SCHEMA_VERSION = 1
 
+NONCANONICAL_CATEGORY_GUIDANCE: tuple[dict[str, Any], ...] = (
+    {
+        "blocked_slug": "automation",
+        "instruction": (
+            "Do not output automation. Pick the active category that describes "
+            "the outcome being automated."
+        ),
+        "active_targets": (
+            {
+                "slug": "workflow",
+                "when": "repeatable procedures, SOPs, pipelines, or task flows",
+            },
+            {
+                "slug": "productivity",
+                "when": "personal or team task management and office automation",
+            },
+            {
+                "slug": "devops",
+                "when": "CI, deployment, release, infrastructure, or ops automation",
+            },
+            {
+                "slug": "orchestration",
+                "when": "coordinating agents, tools, or multi-step execution control",
+            },
+            {
+                "slug": "integration",
+                "when": "connecting external systems, APIs, webhooks, or services",
+            },
+            {
+                "slug": "platform",
+                "when": "platform setup, package management, or runtime plumbing",
+            },
+        ),
+    },
+    {
+        "blocked_slug": "research",
+        "instruction": (
+            "Do not output research. Pick the active category that describes the "
+            "research method or domain."
+        ),
+        "active_targets": (
+            {"slug": "analysis", "when": "comparative study, evaluation, or synthesis"},
+            {"slug": "domains", "when": "industry or subject-matter research"},
+            {"slug": "product", "when": "market, user, product, or roadmap research"},
+            {"slug": "ai-ml", "when": "model, prompt, eval, or AI system research"},
+        ),
+    },
+    {
+        "blocked_slug": "education",
+        "instruction": (
+            "Do not output education. Pick the active category that describes the "
+            "learning artifact or coaching outcome."
+        ),
+        "active_targets": (
+            {
+                "slug": "personal-development",
+                "when": "learning plans, coaching, career growth, or self-improvement",
+            },
+            {
+                "slug": "documents",
+                "when": "courses, lesson materials, guides, or educational documents",
+            },
+            {"slug": "domains", "when": "teaching a specific subject matter domain"},
+        ),
+    },
+    {
+        "blocked_slug": "content",
+        "instruction": (
+            "Do not output content. Pick the active category that describes the "
+            "content job being done."
+        ),
+        "active_targets": (
+            {"slug": "writing", "when": "drafting, editing, copy, or long-form prose"},
+            {"slug": "marketing", "when": "campaign, growth, social, or audience content"},
+            {"slug": "generation", "when": "creating media or generated assets"},
+            {"slug": "documents", "when": "structured document production or conversion"},
+        ),
+    },
+)
 
-def active_category_payload() -> list[dict[str, str]]:
+
+def active_category_payload() -> list[dict[str, Any]]:
     taxonomy = get_taxonomy()
     return [
         {
             "slug": definition.slug,
             "display_name": definition.display_name,
-            "description": definition.description,
+            "description": definition.description or definition.inclusion_rule,
+            "inclusion_rule": definition.inclusion_rule,
+            "exclusion_rule": definition.exclusion_rule,
+            "examples": list(definition.examples),
+            "keywords": list(definition.keywords),
         }
         for definition in sorted(taxonomy.categories.values(), key=lambda item: item.slug)
         if definition.status == "active"
     ]
+
+
+def noncanonical_category_guidance() -> list[dict[str, Any]]:
+    taxonomy = get_taxonomy()
+    guidance: list[dict[str, Any]] = []
+    for entry in NONCANONICAL_CATEGORY_GUIDANCE:
+        blocked_slug = category_slug(entry["blocked_slug"])
+        if taxonomy.is_publishable(blocked_slug):
+            raise ValueError(f"noncanonical guidance blocks active category {blocked_slug!r}")
+        targets: list[dict[str, str]] = []
+        for target in entry["active_targets"]:
+            target_slug = category_slug(target["slug"])
+            if not taxonomy.is_publishable(target_slug):
+                raise ValueError(
+                    f"noncanonical guidance target {target_slug!r} is not an active category"
+                )
+            targets.append({"slug": target_slug, "when": str(target["when"])})
+        guidance.append(
+            {
+                "blocked_slug": blocked_slug,
+                "instruction": str(entry["instruction"]),
+                "active_targets": targets,
+            }
+        )
+    return guidance
 
 
 def load_work_items(path: Path, *, limit: int | None = None) -> list[dict[str, Any]]:
@@ -144,13 +253,26 @@ def build_messages(items: list[dict[str, Any]]) -> list[dict[str, str]]:
     system_prompt = (
         "You are classifying reusable AI skills into a registry taxonomy. "
         "Use SKILL.md frontmatter/body semantics first, then metadata and path. "
-        "Choose one category slug from allowed_categories. Prefer a concrete active "
-        "category over 'other'. Use 'other' only when no active category is defensible, "
-        "and then set confidence <= 0.65. Do not choose review or deprecated categories. "
+        "Allowed category slugs are the only valid outputs; do not invent, translate, "
+        "abbreviate, or return non-canonical category labels. Apply each allowed "
+        "category's inclusion_rule, exclusion_rule, examples, and keywords before "
+        "choosing. Use taxonomy_contract.noncanonical_category_guidance when a broad "
+        "label such as automation, research, education, or content seems tempting. "
+        "Prefer a concrete active category over 'other'. Use 'other' only when no "
+        "active category is defensible, and then set confidence <= 0.65. Do not "
+        "choose review or deprecated categories. "
         "Return only valid compact JSON: an array of objects with keys "
         "id, category, confidence, reason, evidence. confidence must be 0..1."
     )
     payload = {
+        "taxonomy_contract": {
+            "source": "taxonomy/categories.yaml active categories only",
+            "valid_category_rule": (
+                "category must be exactly one slug present in allowed_categories"
+            ),
+            "other_rule": ("other is a last-resort fallback and requires confidence <= 0.65"),
+            "noncanonical_category_guidance": noncanonical_category_guidance(),
+        },
         "allowed_categories": categories,
         "candidates": [compact_candidate(item) for item in items],
     }
@@ -281,9 +403,7 @@ def classify_batch(
             if retry_sleep_seconds > 0:
                 time.sleep(retry_sleep_seconds * (attempt + 1))
     parsed_items = parsed or []
-    payload_by_id = {
-        str(payload.get("id")): payload for payload in parsed_items if "id" in payload
-    }
+    payload_by_id = {str(payload.get("id")): payload for payload in parsed_items if "id" in payload}
     payload_by_path = {
         str(payload.get("path")): payload
         for payload in parsed_items

--- a/tests/test_classify_residual_workset_with_llm.py
+++ b/tests/test_classify_residual_workset_with_llm.py
@@ -292,6 +292,41 @@ def test_batch_classification_can_match_by_path_or_position(tmp_path):
     ]
 
 
+def test_prompt_payload_includes_taxonomy_boundaries_and_blocked_labels():
+    classifier = _load_module()
+
+    messages = classifier.build_messages([{**_work_item("other/automation"), "_batch_id": "0"}])
+    prompt_payload = json.loads(messages[1]["content"])
+
+    categories = {item["slug"]: item for item in prompt_payload["allowed_categories"]}
+    assert "automation" not in categories
+    assert categories["development"]["inclusion_rule"]
+    assert categories["development"]["exclusion_rule"]
+    assert categories["development"]["examples"]
+    assert categories["development"]["keywords"]
+
+    contract = prompt_payload["taxonomy_contract"]
+    assert contract["source"] == "taxonomy/categories.yaml active categories only"
+    assert "allowed_categories" in contract["valid_category_rule"]
+    assert "last-resort" in contract["other_rule"]
+    blocked_slugs = {item["blocked_slug"] for item in contract["noncanonical_category_guidance"]}
+    assert blocked_slugs == {"automation", "research", "education", "content"}
+    automation_guidance = next(
+        item
+        for item in contract["noncanonical_category_guidance"]
+        if item["blocked_slug"] == "automation"
+    )
+    assert {target["slug"] for target in automation_guidance["active_targets"]} >= {
+        "workflow",
+        "productivity",
+        "devops",
+        "orchestration",
+        "integration",
+        "platform",
+    }
+    assert "non-canonical category labels" in messages[0]["content"]
+
+
 def test_invalid_model_category_fails_closed(tmp_path):
     classifier = _load_module()
     workset = tmp_path / "workset.jsonl"
@@ -325,6 +360,41 @@ def test_invalid_model_category_fails_closed(tmp_path):
 
     assert report["summary"]["status_counts"] == {"unknown_or_inactive_category": 1}
     assert report["rows"][0]["llm_category"] == "not-a-real-category"
+
+
+def test_blocked_natural_label_from_model_fails_closed(tmp_path):
+    classifier = _load_module()
+    workset = tmp_path / "workset.jsonl"
+    _write_workset(workset, [_work_item("other/automation")])
+    client = FakeClient(
+        [
+            json.dumps(
+                [
+                    {
+                        "id": "0",
+                        "category": "automation",
+                        "confidence": 0.99,
+                        "reason": "broad label",
+                        "evidence": [],
+                    }
+                ]
+            )
+        ]
+    )
+
+    report = classifier.run_classification(
+        workset_jsonl=workset,
+        client=client,
+        checkpoint_jsonl=None,
+        resume=False,
+        limit=None,
+        batch_size=1,
+        workers=1,
+        sleep_seconds=0,
+    )
+
+    assert report["summary"]["status_counts"] == {"unknown_or_inactive_category": 1}
+    assert report["rows"][0]["llm_category"] == "automation"
 
 
 def test_api_errors_are_retried_before_fail_closed(tmp_path):


### PR DESCRIPTION
Fixes #182

## Summary
- include taxonomy inclusion/exclusion rules, examples, and keywords in residual classification prompts
- add explicit blocked-label guidance for automation, research, education, and content
- keep noncanonical model outputs fail-closed and document the model-facing contract

## Tests
- python -m ruff check scripts/classify_residual_workset_with_llm.py tests/test_classify_residual_workset_with_llm.py
- python -m black --check scripts/classify_residual_workset_with_llm.py tests/test_classify_residual_workset_with_llm.py
- python scripts/check_taxonomy_governance.py --strict-canonical
- python -m pytest