### PR TITLE
Fix publish cleanup for GNU find

### DIFF
--- a/scripts/sync_main_repo.sh
+++ b/scripts/sync_main_repo.sh
@@ -102,9 +102,10 @@ remove_local_artifacts_under() {
     "$root/THIRD_PARTY_NOTICES.generated.md"
   find "$root" \
     \( -path "$root/.git" -o -path "$root/skills" \) -prune \
-    -o -name '__pycache__' -type d -prune -exec rm -rf {} + \
-    -o -name '*.pyc' -type f -delete \
-    -o -name '.DS_Store' -type f -delete
+    -o -name '__pycache__' -type d -prune -exec rm -rf {} +
+  find "$root" \
+    \( -path "$root/.git" -o -path "$root/skills" \) -prune \
+    -o \( -name '*.pyc' -o -name '.DS_Store' \) -type f -exec rm -f {} +
 }
 
 sync_core_to_main() {

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -153,6 +153,14 @@ def test_publish_sync_has_observable_steps_and_cache_excludes():
     assert 'remove_local_artifacts_under "$main_dir/skills"' in sync_script
     assert "--delete-excluded" not in sync_script
 
+    cleanup_block = sync_script[
+        sync_script.index("remove_local_artifacts_under()") : sync_script.index(
+            "sync_core_to_main()"
+        )
+    ]
+    assert "-delete" not in cleanup_block
+    assert "-exec rm -f {} +" in cleanup_block
+
 
 def test_publish_sync_metadata_compliance_is_advisory_for_historical_notices():
     sync_script = read_repo_file("scripts/sync_main_repo.sh")


### PR DESCRIPTION
Fixes #190.

## Summary
- Avoid `find -delete` in `remove_local_artifacts_under` so publish cleanup works on GNU find in GitHub Actions.
- Split directory cleanup and file cleanup into portable `-exec rm` calls.
- Add a pipeline contract assertion so cleanup does not regress to `-delete` with pruned paths.

## Verification
- `bash -n scripts/sync_main_repo.sh`
- `pytest tests/test_pipeline_contracts.py` (16 passed)
- `pytest` (380 passed)
- `ruff check tests/test_pipeline_contracts.py`
- no-rebuild smoke publish to a temp main/data tree

## Note
- Full `ruff check .` still reports pre-existing import/unused issues in unrelated files on latest main; this PR does not touch those paths.