### PR TITLE
Fix build-index raw security report artifact

### DIFF
--- a/.github/workflows/build-index.yml
+++ b/.github/workflows/build-index.yml
@@ -63,14 +63,18 @@ jobs:
             skills/ \
             --quiet \
             --report-only \
-            --output docs/security-report.json
-          test -f docs/security-report.json
-          ls -la docs/security-report.json
+            --output "$RUNNER_TEMP/security-report.json"
+          test -f "$RUNNER_TEMP/security-report.json"
+          ls -la "$RUNNER_TEMP/security-report.json"
 
       - name: Build search index
         run: |
           echo "Building search index from archive tree (recursive)..."
-          python scripts/build_search_index.py --skills-dir skills --registry registry.json --output docs
+          python scripts/build_search_index.py \
+            --skills-dir skills \
+            --registry registry.json \
+            --output docs \
+            --security-report "$RUNNER_TEMP/security-report.json"
 
           echo ""
           echo "Index files generated:"

--- a/scripts/build_search_index.py
+++ b/scripts/build_search_index.py
@@ -120,11 +120,10 @@ def validate_security_decision(decision: Any, context: str) -> Dict[str, Any]:
 
 
 def load_security_report_decisions(
-    output_dir: Path,
+    report_path: Path,
     require_security_evidence: bool,
 ) -> tuple[Dict[str, Dict[str, Any]], Dict[str, Any]]:
-    """Load per-skill security decisions from docs/security-report.json."""
-    report_path = output_dir / "security-report.json"
+    """Load per-skill security decisions from the required security report."""
     if not report_path.exists():
         if require_security_evidence:
             raise FileNotFoundError(f"Required security evidence is missing: {report_path}")
@@ -372,11 +371,13 @@ def build_search_index(
     archive_metadata_count_raw: Optional[int] = None,
     registry_skill_count_dedup: Optional[int] = None,
     require_security_evidence: bool = False,
+    security_report_path: Optional[Path] = None,
 ) -> Dict[str, Any]:
     """Build the lightweight search index."""
     logger.info(f"Building index from {len(skills)} {source_name}...")
+    resolved_security_report_path = security_report_path or (output_dir / "security-report.json")
     security_decisions_by_path, _security_report = load_security_report_decisions(
-        output_dir,
+        resolved_security_report_path,
         require_security_evidence,
     )
 
@@ -764,10 +765,9 @@ def build_search_index(
         ),
     }
     # Attach latest security scan summary if available
-    security_report_path = output_dir / "security-report.json"
-    if security_report_path.exists():
+    if resolved_security_report_path.exists():
         try:
-            with open(security_report_path, "r", encoding="utf-8") as f:
+            with open(resolved_security_report_path, "r", encoding="utf-8") as f:
                 security_report = json.load(f)
             stats["security_scan"] = {
                 "total": security_report.get("total"),
@@ -877,12 +877,21 @@ def main():
         action="store_true",
         help="Allow trust-sensitive outputs to mark security evidence unknown",
     )
+    parser.add_argument(
+        "--security-report",
+        default=None,
+        help=(
+            "Path to scanner output used as security evidence. Defaults to "
+            "<output>/security-report.json for local compatibility."
+        ),
+    )
 
     args = parser.parse_args()
 
     skills_dir = Path(args.skills_dir)
     registry_path = Path(args.registry)
     output_dir = Path(args.output)
+    security_report_path = Path(args.security_report) if args.security_report else None
 
     archive_skill_md_count_raw: Optional[int] = None
     archive_metadata_count_raw: Optional[int] = None
@@ -934,6 +943,7 @@ def main():
         archive_metadata_count_raw=archive_metadata_count_raw,
         registry_skill_count_dedup=registry_skill_count_dedup,
         require_security_evidence=not args.allow_missing_security_evidence,
+        security_report_path=security_report_path,
     )
 
 

--- a/scripts/sync_main_repo.sh
+++ b/scripts/sync_main_repo.sh
@@ -66,14 +66,18 @@ if [[ "$rebuild" -eq 1 ]]; then
     --compat-manifest-pointer
   python "$main_dir/scripts/build_registry_summary.py" --registry "$main_dir/registry.json" --plugins "$main_dir/sources/plugins.json" --output "$main_dir/registry_summary.json"
   echo "Generating required security evidence..."
+  security_report_path="$(mktemp)"
   mkdir -p "$main_dir/docs"
   python "$main_dir/scripts/security_scanner.py" \
     "$main_dir/skills" \
     --quiet \
     --report-only \
-    --output "$main_dir/docs/security-report.json"
-  python "$main_dir/scripts/build_search_index.py" --skills-dir "$main_dir/skills" --output "$main_dir/docs"
-  rm -f "$main_dir/docs/security-report.json"
+    --output "$security_report_path"
+  python "$main_dir/scripts/build_search_index.py" \
+    --skills-dir "$main_dir/skills" \
+    --output "$main_dir/docs" \
+    --security-report "$security_report_path"
+  rm -f "$security_report_path"
   python "$main_dir/scripts/check_canonical_categories.py" \
     --skills-dir "$main_dir/skills" \
     --registry-shards "$main_dir/registry-shards" \

--- a/tests/test_build_search_index.py
+++ b/tests/test_build_search_index.py
@@ -232,6 +232,56 @@ def test_build_search_index_consumes_security_decision_evidence(tmp_path):
     assert record["security_decision"]["id"] == "decision123"
 
 
+def test_build_search_index_consumes_external_security_report_without_publishing_raw(tmp_path):
+    output_dir = tmp_path / "docs"
+    output_dir.mkdir()
+    security_report_path = tmp_path / "security-report.json"
+    security_report_path.write_text(
+        json.dumps(
+            {
+                "total": 1,
+                "passed": 1,
+                "failed": 0,
+                "skills": [
+                    {
+                        "path": "development/demo/SKILL.md",
+                        "security_decision": {
+                            "status": "passed",
+                            "scanner": {
+                                "name": "claude-skill-registry-security-scanner",
+                                "version": "1.1.0",
+                                "ruleset_sha256": "abc123",
+                            },
+                            "provenance": {
+                                "content_sha256": "def456",
+                                "scanned_at": "2026-05-24T00:00:00Z",
+                            },
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    build_search_index(
+        [
+            _skill(
+                path="skills/demo",
+                install="acme/example/skills/demo",
+                archive_path="development/demo/SKILL.md",
+            )
+        ],
+        output_dir,
+        require_security_evidence=True,
+        security_report_path=security_report_path,
+    )
+
+    stats = json.loads((output_dir / "stats.json").read_text())
+    assert stats["security_scan"] == {"total": 1, "passed": 1, "failed": 0}
+    assert not output_dir.joinpath("security-report.json").exists()
+
+
 def test_build_search_index_fails_when_required_security_report_is_missing(tmp_path):
     with pytest.raises(FileNotFoundError, match="Required security evidence is missing"):
         build_search_index(

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -97,13 +97,16 @@ def test_publish_sync_runs_generated_size_guard_after_rebuild():
 
     security_pos = sync_script.index("scripts/security_scanner.py")
     rebuild_pos = sync_script.index("scripts/build_search_index.py")
-    cleanup_pos = sync_script.index("rm -f \"$main_dir/docs/security-report.json\"")
+    cleanup_pos = sync_script.index("rm -f \"$security_report_path\"")
     canonical_pos = sync_script.index("scripts/check_canonical_categories.py")
     guard_pos = sync_script.index("scripts/check_generated_file_sizes.py")
     category_guard_pos = sync_script.index("scripts/check_category_artifacts.py")
 
     assert category_guard_pos > guard_pos > canonical_pos > cleanup_pos > rebuild_pos > security_pos
-    assert "--output \"$main_dir/docs/security-report.json\"" in sync_script
+    assert 'security_report_path="$(mktemp)"' in sync_script
+    assert "--output \"$security_report_path\"" in sync_script
+    assert "--security-report \"$security_report_path\"" in sync_script
+    assert "--output \"$main_dir/docs/security-report.json\"" not in sync_script
     assert "--report-only" in sync_script[sync_script.index("scripts/security_scanner.py") : rebuild_pos]
     assert "--allow-missing-security-evidence" not in sync_script
     assert "--include registry.json" in sync_script
@@ -131,9 +134,11 @@ def test_build_index_generates_security_report_for_checked_out_data():
     build_pos = build_steps.index("scripts/build_search_index.py")
 
     assert security_pos < build_pos
-    assert "--output docs/security-report.json" in build_steps
+    assert "--output \"$RUNNER_TEMP/security-report.json\"" in build_steps
+    assert "--security-report \"$RUNNER_TEMP/security-report.json\"" in build_steps
+    assert "--output docs/security-report.json" not in build_steps
     assert "unzip -o security-report.zip -d docs || true" not in build_steps
-    assert "test -f docs/security-report.json" in build_steps
+    assert "test -f \"$RUNNER_TEMP/security-report.json\"" in build_steps
     assert "--allow-missing-security-evidence" not in build_steps
     assert "'scripts/security_scanner.py'" in workflow
     assert "'scripts/security_blocklist.py'" in workflow


### PR DESCRIPTION
## Summary

Fixes #186 by keeping the raw security scanner report outside the published `docs/` tree while still requiring it as build evidence.

## Changes

- Adds `--security-report` to `scripts/build_search_index.py`.
- Writes Build Search Index security evidence to `$RUNNER_TEMP/security-report.json`.
- Updates publish sync to use a temporary security report path instead of `docs/security-report.json`.
- Adds regression coverage that external security reports are consumed without publishing the raw report.

## Test plan

- `python -m ruff check scripts/build_search_index.py tests/test_build_search_index.py tests/test_pipeline_contracts.py`
- `python -m pytest tests/test_build_search_index.py tests/test_pipeline_contracts.py tests/test_check_generated_file_sizes.py`
- `python -m pytest`
- YAML parse check for `.github/workflows/build-index.yml`
- `bash -n scripts/sync_main_repo.sh`
- `git diff --check`

Note: a whole-repo `python -m ruff check .` still reports existing unrelated lint debt outside this PR scope.