### PR TITLE
docs: add core readiness templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-skill.yml
+++ b/.github/ISSUE_TEMPLATE/add-skill.yml
@@ -1,0 +1,43 @@
+name: Add Skill
+description: Propose a community skill source for registry intake.
+title: "[Skill] "
+labels: ["source-intake"]
+body:
+  - type: input
+    id: repo
+    attributes:
+      label: Repository
+      description: GitHub owner/repo or full HTTPS URL.
+      placeholder: owner/repo
+    validations:
+      required: true
+  - type: input
+    id: path
+    attributes:
+      label: Skill path
+      description: Optional path to SKILL.md when it is not at the repository root.
+      placeholder: skills/example/SKILL.md
+  - type: input
+    id: category
+    attributes:
+      label: Category
+      description: Canonical category slug, such as development, testing, devops, design, security, data, or marketing.
+      placeholder: development
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Short summary of what the skill does.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: The source is public and installable.
+          required: true
+        - label: The skill does not contain secrets, tokens, or private endpoints.
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,38 @@
+name: Bug Report
+description: Report a problem in the core pipeline, generated indexes, search UI, or publish flow.
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Discovery or download
+        - Security scan
+        - Registry or search index
+        - Category or taxonomy
+        - GitHub Pages search UI
+        - Publish orchestration
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What happened, and what did you expect instead?
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Link logs, artifact URLs, commands, or screenshots that show the problem.
+  - type: checkboxes
+    id: routing
+    attributes:
+      label: Routing check
+      options:
+        - label: This belongs in core, not only in the generated main mirror or archived data repo.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Generated mirror routing
+    url: https://github.com/majiayu000/claude-skill-registry
+    about: Use this only when the merged publish artifact itself is wrong.
+  - name: Archived skill data routing
+    url: https://github.com/majiayu000/claude-skill-registry-data
+    about: Use this for archived skill body or archive metadata issues.

--- a/.github/ISSUE_TEMPLATE/data-quality.yml
+++ b/.github/ISSUE_TEMPLATE/data-quality.yml
@@ -1,0 +1,32 @@
+name: Data Quality
+description: Report duplicate, stale, misclassified, unsafe, or incorrectly described registry data.
+title: "[Data] "
+labels: ["data-quality"]
+body:
+  - type: input
+    id: skill
+    attributes:
+      label: Skill or artifact URL
+      placeholder: https://majiayu000.github.io/claude-skill-registry-core/...
+    validations:
+      required: true
+  - type: dropdown
+    id: problem_type
+    attributes:
+      label: Problem type
+      options:
+        - Duplicate skill
+        - Wrong category
+        - Stale metadata
+        - Unsafe content
+        - Missing bundled file
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: Include the current value, expected value, and source evidence when possible.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Summary
+
+<!-- What changed and why? -->
+
+## Routing
+
+- [ ] This PR belongs in `claude-skill-registry-core`.
+- [ ] Generated main-repo artifacts were not edited directly.
+- [ ] Data-repo-only skill body changes were not made here.
+
+## Verification
+
+<!-- List the commands or checks run for this change. -->
+
+## Linked Issues
+
+<!-- Link issues with Fixes/Closes only when this PR fully resolves them. -->

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ The largest searchable index of Claude Code skills, aggregated from GitHub and c
 - **Publish contract**: core dispatches main publish with pinned `core_sha` + `data_sha`
 - **Non-goal for main**: main does not initiate canonical syncs, archive updates, or index generation
 
+## Release, Proof, And Support
+
+- **Release status**: daily catalog refreshes are represented by live generated metadata, not GitHub Releases. GitHub Releases are reserved for intentional pipeline/API milestones.
+- **Live proof**: use the [Web Search](https://majiayu000.github.io/claude-skill-registry-core/) UI, the badges above, and `stats.json` to verify current generated data.
+- **Routing**: pipeline bugs, source intake, registry schema, Pages/search, and publish orchestration belong in this core repo. Archived skill body issues belong in `claude-skill-registry-data`. Generated mirror questions belong in `claude-skill-registry` only when the artifact itself is wrong.
+
+```bash
+curl https://majiayu000.github.io/claude-skill-registry-core/stats.json
+curl https://majiayu000.github.io/claude-skill-registry-core/search-index-lite.json
+```
+
 ## Quick Start
 
 ### Option 1: Web Search


### PR DESCRIPTION
## Summary
- Add issue templates for skill intake, pipeline bugs, and data-quality reports.
- Add a PR template that reinforces core/data/main routing.
- Document release status, live proof paths, and support routing in the README.
- Add missing repo topics and matching template labels in repository settings.

Closes #195.

## Verification
- Parsed all `.github/ISSUE_TEMPLATE/*.yml` files with PyYAML.
- `git diff --cached --check`
- `python -m pytest -q --override-ini='addopts='`
