### PR TITLE
test: cover category source precedence aliases

### DIFF
--- a/tests/test_plan_category_migration.py
+++ b/tests/test_plan_category_migration.py
@@ -146,6 +146,38 @@ def test_plan_reports_source_conflict_before_legacy_migration(tmp_path):
     assert change["review_required"] is True
 
 
+def test_plan_does_not_hide_source_conflicts_by_alias_normalization(tmp_path):
+    planner = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "development",
+        "metadata-alias",
+        {
+            "name": "metadata-alias",
+            "category": "engineering",
+            "description": "Build framework compile debug helper.",
+        },
+    )
+
+    plan = planner.build_plan(skills_dir)
+    change = {item["path"]: item for item in plan["changes"]}[
+        "development/metadata-alias/SKILL.md"
+    ]
+
+    assert change["action"] == "resolve_source_conflict"
+    assert change["current_category"] == "engineering"
+    assert change["raw_sources"] == {
+        "directory": "development",
+        "metadata": "engineering",
+    }
+    assert change["resolved_sources"] == {
+        "directory": "development",
+        "metadata": "engineering",
+    }
+    assert change["review_required"] is True
+
+
 def test_plan_uses_frontmatter_description_when_metadata_description_missing(tmp_path):
     planner = _load_module()
     skills_dir = tmp_path / "skills"


### PR DESCRIPTION
## Summary
- Add a regression test proving category migration planning does not normalize legacy aliases before source-conflict detection.
- Keeps `metadata.category: engineering` distinct from the archive directory `development`, so the planner emits a review-required source conflict instead of silently accepting the alias target.

Completes #159 after #168 and #169.

## Verification
- `python -m pytest tests/test_plan_category_migration.py -q --override-ini='addopts='` -> 6 passed
- `python -m ruff check tests/test_plan_category_migration.py`
- `python -m pytest -q --override-ini='addopts='` -> 391 passed
- `git diff --check`