### PR TITLE
fix: normalize metadata identity aliases

### DIFF
--- a/scripts/audit_category_residuals.py
+++ b/scripts/audit_category_residuals.py
@@ -23,7 +23,7 @@ from apply_category_migration import (
 )
 from category_taxonomy import get_taxonomy
 from plan_category_migration import iter_skill_dirs
-from utils import load_metadata, normalize_name, normalize_repo
+from utils import canonical_metadata_identity, load_metadata, normalize_name, normalize_repo
 
 SCHEMA_VERSION = 1
 MOVABLE_REASON = "movable candidate under selected policy"
@@ -113,12 +113,7 @@ def file_sha256(path: Path) -> str:
 
 
 def metadata_identity(metadata: dict[str, Any]) -> dict[str, Any]:
-    identity: dict[str, Any] = {}
-    for field in CONFLICT_METADATA_IDENTITY_FIELDS:
-        value = metadata.get(field)
-        if value not in (None, ""):
-            identity[field] = value
-    return identity
+    return canonical_metadata_identity(metadata, CONFLICT_METADATA_IDENTITY_FIELDS)
 
 
 def stable_key_conflict_detail(

--- a/scripts/normalize_skill_depth.py
+++ b/scripts/normalize_skill_depth.py
@@ -21,6 +21,7 @@ from category_taxonomy import resolve_category
 from utils import (
     build_legal_metadata,
     build_skill_key,
+    canonical_metadata_identity,
     get_repo_suffix,
     load_metadata,
     normalize_category,
@@ -132,12 +133,7 @@ def file_sha256(path: Path) -> str:
 
 
 def metadata_identity(metadata: dict[str, Any]) -> dict[str, Any]:
-    identity: dict[str, Any] = {}
-    for field in METADATA_IDENTITY_FIELDS:
-        value = metadata.get(field)
-        if value not in (None, ""):
-            identity[field] = value
-    return identity
+    return canonical_metadata_identity(metadata, METADATA_IDENTITY_FIELDS)
 
 
 def duplicate_safety(skills_dir: Path, source_dir: Path, target_rel: Path) -> dict[str, Any]:

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -269,6 +269,34 @@ def build_skill_key(repo: str = "", path: str = "", name: str = "", category: st
     return ""
 
 
+def canonical_metadata_identity(metadata: dict[str, Any], fields: tuple[str, ...]) -> dict[str, Any]:
+    """Build metadata identity while treating known source aliases as equivalent."""
+    identity: dict[str, Any] = {}
+    alias_groups = {
+        "path": ("github_path", "path"),
+        "branch": ("github_branch", "branch"),
+    }
+    handled_aliases = set()
+    field_set = set(fields)
+    for canonical_field, aliases in alias_groups.items():
+        if not any(alias in field_set for alias in aliases):
+            continue
+        handled_aliases.update(aliases)
+        for alias in aliases:
+            value = metadata.get(alias)
+            if value not in (None, ""):
+                identity[canonical_field] = value
+                break
+
+    for field in fields:
+        if field in handled_aliases:
+            continue
+        value = metadata.get(field)
+        if value not in (None, ""):
+            identity[field] = value
+    return identity
+
+
 def iter_source_skills(source: dict):
     """Yield source rows with any top-level repo applied to rows that omit it."""
     default_repo = source.get("repo") if isinstance(source.get("repo"), str) else ""

--- a/tests/test_audit_category_residuals.py
+++ b/tests/test_audit_category_residuals.py
@@ -51,6 +51,28 @@ def _write_classification(path: Path, rows: list[dict]) -> None:
     )
 
 
+def test_metadata_identity_normalizes_path_and_branch_aliases():
+    audit = _load_module()
+
+    assert audit.metadata_identity(
+        {
+            "name": "demo",
+            "repo": "owner/repo",
+            "path": "skills/demo",
+            "branch": "main",
+            "license": "MIT",
+        }
+    ) == audit.metadata_identity(
+        {
+            "name": "demo",
+            "repo": "owner/repo",
+            "github_path": "skills/demo",
+            "github_branch": "main",
+            "license": "MIT",
+        }
+    )
+
+
 def test_report_separates_missing_sources_from_current_residuals(tmp_path):
     audit = _load_module()
     skills_dir = tmp_path / "skills"

--- a/tests/test_normalize_skill_depth.py
+++ b/tests/test_normalize_skill_depth.py
@@ -30,6 +30,28 @@ def _write_skill_with_body(root: Path, rel_dir: str, metadata: dict, body: str) 
     return skill_dir
 
 
+def test_metadata_identity_normalizes_path_and_branch_aliases():
+    module = _load_module()
+
+    assert module.metadata_identity(
+        {
+            "name": "demo",
+            "repo": "owner/repo",
+            "path": "skills/demo",
+            "branch": "main",
+            "license": "MIT",
+        }
+    ) == module.metadata_identity(
+        {
+            "name": "demo",
+            "repo": "owner/repo",
+            "github_path": "skills/demo",
+            "github_branch": "main",
+            "license": "MIT",
+        }
+    )
+
+
 def test_depth_plan_uses_metadata_category_for_nested_skill(tmp_path):
     module = _load_module()
     skills_dir = tmp_path / "skills"


### PR DESCRIPTION
## Summary
- Add shared canonical metadata identity handling for equivalent source aliases.
- Treat `github_path`/`path` as one canonical `path` field and `github_branch`/`branch` as one canonical `branch` field.
- Use the shared identity in residual conflict reporting and skill depth duplicate safety checks.
- Add regressions for both audit paths.

Fixes #161.

## Verification
- `python -m pytest tests/test_audit_category_residuals.py tests/test_normalize_skill_depth.py tests/test_plan_stable_key_duplicate_cleanup.py -q --override-ini='addopts='` -> 27 passed
- `python -m ruff check scripts/utils.py scripts/audit_category_residuals.py scripts/normalize_skill_depth.py tests/test_audit_category_residuals.py tests/test_normalize_skill_depth.py`
- `git diff --check`
- `python -m pytest -q --override-ini='addopts='` -> 395 passed