### PR TITLE
Improve publish rebuild observability

### DIFF
--- a/scripts/security_scanner.py
+++ b/scripts/security_scanner.py
@@ -7,9 +7,10 @@ Implements automated security checks for skill registry
 import hashlib
 import json
 import re
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, TextIO, Tuple
 
 import jsonschema
 import yaml
@@ -667,6 +668,8 @@ def scan_directory(
     quiet: bool = False,
     selected_files: List[Path] = None,
     scanned_at: str = "",
+    progress_interval: int = 0,
+    progress_stream: TextIO | None = None,
 ) -> Dict:
     """Scan all skills in a directory"""
     scanner = SecurityScanner()
@@ -690,6 +693,11 @@ def scan_directory(
         scan_targets = skills_dir.rglob("SKILL.md")
     else:
         scan_targets = selected_files
+
+    if progress_interval < 0:
+        raise ValueError("progress_interval must be non-negative")
+    if progress_interval and progress_stream is None:
+        progress_stream = sys.stderr
 
     for skill_file in scan_targets:
         skill_file = skill_file.resolve()
@@ -722,6 +730,16 @@ def scan_directory(
                 print(f"✗ {skill_file.relative_to(skills_root)}")
                 print(scanner.generate_report())
 
+        if progress_interval and results["total"] % progress_interval == 0:
+            print(
+                "Security scan progress: "
+                f"{results['total']} scanned, "
+                f"{results['passed']} passed, "
+                f"{results['failed']} failed",
+                file=progress_stream,
+                flush=True,
+            )
+
     # Save results
     if output_file:
         with open(output_file, "w", encoding="utf-8") as f:
@@ -743,6 +761,12 @@ def main():
         help="Always exit 0 after writing report (for CI reporting mode)",
     )
     parser.add_argument("--quiet", action="store_true", help="Only print summary")
+    parser.add_argument(
+        "--progress-interval",
+        type=int,
+        default=0,
+        help="Print directory scan progress every N skills to stderr (0 disables progress)",
+    )
     parser.add_argument(
         "--file-list",
         help="Optional newline-delimited list of SKILL.md paths to scan (absolute or relative to path)",
@@ -792,7 +816,13 @@ def main():
             if not args.quiet:
                 print(f"Using file list: {len(selected_files)} file(s)")
 
-        results = scan_directory(path, args.output, quiet=args.quiet, selected_files=selected_files)
+        results = scan_directory(
+            path,
+            args.output,
+            quiet=args.quiet,
+            selected_files=selected_files,
+            progress_interval=args.progress_interval,
+        )
 
         print(f"\n{'='*60}")
         print(f"Total: {results['total']}")

--- a/scripts/sync_main_repo.sh
+++ b/scripts/sync_main_repo.sh
@@ -20,6 +20,7 @@ core_dir=""
 data_dir=""
 main_dir=""
 rebuild=1
+security_report_path=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -41,61 +42,139 @@ core_dir="$(cd "$core_dir" && pwd)"
 data_dir="$(cd "$data_dir" && pwd)"
 main_dir="$(cd "$main_dir" && pwd)"
 
-echo "Sync core -> main (excluding skills)..."
-# Keep all main-owned workflows stable. Mirroring a new workflow file from core
-# requires token workflow scope in the publish repo and breaks scheduled publish.
-rsync -a --delete \
-  --exclude '.git' \
-  --exclude '.gitignore' \
-  --exclude 'skills' \
-  --exclude 'skills/**' \
-  --exclude '.github/workflows/*.yml' \
-  --exclude '.github/workflows/*.yaml' \
-  "$core_dir/" "$main_dir/"
+timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
 
-echo "Sync data -> main/skills..."
-mkdir -p "$main_dir/skills"
-rsync -a --delete --exclude '.git' "$data_dir/" "$main_dir/skills/"
+log() {
+  printf '[%s] %s\n' "$(timestamp)" "$*"
+}
+
+start_group() {
+  local label="$1"
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    printf '::group::%s\n' "$label"
+  fi
+  log "START: $label"
+}
+
+end_group() {
+  local label="$1"
+  local status="$2"
+  local elapsed="$3"
+  log "END: $label status=$status elapsed=${elapsed}s"
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    printf '::endgroup::\n'
+  fi
+}
+
+run_step() {
+  local label="$1"
+  shift
+  local started="$SECONDS"
+  local status
+  start_group "$label"
+  set +e
+  "$@"
+  status="$?"
+  set -e
+  end_group "$label" "$status" "$((SECONDS - started))"
+  return "$status"
+}
+
+cleanup() {
+  if [[ -n "$security_report_path" && -f "$security_report_path" ]]; then
+    rm -f "$security_report_path"
+  fi
+}
+trap cleanup EXIT
+
+sync_core_to_main() {
+  # Keep all main-owned workflows stable. Mirroring a new workflow file from core
+  # requires token workflow scope in the publish repo and breaks scheduled publish.
+  rsync -a --delete \
+    --exclude '.git' \
+    --exclude '.gitignore' \
+    --exclude 'skills' \
+    --exclude 'skills/**' \
+    --exclude '.github/workflows/*.yml' \
+    --exclude '.github/workflows/*.yaml' \
+    --exclude '.ruff_cache' \
+    --exclude '.pytest_cache' \
+    --exclude '.mypy_cache' \
+    --exclude '.venv' \
+    --exclude 'node_modules' \
+    --exclude '__pycache__' \
+    --exclude '*/__pycache__' \
+    --exclude '*.pyc' \
+    --exclude '.DS_Store' \
+    --exclude 'metadata-compliance-report.json' \
+    --exclude 'THIRD_PARTY_NOTICES.generated.md' \
+    "$core_dir/" "$main_dir/"
+}
+
+sync_data_to_main() {
+  mkdir -p "$main_dir/skills"
+  rsync -a --delete \
+    --exclude '.git' \
+    --exclude '.ruff_cache' \
+    --exclude '.pytest_cache' \
+    --exclude '__pycache__' \
+    --exclude '*/__pycache__' \
+    --exclude '*.pyc' \
+    "$data_dir/" "$main_dir/skills/"
+}
+
+run_step "Sync core -> main (excluding skills and local caches)" sync_core_to_main
+run_step "Sync data -> main/skills" sync_data_to_main
 
 if [[ "$rebuild" -eq 1 ]]; then
-  echo "Rebuilding main registry + index..."
-  python "$main_dir/scripts/rebuild_registry.py" \
+  run_step "Rebuild registry shards and category indexes" python "$main_dir/scripts/rebuild_registry.py" \
     --skills-dir "$main_dir/skills" \
     --registry "$main_dir/registry.json" \
     --categories-dir "$main_dir/docs/categories" \
     --compat-manifest-pointer
-  python "$main_dir/scripts/build_registry_summary.py" --registry "$main_dir/registry.json" --plugins "$main_dir/sources/plugins.json" --output "$main_dir/registry_summary.json"
-  echo "Generating required security evidence..."
+
+  run_step "Build registry summary" python "$main_dir/scripts/build_registry_summary.py" \
+    --registry "$main_dir/registry.json" \
+    --plugins "$main_dir/sources/plugins.json" \
+    --output "$main_dir/registry_summary.json"
+
   security_report_path="$(mktemp)"
   mkdir -p "$main_dir/docs"
-  python "$main_dir/scripts/security_scanner.py" \
+  run_step "Generate required security evidence" python "$main_dir/scripts/security_scanner.py" \
     "$main_dir/skills" \
     --quiet \
+    --progress-interval 10000 \
     --report-only \
     --output "$security_report_path"
-  python "$main_dir/scripts/build_search_index.py" \
+
+  run_step "Build search and signal indexes" python "$main_dir/scripts/build_search_index.py" \
     --skills-dir "$main_dir/skills" \
     --output "$main_dir/docs" \
     --security-report "$security_report_path"
   rm -f "$security_report_path"
-  python "$main_dir/scripts/check_canonical_categories.py" \
+  security_report_path=""
+
+  run_step "Check published categories are canonical" python "$main_dir/scripts/check_canonical_categories.py" \
     --skills-dir "$main_dir/skills" \
     --registry-shards "$main_dir/registry-shards" \
     --docs-dir "$main_dir/docs"
-  python "$main_dir/scripts/check_generated_file_sizes.py" \
+
+  run_step "Check generated artifact sizes" python "$main_dir/scripts/check_generated_file_sizes.py" \
     --root "$main_dir" \
     --include registry.json \
     --include registry-shards \
     --include docs
-  python "$main_dir/scripts/check_category_artifacts.py" \
+
+  run_step "Check category artifacts" python "$main_dir/scripts/check_category_artifacts.py" \
     --categories-dir "$main_dir/docs/categories"
 fi
 
-echo "Generating third-party notices (advisory full-archive metadata scan)..."
-python "$main_dir/scripts/check_metadata_compliance.py" \
+run_step "Generate third-party notices (advisory full-archive metadata scan)" python "$main_dir/scripts/check_metadata_compliance.py" \
   --skills-dir "$main_dir/skills" \
   --metadata-schema "$main_dir/schema/metadata.schema.json" \
   --notices "$main_dir/THIRD_PARTY_NOTICES.md" \
   --report-only
 
-echo "Done."
+log "Done."

--- a/scripts/sync_main_repo.sh
+++ b/scripts/sync_main_repo.sh
@@ -20,6 +20,7 @@ core_dir=""
 data_dir=""
 main_dir=""
 rebuild=1
+security_report_path=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -41,61 +42,159 @@ core_dir="$(cd "$core_dir" && pwd)"
 data_dir="$(cd "$data_dir" && pwd)"
 main_dir="$(cd "$main_dir" && pwd)"
 
-echo "Sync core -> main (excluding skills)..."
-# Keep all main-owned workflows stable. Mirroring a new workflow file from core
-# requires token workflow scope in the publish repo and breaks scheduled publish.
-rsync -a --delete \
-  --exclude '.git' \
-  --exclude '.gitignore' \
-  --exclude 'skills' \
-  --exclude 'skills/**' \
-  --exclude '.github/workflows/*.yml' \
-  --exclude '.github/workflows/*.yaml' \
-  "$core_dir/" "$main_dir/"
+timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
 
-echo "Sync data -> main/skills..."
-mkdir -p "$main_dir/skills"
-rsync -a --delete --exclude '.git' "$data_dir/" "$main_dir/skills/"
+log() {
+  printf '[%s] %s\n' "$(timestamp)" "$*"
+}
+
+start_group() {
+  local label="$1"
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    printf '::group::%s\n' "$label"
+  fi
+  log "START: $label"
+}
+
+end_group() {
+  local label="$1"
+  local status="$2"
+  local elapsed="$3"
+  log "END: $label status=$status elapsed=${elapsed}s"
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    printf '::endgroup::\n'
+  fi
+}
+
+run_step() {
+  local label="$1"
+  shift
+  local started="$SECONDS"
+  local status
+  start_group "$label"
+  set +e
+  "$@"
+  status="$?"
+  set -e
+  end_group "$label" "$status" "$((SECONDS - started))"
+  return "$status"
+}
+
+cleanup() {
+  if [[ -n "$security_report_path" && -f "$security_report_path" ]]; then
+    rm -f "$security_report_path"
+  fi
+}
+trap cleanup EXIT
+
+remove_local_artifacts_under() {
+  local root="$1"
+  [[ -d "$root" ]] || return 0
+  rm -rf \
+    "$root/.ruff_cache" \
+    "$root/.pytest_cache" \
+    "$root/.mypy_cache" \
+    "$root/.venv" \
+    "$root/node_modules" \
+    "$root/metadata-compliance-report.json" \
+    "$root/THIRD_PARTY_NOTICES.generated.md"
+  find "$root" \
+    \( -path "$root/.git" -o -path "$root/skills" \) -prune \
+    -o -name '__pycache__' -type d -prune -exec rm -rf {} + \
+    -o -name '*.pyc' -type f -delete \
+    -o -name '.DS_Store' -type f -delete
+}
+
+sync_core_to_main() {
+  # Keep all main-owned workflows stable. Mirroring a new workflow file from core
+  # requires token workflow scope in the publish repo and breaks scheduled publish.
+  rsync -a --delete \
+    --exclude '.git' \
+    --exclude '.gitignore' \
+    --exclude 'skills' \
+    --exclude 'skills/**' \
+    --exclude '.github/workflows/*.yml' \
+    --exclude '.github/workflows/*.yaml' \
+    --exclude '.ruff_cache' \
+    --exclude '.pytest_cache' \
+    --exclude '.mypy_cache' \
+    --exclude '.venv' \
+    --exclude 'node_modules' \
+    --exclude '__pycache__' \
+    --exclude '*/__pycache__' \
+    --exclude '*.pyc' \
+    --exclude '.DS_Store' \
+    --exclude 'metadata-compliance-report.json' \
+    --exclude 'THIRD_PARTY_NOTICES.generated.md' \
+    "$core_dir/" "$main_dir/"
+  remove_local_artifacts_under "$main_dir"
+}
+
+sync_data_to_main() {
+  mkdir -p "$main_dir/skills"
+  rsync -a --delete \
+    --exclude '.git' \
+    --exclude '.ruff_cache' \
+    --exclude '.pytest_cache' \
+    --exclude '__pycache__' \
+    --exclude '*/__pycache__' \
+    --exclude '*.pyc' \
+    "$data_dir/" "$main_dir/skills/"
+  remove_local_artifacts_under "$main_dir/skills"
+}
+
+run_step "Sync core -> main (excluding skills and local caches)" sync_core_to_main
+run_step "Sync data -> main/skills" sync_data_to_main
 
 if [[ "$rebuild" -eq 1 ]]; then
-  echo "Rebuilding main registry + index..."
-  python "$main_dir/scripts/rebuild_registry.py" \
+  run_step "Rebuild registry shards and category indexes" python "$main_dir/scripts/rebuild_registry.py" \
     --skills-dir "$main_dir/skills" \
     --registry "$main_dir/registry.json" \
     --categories-dir "$main_dir/docs/categories" \
     --compat-manifest-pointer
-  python "$main_dir/scripts/build_registry_summary.py" --registry "$main_dir/registry.json" --plugins "$main_dir/sources/plugins.json" --output "$main_dir/registry_summary.json"
-  echo "Generating required security evidence..."
+
+  run_step "Build registry summary" python "$main_dir/scripts/build_registry_summary.py" \
+    --registry "$main_dir/registry.json" \
+    --plugins "$main_dir/sources/plugins.json" \
+    --output "$main_dir/registry_summary.json"
+
   security_report_path="$(mktemp)"
   mkdir -p "$main_dir/docs"
-  python "$main_dir/scripts/security_scanner.py" \
+  run_step "Generate required security evidence" python "$main_dir/scripts/security_scanner.py" \
     "$main_dir/skills" \
     --quiet \
+    --progress-interval 10000 \
     --report-only \
     --output "$security_report_path"
-  python "$main_dir/scripts/build_search_index.py" \
+
+  run_step "Build search and signal indexes" python "$main_dir/scripts/build_search_index.py" \
     --skills-dir "$main_dir/skills" \
     --output "$main_dir/docs" \
     --security-report "$security_report_path"
   rm -f "$security_report_path"
-  python "$main_dir/scripts/check_canonical_categories.py" \
+  security_report_path=""
+
+  run_step "Check published categories are canonical" python "$main_dir/scripts/check_canonical_categories.py" \
     --skills-dir "$main_dir/skills" \
     --registry-shards "$main_dir/registry-shards" \
     --docs-dir "$main_dir/docs"
-  python "$main_dir/scripts/check_generated_file_sizes.py" \
+
+  run_step "Check generated artifact sizes" python "$main_dir/scripts/check_generated_file_sizes.py" \
     --root "$main_dir" \
     --include registry.json \
     --include registry-shards \
     --include docs
-  python "$main_dir/scripts/check_category_artifacts.py" \
+
+  run_step "Check category artifacts" python "$main_dir/scripts/check_category_artifacts.py" \
     --categories-dir "$main_dir/docs/categories"
 fi
 
-echo "Generating third-party notices (advisory full-archive metadata scan)..."
-python "$main_dir/scripts/check_metadata_compliance.py" \
+run_step "Generate third-party notices (advisory full-archive metadata scan)" python "$main_dir/scripts/check_metadata_compliance.py" \
   --skills-dir "$main_dir/skills" \
   --metadata-schema "$main_dir/schema/metadata.schema.json" \
   --notices "$main_dir/THIRD_PARTY_NOTICES.md" \
   --report-only
 
-echo "Done."
+log "Done."

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -94,20 +94,22 @@ def test_pages_leaderboard_loads_full_data_before_ranking():
 
 def test_publish_sync_runs_generated_size_guard_after_rebuild():
     sync_script = read_repo_file("scripts/sync_main_repo.sh")
+    rebuild_block = sync_script[sync_script.index('if [[ "$rebuild" -eq 1 ]]') :]
 
-    security_pos = sync_script.index("scripts/security_scanner.py")
-    rebuild_pos = sync_script.index("scripts/build_search_index.py")
-    cleanup_pos = sync_script.index("rm -f \"$security_report_path\"")
-    canonical_pos = sync_script.index("scripts/check_canonical_categories.py")
-    guard_pos = sync_script.index("scripts/check_generated_file_sizes.py")
-    category_guard_pos = sync_script.index("scripts/check_category_artifacts.py")
+    security_pos = rebuild_block.index("scripts/security_scanner.py")
+    rebuild_pos = rebuild_block.index("scripts/build_search_index.py")
+    cleanup_pos = rebuild_block.index("rm -f \"$security_report_path\"")
+    canonical_pos = rebuild_block.index("scripts/check_canonical_categories.py")
+    guard_pos = rebuild_block.index("scripts/check_generated_file_sizes.py")
+    category_guard_pos = rebuild_block.index("scripts/check_category_artifacts.py")
 
     assert category_guard_pos > guard_pos > canonical_pos > cleanup_pos > rebuild_pos > security_pos
     assert 'security_report_path="$(mktemp)"' in sync_script
     assert "--output \"$security_report_path\"" in sync_script
     assert "--security-report \"$security_report_path\"" in sync_script
+    assert "--progress-interval 10000" in sync_script
     assert "--output \"$main_dir/docs/security-report.json\"" not in sync_script
-    assert "--report-only" in sync_script[sync_script.index("scripts/security_scanner.py") : rebuild_pos]
+    assert "--report-only" in rebuild_block[security_pos:rebuild_pos]
     assert "--allow-missing-security-evidence" not in sync_script
     assert "--include registry.json" in sync_script
     assert "--include registry-shards" in sync_script
@@ -116,9 +118,45 @@ def test_publish_sync_runs_generated_size_guard_after_rebuild():
     assert "--registry-shards" in sync_script
 
 
+def test_publish_sync_has_observable_steps_and_cache_excludes():
+    sync_script = read_repo_file("scripts/sync_main_repo.sh")
+
+    expected_steps = [
+        "Sync core -> main (excluding skills and local caches)",
+        "Sync data -> main/skills",
+        "Rebuild registry shards and category indexes",
+        "Build registry summary",
+        "Generate required security evidence",
+        "Build search and signal indexes",
+        "Check published categories are canonical",
+        "Check generated artifact sizes",
+        "Check category artifacts",
+        "Generate third-party notices (advisory full-archive metadata scan)",
+    ]
+    for label in expected_steps:
+        assert f'run_step "{label}"' in sync_script
+
+    for excluded in [
+        ".ruff_cache",
+        ".pytest_cache",
+        "__pycache__",
+        "*.pyc",
+        "metadata-compliance-report.json",
+        "THIRD_PARTY_NOTICES.generated.md",
+    ]:
+        assert f"--exclude '{excluded}'" in sync_script
+
+    assert "::group::%s" in sync_script
+    assert "elapsed=${elapsed}s" in sync_script
+    assert "remove_local_artifacts_under()" in sync_script
+    assert 'remove_local_artifacts_under "$main_dir"' in sync_script
+    assert 'remove_local_artifacts_under "$main_dir/skills"' in sync_script
+    assert "--delete-excluded" not in sync_script
+
+
 def test_publish_sync_metadata_compliance_is_advisory_for_historical_notices():
     sync_script = read_repo_file("scripts/sync_main_repo.sh")
-    notices_block = sync_script[sync_script.index("Generating third-party notices") :]
+    notices_block = sync_script[sync_script.index("Generate third-party notices") :]
 
     assert "scripts/check_metadata_compliance.py" in notices_block
     assert "--notices \"$main_dir/THIRD_PARTY_NOTICES.md\"" in notices_block

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -94,20 +94,22 @@ def test_pages_leaderboard_loads_full_data_before_ranking():
 
 def test_publish_sync_runs_generated_size_guard_after_rebuild():
     sync_script = read_repo_file("scripts/sync_main_repo.sh")
+    rebuild_block = sync_script[sync_script.index('if [[ "$rebuild" -eq 1 ]]') :]
 
-    security_pos = sync_script.index("scripts/security_scanner.py")
-    rebuild_pos = sync_script.index("scripts/build_search_index.py")
-    cleanup_pos = sync_script.index("rm -f \"$security_report_path\"")
-    canonical_pos = sync_script.index("scripts/check_canonical_categories.py")
-    guard_pos = sync_script.index("scripts/check_generated_file_sizes.py")
-    category_guard_pos = sync_script.index("scripts/check_category_artifacts.py")
+    security_pos = rebuild_block.index("scripts/security_scanner.py")
+    rebuild_pos = rebuild_block.index("scripts/build_search_index.py")
+    cleanup_pos = rebuild_block.index("rm -f \"$security_report_path\"")
+    canonical_pos = rebuild_block.index("scripts/check_canonical_categories.py")
+    guard_pos = rebuild_block.index("scripts/check_generated_file_sizes.py")
+    category_guard_pos = rebuild_block.index("scripts/check_category_artifacts.py")
 
     assert category_guard_pos > guard_pos > canonical_pos > cleanup_pos > rebuild_pos > security_pos
     assert 'security_report_path="$(mktemp)"' in sync_script
     assert "--output \"$security_report_path\"" in sync_script
     assert "--security-report \"$security_report_path\"" in sync_script
+    assert "--progress-interval 10000" in sync_script
     assert "--output \"$main_dir/docs/security-report.json\"" not in sync_script
-    assert "--report-only" in sync_script[sync_script.index("scripts/security_scanner.py") : rebuild_pos]
+    assert "--report-only" in rebuild_block[security_pos:rebuild_pos]
     assert "--allow-missing-security-evidence" not in sync_script
     assert "--include registry.json" in sync_script
     assert "--include registry-shards" in sync_script
@@ -116,9 +118,41 @@ def test_publish_sync_runs_generated_size_guard_after_rebuild():
     assert "--registry-shards" in sync_script
 
 
+def test_publish_sync_has_observable_steps_and_cache_excludes():
+    sync_script = read_repo_file("scripts/sync_main_repo.sh")
+
+    expected_steps = [
+        "Sync core -> main (excluding skills and local caches)",
+        "Sync data -> main/skills",
+        "Rebuild registry shards and category indexes",
+        "Build registry summary",
+        "Generate required security evidence",
+        "Build search and signal indexes",
+        "Check published categories are canonical",
+        "Check generated artifact sizes",
+        "Check category artifacts",
+        "Generate third-party notices (advisory full-archive metadata scan)",
+    ]
+    for label in expected_steps:
+        assert f'run_step "{label}"' in sync_script
+
+    for excluded in [
+        ".ruff_cache",
+        ".pytest_cache",
+        "__pycache__",
+        "*.pyc",
+        "metadata-compliance-report.json",
+        "THIRD_PARTY_NOTICES.generated.md",
+    ]:
+        assert f"--exclude '{excluded}'" in sync_script
+
+    assert "::group::%s" in sync_script
+    assert "elapsed=${elapsed}s" in sync_script
+
+
 def test_publish_sync_metadata_compliance_is_advisory_for_historical_notices():
     sync_script = read_repo_file("scripts/sync_main_repo.sh")
-    notices_block = sync_script[sync_script.index("Generating third-party notices") :]
+    notices_block = sync_script[sync_script.index("Generate third-party notices") :]
 
     assert "scripts/check_metadata_compliance.py" in notices_block
     assert "--notices \"$main_dir/THIRD_PARTY_NOTICES.md\"" in notices_block

--- a/tests/test_security_scanner.py
+++ b/tests/test_security_scanner.py
@@ -1,4 +1,5 @@
 import importlib.util
+import io
 import json
 import sys
 from pathlib import Path
@@ -58,6 +59,35 @@ description: Demo skill used to verify security decision evidence.
     assert decision["provenance"]["source_ref"] == "main"
     assert decision["provenance"]["content_sha256"]
     assert decision["provenance"]["scanned_at"] == "2026-05-24T00:00:00Z"
+
+
+def test_scan_directory_progress_interval_reports_counts(tmp_path):
+    module = load_module()
+    for index in range(2):
+        skill_dir = tmp_path / "skills" / "development" / f"demo-{index}"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"""---
+name: demo-{index}
+description: Demo skill used to verify security scan progress.
+---
+
+# Demo {index}
+""",
+            encoding="utf-8",
+        )
+
+    progress = io.StringIO()
+    report = module.scan_directory(
+        tmp_path / "skills",
+        quiet=True,
+        progress_interval=1,
+        progress_stream=progress,
+    )
+
+    assert report["total"] == 2
+    assert "Security scan progress: 1 scanned" in progress.getvalue()
+    assert "Security scan progress: 2 scanned" in progress.getvalue()
 
 
 def test_scanner_checks_reference_implementations(tmp_path):


### PR DESCRIPTION
## Summary
- add timestamped `run_step` logging and GitHub Actions log groups to `sync_main_repo.sh`
- split the publish rebuild into named phases for registry, summary, security evidence, search indexes, guards, and notices
- exclude local cache/report artifacts from core/data rsync mirrors so publish cannot accidentally copy `.ruff_cache`, `__pycache__`, or local compliance reports
- add security scanner `--progress-interval` so long quiet scans emit low-noise progress during publish

Fixes #188

## Validation
- `bash -n scripts/sync_main_repo.sh`
- `python -m py_compile scripts/security_scanner.py`
- `python -m pytest tests/test_pipeline_contracts.py tests/test_security_scanner.py -q`
- fixture `sync_main_repo.sh --no-rebuild` publish proving cache/report excludes
- `git diff --check`
- `python -m pytest -q --cov-fail-under=50` (`380 passed`, coverage 61.97%)
- `python -m ruff check scripts/security_scanner.py tests/test_security_scanner.py tests/test_pipeline_contracts.py`
- `python scripts/check_taxonomy_governance.py`