### PR TITLE
Classify discovery intake from SKILL.md semantics

### DIFF
--- a/.github/workflows/sync-data.yml
+++ b/.github/workflows/sync-data.yml
@@ -105,7 +105,7 @@ jobs:
         run: |
           echo "🔍 Running full discovery via GitHub API..."
           python scripts/discover_by_topic.py \
-            --output skills/other \
+            --output skills \
             --json sources/discovered.json \
             --candidates-output sources/learning/discovery_candidates.jsonl \
             --priors-output sources/learning/discovery_priors.json 2>&1 | tee discover.log
@@ -120,7 +120,7 @@ jobs:
         run: |
           echo "🔍 Running bounded daily discovery..."
           python scripts/discover_by_topic.py \
-            --output skills/other \
+            --output skills \
             --json sources/discovered.json \
             --candidates-output sources/learning/discovery_candidates.jsonl \
             --priors-output sources/learning/discovery_priors.json \

--- a/docs/plan/skillmd-first-intake-category-spec.md
+++ b/docs/plan/skillmd-first-intake-category-spec.md
@@ -1,0 +1,61 @@
+# SKILL.md-first intake category classification
+
+## Context
+
+GitHub discovery can find valid upstream skills that only provide `SKILL.md`.
+Upstream skills are not required to ship `metadata.json`; registry metadata is a
+local archive companion generated during intake.
+
+The previous discovery path wrote every downloaded skill into `other`, then
+expected later cleanup to migrate obvious categories. A broad discovery batch can
+therefore create thousands of publishable but poorly classified `other` entries.
+
+## Design
+
+Discovery intake now classifies from the downloaded `SKILL.md` before choosing an
+archive category directory.
+
+Semantic extraction is ordered as:
+
+1. `SKILL.md` frontmatter fields
+2. `SKILL.md` body-derived description
+3. source path and directory hints
+4. generated metadata seed fields
+
+The classifier uses canonical taxonomy keywords and returns an auditable decision:
+
+- `category`
+- `status`
+- `method`
+- `confidence`
+- `reason`
+- `score`
+- `runner_up`
+- `runner_up_score`
+- `signals`
+- `semantic_sources`
+
+High- and medium-confidence matches are archived under the proposed canonical
+category. Unresolved, weak, or ambiguous matches remain under `other` with an
+explicit low-confidence reason.
+
+## Non-goals
+
+- Do not call an external LLM during publish or discovery intake.
+- Do not make `other` a publish blocker.
+- Do not treat category confidence as a security decision.
+- Do not require upstream `metadata.json`.
+
+## Safety invariants
+
+- Security scanning remains fail-closed and runs before archive writes.
+- Case-safe directory naming and stable-key conflict behavior remain in place.
+- `other` remains a valid fallback category, but it must be explainable.
+- Publish can continue when classification is unresolved.
+
+## Expected effect
+
+New discovery batches should no longer flood `other` simply because upstream
+skills lack generated registry metadata. The remaining `other` entries should
+represent genuine taxonomy gaps, weak semantic signals, or ambiguity that needs
+review.

--- a/scripts/discover_by_topic.py
+++ b/scripts/discover_by_topic.py
@@ -4,20 +4,28 @@ Discover skills by GitHub Topics
 Uses GitHub Search API to find repositories with claude-code-skills or claude-skills topics
 """
 
-import os
 import json
-import time
 import logging
+import os
 import shutil
 import tempfile
+import time
 from collections import defaultdict
-import requests
 from datetime import datetime
 from pathlib import Path
 
+import requests
 from security_blocklist import blocked_metadata_source, load_security_blocklist
 from security_scanner import SecurityScanner
-from utils import normalize_name, ensure_unique_dir, build_skill_key, build_legal_metadata
+from utils import (
+    build_legal_metadata,
+    build_skill_key,
+    classify_category_from_semantics,
+    ensure_unique_dir,
+    extract_frontmatter,
+    normalize_name,
+    skill_semantic_fields,
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -269,14 +277,6 @@ class GitHubTopicDiscovery:
         """Find all SKILL.md files in a repository"""
         skills = []
 
-        # Common skill locations
-        paths_to_check = [
-            '',
-            'skills',
-            '.claude/skills',
-            '.codex/skills',
-        ]
-
         # First try to search the repo for SKILL.md files
         url = f"{GITHUB_API}/search/code"
         params = {
@@ -335,18 +335,31 @@ class GitHubTopicDiscovery:
                     if '---' not in content[:100] and 'name:' not in content[:500]:
                         continue
 
-                    # Save skill (case-safe)
-                    category = "other"
+                    semantic_seed_metadata = {
+                        'name': skill_dir,
+                        'repo': repo,
+                        'path': path,
+                    }
+                    frontmatter = extract_frontmatter(content)
+                    semantics = skill_semantic_fields(
+                        Path(skill_dir),
+                        metadata=semantic_seed_metadata,
+                        frontmatter=frontmatter,
+                        rel=Path(path),
+                        content=content,
+                        content_chars=4096,
+                    )
+                    classification = classify_category_from_semantics(semantics)
+                    category = str(classification["category"])
                     key = build_skill_key(repo, path, name=skill_dir, category=category)
 
-                    # Save metadata
                     legal_meta = build_legal_metadata(
                         repo=repo,
                         path=path,
                         branch=branch,
                     )
                     metadata = {
-                        'name': skill_dir,
+                        'name': semantics["name"],
                         'repo': repo,
                         'path': path,
                         'github_branch': branch,
@@ -354,8 +367,14 @@ class GitHubTopicDiscovery:
                         'source': f'github.com/{repo}',
                         'dir_name': skill_dir,
                         'downloaded_at': datetime.utcnow().isoformat() + 'Z',
+                        'classification': {
+                            'schema_version': 1,
+                            **classification,
+                        },
                         **legal_meta,
                     }
+                    if semantics["description"]:
+                        metadata["description"] = semantics["description"]
 
                     output_dir.mkdir(parents=True, exist_ok=True)
                     with tempfile.TemporaryDirectory(
@@ -591,7 +610,7 @@ class GitHubTopicDiscovery:
         )
         self._update_priors(priors_output, discovered_at, repos_to_scan)
 
-        logger.info(f"\n=== Summary ===")
+        logger.info("\n=== Summary ===")
         logger.info(f"Repositories discovered: {len(self.discovered_repos)}")
         logger.info(f"Skills downloaded: {downloaded}")
         logger.info(f"Candidate records written: {candidates_written}")

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -546,6 +546,134 @@ def skill_semantic_fields(
     }
 
 
+def _semantic_tokens(text: str) -> list[str]:
+    return re.findall(r"[a-z0-9]+", text.lower())
+
+
+def _keyword_matches(tokens: list[str], keyword: str) -> bool:
+    parts = [part for part in keyword.split("-") if part]
+    if not parts:
+        return False
+    if len(parts) > 1:
+        window = len(parts)
+        return any(tokens[index : index + window] == parts for index in range(len(tokens)))
+
+    part = parts[0]
+    if len(part) <= 3:
+        return part in tokens
+    return any(token == part or token.startswith(part) for token in tokens)
+
+
+def category_keyword_scores(
+    text: str,
+    keyword_map: dict[str, list[str]] | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Score taxonomy categories against semantic text and retain matched signals."""
+    tokens = _semantic_tokens(text)
+    scores: dict[str, dict[str, Any]] = {}
+    for category, keywords in (keyword_map or CATEGORY_KEYWORDS).items():
+        signals = [
+            keyword
+            for keyword in keywords
+            if _keyword_matches(tokens, str(keyword).strip().lower())
+        ]
+        if signals:
+            scores[category] = {
+                "score": len(signals),
+                "signals": signals,
+            }
+    return scores
+
+
+def classify_category_from_semantics(
+    semantics: dict[str, Any],
+    *,
+    default_category: str = "other",
+    min_score: int = 2,
+    min_delta: int = 1,
+    high_score: int = 4,
+    high_delta: int = 2,
+) -> dict[str, Any]:
+    """Classify semantic fields with auditable taxonomy keyword evidence."""
+    scores = category_keyword_scores(str(semantics.get("text") or ""))
+    ranked = sorted(
+        scores.items(),
+        key=lambda item: (-int(item[1]["score"]), item[0]),
+    )
+    semantic_sources = dict(semantics.get("sources") or {})
+
+    if not ranked:
+        return {
+            "category": default_category,
+            "status": "unclassified",
+            "method": "taxonomy_keyword_v1",
+            "confidence": "low",
+            "reason": "no taxonomy keywords matched SKILL.md semantic text",
+            "score": 0,
+            "runner_up": "",
+            "runner_up_score": 0,
+            "signals": [],
+            "semantic_sources": semantic_sources,
+        }
+
+    top_category, top = ranked[0]
+    top_score = int(top["score"])
+    runner_category = ranked[1][0] if len(ranked) > 1 else ""
+    runner_score = int(ranked[1][1]["score"]) if len(ranked) > 1 else 0
+    delta = top_score - runner_score
+
+    if top_score < min_score:
+        return {
+            "category": default_category,
+            "status": "unclassified",
+            "method": "taxonomy_keyword_v1",
+            "confidence": "low",
+            "reason": (
+                f"top category {top_category} scored {top_score}, below "
+                f"minimum score {min_score}"
+            ),
+            "score": top_score,
+            "runner_up": runner_category,
+            "runner_up_score": runner_score,
+            "signals": list(top["signals"]),
+            "semantic_sources": semantic_sources,
+        }
+
+    if delta < min_delta:
+        return {
+            "category": default_category,
+            "status": "unclassified",
+            "method": "taxonomy_keyword_v1",
+            "confidence": "low",
+            "reason": (
+                f"ambiguous taxonomy keyword scores: {top_category}={top_score}, "
+                f"{runner_category}={runner_score}"
+            ),
+            "score": top_score,
+            "runner_up": runner_category,
+            "runner_up_score": runner_score,
+            "signals": list(top["signals"]),
+            "semantic_sources": semantic_sources,
+        }
+
+    confidence = "high" if top_score >= high_score and delta >= high_delta else "medium"
+    return {
+        "category": top_category,
+        "status": "classified",
+        "method": "taxonomy_keyword_v1",
+        "confidence": confidence,
+        "reason": (
+            f"matched taxonomy keywords for {top_category}: "
+            f"{', '.join(top['signals'])}"
+        ),
+        "score": top_score,
+        "runner_up": runner_category,
+        "runner_up_score": runner_score,
+        "signals": list(top["signals"]),
+        "semantic_sources": semantic_sources,
+    }
+
+
 def load_metadata(skill_dir: Path) -> dict:
     """Safely load metadata.json from a skill directory."""
     meta_path = skill_dir / "metadata.json"
@@ -569,12 +697,8 @@ def write_metadata(skill_dir: Path, meta: dict) -> None:
 
 def guess_category(text: str) -> str:
     """Guess category from combined text (path + content snippet)."""
-    lowered = text.lower()
-    scores: dict[str, int] = {}
-    for category, keywords in CATEGORY_KEYWORDS.items():
-        score = sum(1 for kw in keywords if kw in lowered)
-        if score > 0:
-            scores[category] = score
+    scored = category_keyword_scores(text)
+    scores = {category: int(result["score"]) for category, result in scored.items()}
     if scores:
         return max(scores, key=scores.get)
     return "other"

--- a/tests/test_discover_by_topic_learning_outputs.py
+++ b/tests/test_discover_by_topic_learning_outputs.py
@@ -212,6 +212,71 @@ def test_download_skill_preserves_existing_archive_on_security_scan_failure(tmp_
     assert (existing_dir / "metadata.json").read_text(encoding="utf-8") == existing_metadata
 
 
+def test_download_skill_classifies_from_skill_md_first(tmp_path):
+    module = load_module()
+    discovery = module.GitHubTopicDiscovery(request_delay=0.0)
+    discovery.session = FakeSession(
+        FakeResponse(
+            200,
+            (
+                "---\n"
+                "name: docker-deployer\n"
+                "description: Deploy Docker Kubernetes CI CD infrastructure automation.\n"
+                "tags: [docker, kubernetes, ci]\n"
+                "---\n"
+                "# Docker Deployer\n\n"
+                "Builds release images and deploys services to Kubernetes clusters.\n"
+            ),
+        )
+    )
+
+    downloaded = discovery.download_skill(
+        "acme/docker-deployer",
+        "skills/docker-deployer/SKILL.md",
+        tmp_path / "skills",
+    )
+
+    assert downloaded is True
+    skill_dir = tmp_path / "skills" / "devops" / "docker-deployer"
+    metadata = module.json.loads((skill_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert (skill_dir / "SKILL.md").exists()
+    assert not (tmp_path / "skills" / "other" / "docker-deployer").exists()
+    assert metadata["category"] == "devops"
+    assert metadata["description"] == "Deploy Docker Kubernetes CI CD infrastructure automation."
+    assert metadata["classification"]["status"] == "classified"
+    assert metadata["classification"]["confidence"] == "high"
+    assert metadata["classification"]["method"] == "taxonomy_keyword_v1"
+    assert metadata["classification"]["semantic_sources"]["description"] == "frontmatter"
+
+
+def test_download_skill_falls_back_to_other_with_audit_reason(tmp_path):
+    module = load_module()
+    discovery = module.GitHubTopicDiscovery(request_delay=0.0)
+    discovery.session = FakeSession(
+        FakeResponse(
+            200,
+            "---\nname: quiet-helper\n---\n# Quiet Helper\n\nShort note.\n",
+        )
+    )
+
+    downloaded = discovery.download_skill(
+        "acme/quiet-helper",
+        "skills/quiet-helper/SKILL.md",
+        tmp_path / "skills",
+    )
+
+    assert downloaded is True
+    skill_dir = tmp_path / "skills" / "other" / "quiet-helper"
+    metadata = module.json.loads((skill_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert (skill_dir / "SKILL.md").exists()
+    assert metadata["category"] == "other"
+    assert metadata["classification"]["status"] == "unclassified"
+    assert metadata["classification"]["confidence"] == "low"
+    assert metadata["classification"]["reason"] == (
+        "no taxonomy keywords matched SKILL.md semantic text"
+    )
+
+
 def test_download_skill_scans_existing_bundled_files_before_refresh(tmp_path):
     module = load_module()
     discovery = module.GitHubTopicDiscovery(request_delay=0.0)

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -264,6 +264,13 @@ def test_sync_data_cleans_ci_archive_leftovers_before_discovery():
     assert workflow.count("--skip-ci-untracked-cleanup") == 2
 
 
+def test_sync_data_discovery_writes_to_archive_root_not_other_category():
+    workflow = read_repo_file(".github/workflows/sync-data.yml")
+
+    assert "--output skills/other" not in workflow
+    assert workflow.count("--output skills") == 2
+
+
 def test_metadata_compliance_refuses_unexpected_zero_target_scan():
     workflow = read_repo_file(".github/workflows/metadata-compliance.yml")
 


### PR DESCRIPTION
## Summary

- add a versioned SKILL.md-first intake category design spec
- classify newly discovered GitHub skills from `SKILL.md` semantics before choosing the archive category directory
- add auditable classification metadata for status, method, confidence, reason, score, signals, and semantic sources
- keep unresolved/ambiguous cases publishable under `other` with an explicit reason

Closes #207.

## Verification

- `python -m ruff check scripts/discover_by_topic.py scripts/utils.py tests/test_discover_by_topic_learning_outputs.py`
- `python -m pytest tests/test_discover_by_topic_learning_outputs.py tests/test_utils.py -q`
- `python scripts/check_taxonomy_governance.py`
- `python -m pytest -q --cov-fail-under=50`
