### PR TITLE
fix: fail closed on registry rebuild outputs

### DIFF
--- a/scripts/rebuild_registry.py
+++ b/scripts/rebuild_registry.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 
-from utils import extract_description, load_metadata
+from utils import extract_description, load_metadata, normalize_category
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(message)s')
 logger = logging.getLogger(__name__)
@@ -33,11 +33,18 @@ def safe_write_registry(registry_path: Path, registry: dict) -> bool:
 
         temp_path.rename(registry_path)
         return True
-    except Exception as e:
-        logger.error(f"Failed to write registry: {e}")
-        if temp_path.exists():
-            temp_path.unlink()
-        return False
+    except Exception:
+        logger.exception("Failed to write registry")
+        try:
+            if temp_path.exists():
+                temp_path.unlink()
+        except Exception as cleanup_error:
+            logger.error(
+                "Failed to remove temporary registry file %s: %s",
+                temp_path,
+                cleanup_error,
+            )
+        raise
 
 
 def safe_write_json(output_path: Path, payload: dict) -> None:
@@ -310,8 +317,7 @@ def cleanup_orphan_metadata(skills_dir: Path) -> int:
 
 def sanitize_category(category: str) -> str:
     """Sanitize category name for use as filename."""
-    # Replace / and other problematic characters with -
-    return category.replace("/", "-").replace("\\", "-").replace(":", "-")
+    return normalize_category(category or "other")
 
 
 def build_category_indexes(skills: list, output_dir: Path):
@@ -482,14 +488,11 @@ if __name__ == "__main__":
             manifest_path=manifest_ref if args.compat_manifest_pointer else None,
         )
 
-        if safe_write_registry(registry_path, registry):
-            print(
-                f"Written compatibility {registry_path} "
-                f"with {len(unique_skills)} skills, {len(plugins)} plugins"
-            )
-        else:
-            print("Failed to write registry!")
-            return
+        safe_write_registry(registry_path, registry)
+        print(
+            f"Written compatibility {registry_path} "
+            f"with {len(unique_skills)} skills, {len(plugins)} plugins"
+        )
         print()
 
         if not args.skip_categories:

--- a/tests/test_plugin_contract.py
+++ b/tests/test_plugin_contract.py
@@ -3,6 +3,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS_DIR = ROOT / "scripts"
 if str(SCRIPTS_DIR) not in sys.path:
@@ -445,6 +447,39 @@ def test_safe_write_registry_writes_compact_json(tmp_path):
     assert content == '{"skills":[{"name":"demo","repo":"owner/repo"}]}'
 
 
+def test_safe_write_registry_raises_on_write_failure(tmp_path):
+    registry_path = tmp_path / "missing" / "registry.json"
+
+    with pytest.raises(FileNotFoundError):
+        rebuild_registry.safe_write_registry(registry_path, {"skills": []})
+
+    assert not (tmp_path / "missing" / "registry.json.tmp").exists()
+
+
+def test_build_category_indexes_normalizes_control_character_categories(tmp_path):
+    output_dir = tmp_path / "categories"
+    skills = [
+        {
+            "name": "demo",
+            "description": "Demo skill",
+            "category": "nestjs-validation-and-pipes\n",
+            "stars": 0,
+        }
+    ]
+
+    rebuild_registry.build_category_indexes(skills, output_dir)
+
+    category_files = [
+        path for path in output_dir.iterdir() if path.name != "index.json"
+    ]
+    assert [path.name for path in category_files] == [
+        "nestjs-validation-and-pipes.json"
+    ]
+    assert not any("\n" in path.name for path in category_files)
+    category_data = json.loads(category_files[0].read_text(encoding="utf-8"))
+    assert category_data["category"] == "nestjs-validation-and-pipes"
+
+
 def test_registry_shard_id_is_stable_for_install_and_branch():
     skill = {
         "name": "demo",
@@ -596,6 +631,51 @@ def test_rebuild_registry_accepts_absolute_manifest_output(tmp_path):
     assert registry["manifest"] == "artifacts/registry-manifest.json"
     assert manifest["shard_count"] == 256
     assert all(entry["path"].startswith("registry-shards/") for entry in manifest["shards"])
+
+
+def test_rebuild_registry_exits_nonzero_on_registry_write_failure(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "development" / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# demo\n\nDemo skill.", encoding="utf-8")
+    (skill_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "name": "demo",
+                "repo": "owner/repo",
+                "github_path": "skills/demo",
+                "github_branch": "main",
+                "category": "development",
+                "tags": ["demo"],
+                "stars": 1,
+                "source": "test",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPTS_DIR / "rebuild_registry.py"),
+            "--skills-dir",
+            str(skills_dir),
+            "--registry",
+            str(tmp_path / "missing" / "registry.json"),
+            "--manifest",
+            str(tmp_path / "artifacts" / "registry-manifest.json"),
+            "--shards-dir",
+            str(tmp_path / "artifacts" / "registry-shards"),
+            "--skip-categories",
+        ],
+        check=False,
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode != 0
+    assert "Failed to write registry" in result.stderr
 
 
 def test_cleanup_orphan_metadata_removes_only_orphans(tmp_path):


### PR DESCRIPTION
## Summary
- Make `safe_write_registry()` fail closed by re-raising write errors after temporary-file cleanup.
- Route rebuild category filenames through the core category normalization path so control characters cannot create generated JSON filenames.

References majiayu000/claude-skill-registry#44 and majiayu000/claude-skill-registry#45.

## Test plan
- `python -m pytest tests/test_plugin_contract.py::test_safe_write_registry_writes_compact_json tests/test_plugin_contract.py::test_safe_write_registry_raises_on_write_failure tests/test_plugin_contract.py::test_build_category_indexes_normalizes_control_character_categories tests/test_plugin_contract.py::test_rebuild_registry_exits_nonzero_on_registry_write_failure -q --override-ini='addopts='`
- `python -m ruff check scripts/rebuild_registry.py tests/test_plugin_contract.py`
- `git diff --check`
- `python -m pytest -q --override-ini='addopts='`
