### PR TITLE
fix: preserve main routing files on publish

### DIFF
--- a/scripts/sync_main_repo.sh
+++ b/scripts/sync_main_repo.sh
@@ -109,13 +109,18 @@ remove_local_artifacts_under() {
 }
 
 sync_core_to_main() {
-  # Keep all main-owned workflows stable. Mirroring a new workflow file from core
-  # requires token workflow scope in the publish repo and breaks scheduled publish.
+  # Keep main-owned workflows and repository routing docs/templates stable.
+  # Mirroring a new workflow file from core requires token workflow scope in the
+  # publish repo and breaks scheduled publish.
   rsync -a --delete \
     --exclude '.git' \
     --exclude '.gitignore' \
+    --exclude 'README.md' \
     --exclude 'skills' \
     --exclude 'skills/**' \
+    --exclude '.github/ISSUE_TEMPLATE' \
+    --exclude '.github/ISSUE_TEMPLATE/**' \
+    --exclude '.github/PULL_REQUEST_TEMPLATE.md' \
     --exclude '.github/workflows/*.yml' \
     --exclude '.github/workflows/*.yaml' \
     --exclude '.ruff_cache' \

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -162,6 +162,21 @@ def test_publish_sync_has_observable_steps_and_cache_excludes():
     assert "-exec rm -f {} +" in cleanup_block
 
 
+def test_publish_sync_preserves_main_owned_routing_files():
+    sync_script = read_repo_file("scripts/sync_main_repo.sh")
+    sync_block = sync_script[
+        sync_script.index("sync_core_to_main()") : sync_script.index(
+            "sync_data_to_main()"
+        )
+    ]
+
+    assert "--exclude 'README.md'" in sync_block
+    assert "--exclude '.github/ISSUE_TEMPLATE'" in sync_block
+    assert "--exclude '.github/ISSUE_TEMPLATE/**'" in sync_block
+    assert "--exclude '.github/PULL_REQUEST_TEMPLATE.md'" in sync_block
+    assert "--delete-excluded" not in sync_block
+
+
 def test_publish_sync_metadata_compliance_is_advisory_for_historical_notices():
     sync_script = read_repo_file("scripts/sync_main_repo.sh")
     notices_block = sync_script[sync_script.index("Generate third-party notices") :]


### PR DESCRIPTION
## Summary
- Preserve main-owned README and issue/PR routing templates during `sync_main_repo.sh` publish.
- Add a workflow contract test so future publishes do not overwrite the generated mirror routing files added in main PR #49.

This keeps majiayu000/claude-skill-registry#46 stable across future publishes.

## Verification
- `python -m pytest tests/test_pipeline_contracts.py::test_publish_sync_preserves_main_owned_routing_files tests/test_pipeline_contracts.py::test_publish_sync_has_observable_steps_and_cache_excludes -q --override-ini='addopts='`
- `git diff --check`

Note: a later local attempt to run `ruff --version` and full `pytest` hung with no output in this desktop session, so I stopped those local processes. CI should still run the repository checks on this PR.
