### PR TITLE
fix: fail closed for unsafe single-file security scans

### DIFF
--- a/scripts/security_scanner.py
+++ b/scripts/security_scanner.py
@@ -806,7 +806,7 @@ def main():
 
         if args.report_only:
             exit(0)
-        exit(0 if is_safe or not args.strict else 1)
+        exit(0 if is_safe else 1)
 
     elif path.is_dir():
         # Scan directory

--- a/tests/test_security_scanner.py
+++ b/tests/test_security_scanner.py
@@ -1,6 +1,7 @@
 import importlib.util
 import io
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -152,6 +153,50 @@ description: Demo skill used to verify bundled rule scanning.
         and "rules/dangerous.md" in issue.get("file", "")
         for issue in issues
     )
+
+
+def test_scanner_rejects_missing_frontmatter(tmp_path):
+    module = load_module()
+    skill_dir = tmp_path / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Demo\n", encoding="utf-8")
+
+    scanner = module.SecurityScanner()
+    is_safe, issues = scanner.scan_file(skill_dir / "SKILL.md")
+
+    assert is_safe is False
+    assert any(issue.get("type") == "no_frontmatter" for issue in issues)
+
+
+def test_single_file_scan_exits_nonzero_for_unsafe_skill(tmp_path):
+    skill_dir = tmp_path / "demo"
+    skill_dir.mkdir(parents=True)
+    skill_file = skill_dir / "SKILL.md"
+    skill_file.write_text(
+        """---
+name: demo
+description: Demo skill used to verify single-file unsafe scan exit status.
+---
+
+# Demo
+
+```python
+eval("unsafe")
+```
+""",
+        encoding="utf-8",
+    )
+
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "security_scanner.py"
+    result = subprocess.run(
+        [sys.executable, str(script_path), str(skill_file)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "ERROR" in result.stdout
 
 
 def test_scanner_checks_flowhunt_style_support_files(tmp_path):


### PR DESCRIPTION
## Summary
- Make single-file `scripts/security_scanner.py SKILL.md` scans exit non-zero when the scan is unsafe, even without `--strict`.
- Add regression coverage for missing frontmatter being unsafe.
- Add CLI regression coverage for unsafe single-file scan exit status.

Fixes #193.
Fixes #194.

## Verification
- `python -m pytest tests/test_security_scanner.py::test_scanner_rejects_missing_frontmatter tests/test_security_scanner.py::test_scanner_rejects_obfuscation_execution_error tests/test_security_scanner.py::test_single_file_scan_exits_nonzero_for_unsafe_skill -q --override-ini='addopts='`
- `python -m ruff check scripts/security_scanner.py tests/test_security_scanner.py`
- `python -m pytest tests/test_security_scanner.py -q --override-ini='addopts='`
- `python -m pytest -q --override-ini='addopts='` -> 387 passed
- `git diff --check`