### PR TITLE
fix: tighten category migration input guards

### DIFF
--- a/scripts/apply_category_migration.py
+++ b/scripts/apply_category_migration.py
@@ -240,6 +240,9 @@ def build_apply_plan(
         if not source_dir.exists():
             reject_reasons["source directory missing"] += 1
             continue
+        if not (skills_dir / source_skill_rel).is_file():
+            reject_reasons["source SKILL.md missing"] += 1
+            continue
         if reason := source_hash_mismatch(row, source_dir):
             reject_reasons[reason] += 1
             continue

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -485,7 +485,7 @@ def skill_semantic_fields(
         description = _semantic_text(metadata.get("description"))
         if description:
             sources["description"] = "metadata"
-        elif content:
+        elif content_chars > 0 and content:
             description = extract_description(content)
             if description:
                 sources["description"] = "body"

--- a/tests/test_apply_category_migration.py
+++ b/tests/test_apply_category_migration.py
@@ -213,6 +213,47 @@ def test_source_hash_mismatch_blocks_stale_classification(tmp_path):
     }
 
 
+def test_missing_source_skill_file_blocks_apply_plan(tmp_path):
+    migrator = _load_module()
+    skills_dir = tmp_path / "skills"
+    source_dir = skills_dir / "other" / "missing-skill"
+    source_dir.mkdir(parents=True)
+    (source_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "name": "missing-skill",
+                "category": "other",
+                "dir_name": "missing-skill",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    classification = tmp_path / "classification.jsonl"
+    _write_classification(
+        classification,
+        [
+            {
+                "path": "other/missing-skill/SKILL.md",
+                "name": "missing-skill",
+                "current_category": "other",
+                "llm_category": "development",
+                "confidence": 0.95,
+                "status": "ok",
+            }
+        ],
+    )
+
+    plan = migrator.build_apply_plan(
+        skills_dir=skills_dir,
+        classification_jsonl=classification,
+        from_categories={"other"},
+    )
+
+    assert plan["summary"]["planned_move_count"] == 0
+    assert plan["summary"]["reject_reasons"] == {"source SKILL.md missing": 1}
+
+
 def test_movable_only_skips_blocked_moves_and_fills_limit(tmp_path):
     migrator = _load_module()
     skills_dir = tmp_path / "skills"

--- a/tests/test_plan_category_migration.py
+++ b/tests/test_plan_category_migration.py
@@ -207,3 +207,38 @@ def test_plan_uses_frontmatter_description_when_metadata_description_missing(tmp
 
     assert change["action"] == "heuristic_reclassify"
     assert change["proposed_category"] == "devops"
+
+
+def test_plan_does_not_use_body_description_when_content_chars_zero(tmp_path):
+    planner = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "other",
+        "quiet-helper",
+        {
+            "name": "quiet-helper",
+            "category": "other",
+        },
+        (
+            "---\n"
+            "name: quiet-helper\n"
+            "---\n\n"
+            "Docker Kubernetes CI CD deploy infrastructure workflow.\n"
+        ),
+    )
+
+    default_plan = planner.build_plan(skills_dir, min_score=2, min_delta=2)
+    scanned_body_plan = planner.build_plan(
+        skills_dir,
+        content_chars=200,
+        min_score=2,
+        min_delta=2,
+    )
+
+    assert default_plan["changes"] == []
+    change = {item["path"]: item for item in scanned_body_plan["changes"]}[
+        "other/quiet-helper/SKILL.md"
+    ]
+    assert change["action"] == "heuristic_reclassify"
+    assert change["proposed_category"] == "devops"


### PR DESCRIPTION
## Summary
- Only use SKILL.md body-derived descriptions when body scanning is explicitly enabled with `content_chars > 0`.
- Reject category migration apply rows whose referenced source `SKILL.md` is missing, even if the source directory exists.
- Add regression coverage for default `content_chars=0` behavior and missing source `SKILL.md` rows.

Fixes #160.

## Verification
- `python -m pytest tests/test_plan_category_migration.py tests/test_apply_category_migration.py -q --override-ini='addopts='` -> 14 passed
- `python -m ruff check scripts/utils.py scripts/apply_category_migration.py tests/test_plan_category_migration.py tests/test_apply_category_migration.py`
- `git diff --check`
- `python -m pytest -q --override-ini='addopts='` -> 393 passed