### PR TITLE
fix: tighten bundled hints and audit status filters

### DIFF
--- a/scripts/sample_category_classification_audit.py
+++ b/scripts/sample_category_classification_audit.py
@@ -142,7 +142,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--output", type=Path)
     parser.add_argument("--sample-size", type=int, default=50)
     parser.add_argument("--seed", default="category-audit-v1")
-    parser.add_argument("--status", action="append", default=["ok"])
+    parser.add_argument("--status", action="append")
     parser.add_argument("--min-confidence", type=float)
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--preview-limit", type=int, default=10)
@@ -160,7 +160,7 @@ def main(argv: list[str] | None = None) -> int:
         classification_jsonl=args.classification_jsonl,
         output_sample_size=args.sample_size,
         seed=args.seed,
-        statuses=parse_csv(args.status),
+        statuses=parse_csv(args.status) if args.status else None,
         min_confidence=args.min_confidence,
     )
     payload = json.dumps(report, indent=2, ensure_ascii=False)

--- a/scripts/sync_pipeline_support.py
+++ b/scripts/sync_pipeline_support.py
@@ -26,6 +26,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -253,7 +254,7 @@ def requires_complete_bundled_archive(skill_content: str) -> bool:
     """Return True when SKILL.md explicitly depends on bundled support files."""
     normalized = (skill_content or "").lower().replace("\\", "/")
     for dirname in BUNDLED_DIR_ALLOWLIST:
-        if f"{dirname}/" in normalized:
+        if re.search(rf"(?<![a-z0-9_.-]){re.escape(dirname)}/", normalized):
             return True
     return any(filename.lower() in normalized for filename in BUNDLED_REQUIRED_ROOT_FILE_HINTS)
 

--- a/tests/test_sample_category_classification_audit.py
+++ b/tests/test_sample_category_classification_audit.py
@@ -20,6 +20,23 @@ def _write_jsonl(path: Path, rows: list[dict]) -> None:
     )
 
 
+def test_parse_args_status_replaces_default_ok():
+    sampler = _load_module()
+
+    args = sampler.parse_args(
+        [
+            "--workset-jsonl",
+            "workset.jsonl",
+            "--classification-jsonl",
+            "classification.jsonl",
+            "--status",
+            "api_error",
+        ]
+    )
+
+    assert args.status == ["api_error"]
+
+
 def test_builds_deterministic_sample_with_input_context(tmp_path):
     sampler = _load_module()
     workset = tmp_path / "workset.jsonl"

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -695,6 +695,7 @@ def test_skill_source_dir_resolves_skill_parent():
 
 def test_bundled_file_allowlist_is_scoped_and_size_limited():
     module = load_module()
+    support = load_support_module()
 
     assert module.bundled_relative_path("", "package.json") == "package.json"
     assert (
@@ -729,6 +730,8 @@ def test_bundled_file_allowlist_is_scoped_and_size_limited():
         )
         is False
     )
+    assert support.requires_complete_bundled_archive("See references/guide.md") is True
+    assert support.requires_complete_bundled_archive("Set user preference/theme.md") is False
 
 
 def test_bundled_download_failure_does_not_publish_partial_archive(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Make bundled archive hint detection segment-aware so `preference/...` no longer matches the `reference/` support directory hint.
- Let explicit `sample_category_classification_audit.py --status ...` values replace the default `ok` filter.
- Add regressions for both edge cases.

Fixes #162.

## Verification
- `python -m pytest tests/test_sync_and_download.py::test_bundled_file_allowlist_is_scoped_and_size_limited tests/test_sample_category_classification_audit.py -q --override-ini='addopts='` -> 3 passed
- `python -m ruff check scripts/sync_pipeline_support.py scripts/sample_category_classification_audit.py tests/test_sync_and_download.py tests/test_sample_category_classification_audit.py`
- `git diff --check`
- `python -m pytest -q --override-ini='addopts='` -> 396 passed