### PR TITLE
Prevent discovery from re-adding migrated skills

### DIFF
--- a/scripts/discover_by_topic.py
+++ b/scripts/discover_by_topic.py
@@ -82,6 +82,7 @@ class GitHubTopicDiscovery:
         self.security_scanner = SecurityScanner()
         self.repo_candidates = {}
         self.path_candidates = {}
+        self._archive_source_indexes = {}
         self.topic_stats = defaultdict(
             lambda: {"repo_hits": 0, "repo_selected": 0, "downloaded_skills": 0}
         )
@@ -137,6 +138,40 @@ class GitHubTopicDiscovery:
             return False
         lower = norm.lower()
         return lower == "skill.md" or lower.endswith("/skill.md")
+
+    @staticmethod
+    def _source_identity_key(repo: str, path: str) -> str:
+        if not (repo or "").strip() or not (path or "").strip():
+            return ""
+        return build_skill_key(repo, path)
+
+    def _archive_source_index(self, output_dir: Path) -> set[str]:
+        root = output_dir.resolve()
+        cache_key = str(root)
+        if cache_key in self._archive_source_indexes:
+            return self._archive_source_indexes[cache_key]
+
+        index: set[str] = set()
+        if root.exists():
+            for metadata_path in root.rglob("metadata.json"):
+                if any(part.startswith(".") for part in metadata_path.relative_to(root).parts):
+                    continue
+                try:
+                    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+                except (OSError, json.JSONDecodeError):
+                    continue
+                repo = str(metadata.get("repo") or "")
+                path = str(metadata.get("github_path") or metadata.get("path") or "")
+                source_key = self._source_identity_key(repo, path)
+                if source_key:
+                    index.add(source_key)
+
+        self._archive_source_indexes[cache_key] = index
+        return index
+
+    def _archive_has_source(self, repo: str, path: str, output_dir: Path) -> bool:
+        source_key = self._source_identity_key(repo, path)
+        return bool(source_key and source_key in self._archive_source_index(output_dir))
 
     def _request(self, url, params=None):
         """Make rate-limited request"""
@@ -299,6 +334,7 @@ class GitHubTopicDiscovery:
 
     def download_skill(self, repo, path, output_dir):
         """Download a SKILL.md file"""
+        output_dir = Path(output_dir)
         blocked_source = blocked_metadata_source(
             {"repo": repo, "path": path},
             self.security_blocklist,
@@ -311,6 +347,10 @@ class GitHubTopicDiscovery:
                 source_field,
                 path,
             )
+            return False
+        source_key = self._source_identity_key(repo, path)
+        if self._archive_has_source(repo, path, output_dir):
+            logger.info("Skipping already archived discovered source: %s/%s", repo, path)
             return False
 
         # Extract skill name from path
@@ -440,6 +480,8 @@ class GitHubTopicDiscovery:
                     (skill_path / 'metadata.json').write_text(
                         json.dumps(metadata, indent=2), encoding='utf-8'
                     )
+                    if source_key:
+                        self._archive_source_index(output_dir).add(source_key)
 
                     return True
             except Exception as e:

--- a/scripts/discover_by_topic.py
+++ b/scripts/discover_by_topic.py
@@ -141,8 +141,15 @@ class GitHubTopicDiscovery:
 
     @staticmethod
     def _source_identity_key(repo: str, path: str) -> str:
-        if not (repo or "").strip() or not (path or "").strip():
+        repo = (repo or "").strip()
+        path = (path or "").strip().replace("\\", "/").strip("/")
+        if not repo or not path:
             return ""
+        lower_path = path.lower()
+        if lower_path == "skill.md":
+            path = ""
+        elif lower_path.endswith("/skill.md"):
+            path = path.rsplit("/", 1)[0]
         return build_skill_key(repo, path)
 
     def _archive_source_index(self, output_dir: Path) -> set[str]:

--- a/tests/test_discover_by_topic_learning_outputs.py
+++ b/tests/test_discover_by_topic_learning_outputs.py
@@ -274,7 +274,7 @@ def test_download_skill_skips_source_already_archived_in_another_category(tmp_pa
         {
             "name": "docker-deployer",
             "repo": "acme/docker-deployer",
-            "path": "skills/docker-deployer/SKILL.md",
+            "path": "skills/docker-deployer",
             "category": "development",
             "source": "github.com/acme/docker-deployer",
             "dir_name": "docker-deployer",

--- a/tests/test_discover_by_topic_learning_outputs.py
+++ b/tests/test_discover_by_topic_learning_outputs.py
@@ -25,8 +25,10 @@ class FakeSession:
     def __init__(self, response):
         self.response = response
         self.headers = {}
+        self.calls = 0
 
     def get(self, url, timeout=None):
+        self.calls += 1
         return self.response
 
 
@@ -247,6 +249,52 @@ def test_download_skill_classifies_from_skill_md_first(tmp_path):
     assert metadata["classification"]["confidence"] == "high"
     assert metadata["classification"]["method"] == "taxonomy_keyword_v1"
     assert metadata["classification"]["semantic_sources"]["description"] == "frontmatter"
+
+
+def test_download_skill_skips_source_already_archived_in_another_category(tmp_path):
+    module = load_module()
+    discovery = module.GitHubTopicDiscovery(request_delay=0.0)
+    discovery.session = FakeSession(
+        FakeResponse(
+            200,
+            (
+                "---\n"
+                "name: docker-deployer\n"
+                "description: Deploy Docker Kubernetes CI CD infrastructure automation.\n"
+                "---\n"
+                "# Docker Deployer\n"
+            ),
+        )
+    )
+
+    existing_dir = tmp_path / "skills" / "development" / "docker-deployer"
+    existing_dir.mkdir(parents=True)
+    existing_skill = "---\nname: docker-deployer\n---\n# Existing Docker Deployer\n"
+    existing_metadata = module.json.dumps(
+        {
+            "name": "docker-deployer",
+            "repo": "acme/docker-deployer",
+            "path": "skills/docker-deployer/SKILL.md",
+            "category": "development",
+            "source": "github.com/acme/docker-deployer",
+            "dir_name": "docker-deployer",
+        },
+        indent=2,
+    )
+    (existing_dir / "SKILL.md").write_text(existing_skill, encoding="utf-8")
+    (existing_dir / "metadata.json").write_text(existing_metadata, encoding="utf-8")
+
+    downloaded = discovery.download_skill(
+        "acme/docker-deployer",
+        "skills/docker-deployer/SKILL.md",
+        tmp_path / "skills",
+    )
+
+    assert downloaded is False
+    assert discovery.session.calls == 0
+    assert (existing_dir / "SKILL.md").read_text(encoding="utf-8") == existing_skill
+    assert not (tmp_path / "skills" / "other" / "docker-deployer").exists()
+    assert not (tmp_path / "skills" / "devops" / "docker-deployer").exists()
 
 
 def test_download_skill_falls_back_to_other_with_audit_reason(tmp_path):


### PR DESCRIPTION
## Summary
- add a repo/path source-identity index for GitHub discovery archive writes
- skip discovery downloads when the same source is already archived in any category
- cover the regression where a migrated skill could be re-added under `other`

Closes #209.

## Validation
- `python -m ruff check scripts/discover_by_topic.py tests/test_discover_by_topic_learning_outputs.py`
- `python -m pytest tests/test_discover_by_topic_learning_outputs.py -q`
- `python -m pytest tests/test_sync_and_download.py::test_download_can_skip_ci_untracked_archive_cleanup tests/test_sync_and_download.py::test_download_skills_can_disable_acquisition_manifest tests/test_utils.py::test_build_skill_key_priority -q`
- `python scripts/check_taxonomy_governance.py`
- `git diff --check`
- `python -m pytest -q --cov-fail-under=50`
