### PR TITLE
Add report-only release readiness tools

### DIFF
--- a/docs/plan/canonical-taxonomy-governance-spec.md
+++ b/docs/plan/canonical-taxonomy-governance-spec.md
@@ -213,6 +213,13 @@ by policy, target `other`, classification status/path failures, stable-key
 conflicts, source missing, current archive category filtered out, and movable
 candidates under the selected policy.
 
+`scripts/build_other_residual_governance_report.py` explains the live residual
+bucket after a publish or data merge when there may no longer be a single active
+classification batch. It is report-only and groups current residual skills into
+security failures, structural review, semantic review candidates, low-context
+items, and manual taxonomy review. This script must not mutate archive contents
+or make publish decisions.
+
 ## Governance Gates
 
 Taxonomy gate:
@@ -247,6 +254,15 @@ Category artifact gate:
 - It also checks category count consistency across
   `docs/categories/index.json`, category pointers, category manifests, manifest
   part counts, category parts, and `docs/stats.json`.
+
+Release acceptance report:
+
+- `scripts/build_publish_readiness_report.py` reads the generated main artifact
+  and summarizes provenance, publish status, registry counts, category counts,
+  and category manifest consistency.
+- The readiness report is informational. It does not implement an `other`
+  count publish gate, and it must not be wired into publish as a blocker without
+  a separate maintainer decision.
 
 ## Operating Flow
 

--- a/docs/plan/release-readiness-reporting.md
+++ b/docs/plan/release-readiness-reporting.md
@@ -1,0 +1,55 @@
+# Release Readiness Reporting
+
+## Purpose
+
+Release readiness reporting gives maintainers a short, reproducible summary of
+the generated main artifact after core and data have been published together.
+It is not a publish gate.
+
+## Report-Only Checks
+
+Run:
+
+```bash
+python scripts/build_publish_readiness_report.py \
+  --main-dir ../claude-skill-registry \
+  --output-json /tmp/publish-readiness.json
+```
+
+The report reads:
+
+- `docs/stats.json`
+- `docs/categories/other/manifest.json`
+- `registry-manifest.json`
+- `provenance/merge-source.json`
+- `provenance/publish-status.json`
+
+It summarizes the current `other` count, raw archive counts, deduped registry
+count, provenance tuple, publish-status checks, and manifest consistency.
+
+## Residual Governance
+
+Run:
+
+```bash
+python scripts/build_other_residual_governance_report.py \
+  --skills-dir ../claude-skill-registry/skills \
+  --output-json /tmp/other-residual-governance.json
+```
+
+The residual report groups current `other` skills into:
+
+- `security_failed`
+- `structure_review`
+- `semantic_review_candidate`
+- `low_context`
+- `manual_taxonomy_review`
+
+These buckets are review queues. They are not automatic migrations and do not
+block publish.
+
+## Deferred Gate Discussion
+
+An `other` count or growth threshold may be useful later, but it should remain
+an issue-level discussion until maintainers explicitly choose to make it a
+publish blocker.

--- a/scripts/build_other_residual_governance_report.py
+++ b/scripts/build_other_residual_governance_report.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Build a report-only governance summary for live residual category skills."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+from audit_category_quality import best_suggestion, read_text_prefix
+from category_taxonomy import category_keywords
+from utils import extract_frontmatter, load_metadata, skill_semantic_fields
+
+SCHEMA_VERSION = 1
+
+
+def utc_now_isoformat() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def sorted_counter(counter: Counter[str]) -> dict[str, int]:
+    return dict(sorted(counter.items()))
+
+
+def iter_category_skill_dirs(skills_dir: Path, category: str):
+    category_dir = skills_dir / category
+    if not category_dir.exists():
+        return
+    for skill_file in sorted(category_dir.glob("*/SKILL.md")):
+        yield skill_file.parent, skill_file.relative_to(skills_dir)
+
+
+def frontmatter_status(content: str) -> tuple[str, str]:
+    if not content.startswith("---"):
+        return "no_frontmatter", "SKILL.md does not begin with YAML frontmatter"
+    end_index = content.find("---", 3)
+    if end_index == -1:
+        return "invalid_frontmatter", "frontmatter is not terminated"
+    try:
+        payload = yaml.safe_load(content[3:end_index].strip())
+    except yaml.YAMLError as exc:
+        return "invalid_frontmatter", f"frontmatter YAML parse error: {exc}"
+    if not isinstance(payload, dict):
+        return "invalid_frontmatter", "frontmatter is not a mapping"
+    return "ok", ""
+
+
+def load_security_statuses(security_report: Path | None) -> dict[str, dict[str, Any]]:
+    if security_report is None or not security_report.exists():
+        return {}
+    payload = json.loads(security_report.read_text(encoding="utf-8"))
+    statuses: dict[str, dict[str, Any]] = {}
+    skills = payload.get("skills") if isinstance(payload, Mapping) else []
+    if not isinstance(skills, list):
+        return statuses
+    for item in skills:
+        if not isinstance(item, Mapping):
+            continue
+        path = item.get("path")
+        if isinstance(path, str) and path:
+            statuses[path] = dict(item)
+    return statuses
+
+
+def issue_types(item: Mapping[str, Any] | None) -> list[str]:
+    if not item:
+        return []
+    issues = item.get("issues")
+    if not isinstance(issues, list):
+        return []
+    values = []
+    for issue in issues:
+        if isinstance(issue, Mapping) and isinstance(issue.get("type"), str):
+            values.append(str(issue["type"]))
+    return values
+
+
+def classify_bucket(
+    *,
+    security: Mapping[str, Any] | None,
+    frontmatter: str,
+    suggestion: dict[str, Any] | None,
+    description: str,
+    tags: list[str],
+) -> str:
+    if security and security.get("safe") is False:
+        return "security_failed"
+    if frontmatter != "ok":
+        return "structure_review"
+    if suggestion:
+        return "semantic_review_candidate"
+    if not description and not tags:
+        return "low_context"
+    return "manual_taxonomy_review"
+
+
+def build_report(
+    skills_dir: Path,
+    *,
+    category: str = "other",
+    security_report: Path | None = None,
+    content_chars: int = 2000,
+    min_score: int = 2,
+    min_delta: int = 2,
+    limit_examples: int = 20,
+) -> dict[str, Any]:
+    security_statuses = load_security_statuses(security_report)
+    keyword_map = category_keywords()
+    bucket_counts: Counter[str] = Counter()
+    frontmatter_counts: Counter[str] = Counter()
+    suggested_category_counts: Counter[str] = Counter()
+    security_issue_counts: Counter[str] = Counter()
+    examples: dict[str, list[dict[str, Any]]] = {}
+    total = 0
+
+    for skill_dir, rel in iter_category_skill_dirs(skills_dir, category):
+        total += 1
+        content = read_text_prefix(skill_dir / "SKILL.md", max_chars=max(content_chars, 8192))
+        metadata = load_metadata(skill_dir)
+        frontmatter = extract_frontmatter(content)
+        semantics = skill_semantic_fields(
+            skill_dir,
+            metadata=metadata,
+            frontmatter=frontmatter,
+            rel=rel,
+            content=content,
+            content_chars=content_chars,
+        )
+        frontmatter_state, frontmatter_reason = frontmatter_status(content)
+        frontmatter_counts[frontmatter_state] += 1
+        suggestion = best_suggestion(
+            category,
+            str(semantics["text"]),
+            keyword_map,
+            min_score=min_score,
+            min_delta=min_delta,
+        )
+        if suggestion:
+            suggested_category_counts[str(suggestion["suggested_category"])] += 1
+
+        security = security_statuses.get(str(rel))
+        for issue_type in issue_types(security):
+            security_issue_counts[issue_type] += 1
+
+        bucket = classify_bucket(
+            security=security,
+            frontmatter=frontmatter_state,
+            suggestion=suggestion,
+            description=str(semantics.get("description") or ""),
+            tags=list(semantics.get("tags") or []),
+        )
+        bucket_counts[bucket] += 1
+
+        bucket_examples = examples.setdefault(bucket, [])
+        if len(bucket_examples) < limit_examples:
+            item: dict[str, Any] = {
+                "path": str(rel),
+                "name": semantics["name"],
+                "description": semantics["description"],
+                "semantic_sources": semantics["sources"],
+                "frontmatter_status": frontmatter_state,
+            }
+            if frontmatter_reason:
+                item["frontmatter_reason"] = frontmatter_reason
+            if suggestion:
+                item["suggested_category"] = suggestion["suggested_category"]
+                item["score"] = suggestion["score"]
+                item["signals"] = suggestion["signals"]
+            if security:
+                item["security_safe"] = security.get("safe")
+                item["security_issue_types"] = issue_types(security)
+            bucket_examples.append(item)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": utc_now_isoformat(),
+        "skills_dir": str(skills_dir),
+        "category": category,
+        "total": total,
+        "policy": {
+            "content_chars": content_chars,
+            "min_score": min_score,
+            "min_delta": min_delta,
+            "security_report": str(security_report) if security_report else "",
+        },
+        "bucket_counts": sorted_counter(bucket_counts),
+        "frontmatter_status_counts": sorted_counter(frontmatter_counts),
+        "suggested_category_counts": sorted_counter(suggested_category_counts),
+        "security_issue_counts": sorted_counter(security_issue_counts),
+        "examples": examples,
+        "notes": [
+            "This is report-only and does not mutate archive contents.",
+            "security_failed residuals should stay out of canonical categories until fixed.",
+            "semantic_review_candidate residuals are review queues, not automatic moves.",
+        ],
+    }
+
+
+def print_report(report: dict[str, Any]) -> None:
+    print("Other residual governance report")
+    print(f"Category: {report['category']}")
+    print(f"Total: {report['total']}")
+    print(f"Buckets: {report['bucket_counts']}")
+    print(f"Frontmatter: {report['frontmatter_status_counts']}")
+    print(f"Suggested targets: {report['suggested_category_counts']}")
+    print(f"Security issues: {report['security_issue_counts']}")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--skills-dir", type=Path, default=Path("skills"))
+    parser.add_argument("--category", default="other")
+    parser.add_argument("--security-report", type=Path)
+    parser.add_argument("--content-chars", type=int, default=2000)
+    parser.add_argument("--min-score", type=int, default=2)
+    parser.add_argument("--min-delta", type=int, default=2)
+    parser.add_argument("--limit-examples", type=int, default=20)
+    parser.add_argument("--output-json", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = build_report(
+        args.skills_dir,
+        category=args.category,
+        security_report=args.security_report,
+        content_chars=args.content_chars,
+        min_score=args.min_score,
+        min_delta=args.min_delta,
+        limit_examples=args.limit_examples,
+    )
+    if args.output_json:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(
+            json.dumps(report, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+    print_report(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_publish_readiness_report.py
+++ b/scripts/build_publish_readiness_report.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Build a report-only readiness summary for a published main artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+
+
+def utc_now_isoformat() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def optional_json(path: Path, issues: list[dict[str, str]], *, label: str) -> Any:
+    if not path.exists():
+        issues.append(
+            {
+                "severity": "error",
+                "code": "missing-artifact",
+                "path": str(path),
+                "message": f"missing {label}",
+            }
+        )
+        return {}
+    try:
+        return load_json(path)
+    except json.JSONDecodeError as exc:
+        issues.append(
+            {
+                "severity": "error",
+                "code": "invalid-json",
+                "path": str(path),
+                "message": f"{label} is not valid JSON: {exc}",
+            }
+        )
+        return {}
+
+
+def category_count(stats: Mapping[str, Any], category: str) -> int | None:
+    raw_counts = stats.get("category_counts")
+    if isinstance(raw_counts, list):
+        for item in raw_counts:
+            if isinstance(item, Mapping) and item.get("name") == category:
+                count = item.get("count")
+                return int(count) if isinstance(count, int) else None
+    if isinstance(raw_counts, Mapping):
+        count = raw_counts.get(category)
+        return int(count) if isinstance(count, int) else None
+    return None
+
+
+def manifest_record_count(manifest: Mapping[str, Any]) -> int | None:
+    for key in ("count", "record_count", "total_count", "total"):
+        count = manifest.get(key)
+        if isinstance(count, int):
+            return count
+    return None
+
+
+def registry_shard_count(manifest: Mapping[str, Any]) -> int:
+    shards = manifest.get("shards")
+    return len(shards) if isinstance(shards, list) else 0
+
+
+def summarize_publish_status(payload: Mapping[str, Any]) -> dict[str, Any]:
+    checks = payload.get("checks")
+    check_items = checks if isinstance(checks, list) else []
+    check_status_counts: dict[str, int] = {}
+    for item in check_items:
+        if not isinstance(item, Mapping):
+            continue
+        status = str(item.get("status") or "unknown")
+        check_status_counts[status] = check_status_counts.get(status, 0) + 1
+    return {
+        "status": payload.get("status") or "",
+        "github_run_id": payload.get("github_run_id") or "",
+        "github_run_url": payload.get("github_run_url") or "",
+        "check_count": len(check_items),
+        "check_status_counts": dict(sorted(check_status_counts.items())),
+    }
+
+
+def build_report(main_dir: Path, *, category: str = "other") -> dict[str, Any]:
+    issues: list[dict[str, str]] = []
+    docs_dir = main_dir / "docs"
+    stats = optional_json(docs_dir / "stats.json", issues, label="docs stats")
+    category_manifest = optional_json(
+        docs_dir / "categories" / category / "manifest.json",
+        issues,
+        label=f"{category} category manifest",
+    )
+    registry_manifest = optional_json(
+        main_dir / "registry-manifest.json",
+        issues,
+        label="registry manifest",
+    )
+    provenance = optional_json(
+        main_dir / "provenance" / "merge-source.json",
+        issues,
+        label="merge provenance",
+    )
+    publish_status = optional_json(
+        main_dir / "provenance" / "publish-status.json",
+        issues,
+        label="publish status",
+    )
+
+    stats_category_count = category_count(stats, category) if isinstance(stats, Mapping) else None
+    manifest_category_count = (
+        manifest_record_count(category_manifest)
+        if isinstance(category_manifest, Mapping)
+        else None
+    )
+    if (
+        stats_category_count is not None
+        and manifest_category_count is not None
+        and stats_category_count != manifest_category_count
+    ):
+        issues.append(
+            {
+                "severity": "error",
+                "code": "category-count-mismatch",
+                "path": f"docs/categories/{category}/manifest.json",
+                "message": (
+                    f"docs/stats.json reports {category}={stats_category_count}, "
+                    f"manifest reports {manifest_category_count}"
+                ),
+            }
+        )
+
+    publish_summary = (
+        summarize_publish_status(publish_status)
+        if isinstance(publish_status, Mapping)
+        else summarize_publish_status({})
+    )
+    if publish_summary["status"] and publish_summary["status"] != "passed":
+        issues.append(
+            {
+                "severity": "warning",
+                "code": "publish-status-not-passed",
+                "path": "provenance/publish-status.json",
+                "message": f"publish status is {publish_summary['status']!r}",
+            }
+        )
+
+    error_count = sum(1 for issue in issues if issue["severity"] == "error")
+    warning_count = sum(1 for issue in issues if issue["severity"] == "warning")
+    readiness = "ready" if error_count == 0 else "not_ready"
+    if readiness == "ready" and warning_count:
+        readiness = "ready_with_warnings"
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": utc_now_isoformat(),
+        "main_dir": str(main_dir),
+        "readiness": readiness,
+        "category": category,
+        "category_count": manifest_category_count,
+        "stats_category_count": stats_category_count,
+        "archive_skill_md_count_raw": stats.get("archive_skill_md_count_raw")
+        if isinstance(stats, Mapping)
+        else None,
+        "archive_metadata_count_raw": stats.get("archive_metadata_count_raw")
+        if isinstance(stats, Mapping)
+        else None,
+        "registry_skill_count_dedup": stats.get("registry_skill_count_dedup")
+        if isinstance(stats, Mapping)
+        else None,
+        "category_total": stats.get("categories") if isinstance(stats, Mapping) else None,
+        "registry_manifest": {
+            "shard_count": registry_shard_count(registry_manifest)
+            if isinstance(registry_manifest, Mapping)
+            else 0,
+            "record_count": manifest_record_count(registry_manifest)
+            if isinstance(registry_manifest, Mapping)
+            else None,
+        },
+        "provenance": {
+            "core_repo": provenance.get("core_repo") if isinstance(provenance, Mapping) else "",
+            "core_sha": provenance.get("core_sha") if isinstance(provenance, Mapping) else "",
+            "data_repo": provenance.get("data_repo") if isinstance(provenance, Mapping) else "",
+            "data_sha": provenance.get("data_sha") if isinstance(provenance, Mapping) else "",
+            "generated_at": provenance.get("generated_at")
+            if isinstance(provenance, Mapping)
+            else "",
+        },
+        "publish_status": publish_summary,
+        "issue_count": len(issues),
+        "error_count": error_count,
+        "warning_count": warning_count,
+        "issues": issues,
+        "notes": [
+            "This is report-only and does not implement a publish gate.",
+            "Use it for release acceptance, issue comments, and provenance review.",
+        ],
+    }
+
+
+def print_report(report: dict[str, Any]) -> None:
+    print("Publish readiness report")
+    print(f"Readiness: {report['readiness']}")
+    print(f"{report['category']} count: {report['category_count']}")
+    print(f"Archive skills: {report['archive_skill_md_count_raw']}")
+    print(f"Registry deduped skills: {report['registry_skill_count_dedup']}")
+    print(f"Publish status: {report['publish_status']['status']}")
+    print(f"Core SHA: {report['provenance']['core_sha']}")
+    print(f"Data SHA: {report['provenance']['data_sha']}")
+    print(f"Errors: {report['error_count']}")
+    print(f"Warnings: {report['warning_count']}")
+    for issue in report["issues"][:20]:
+        print(f"- {issue['severity']} {issue['code']} {issue['path']}: {issue['message']}")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--main-dir", type=Path, default=Path("."))
+    parser.add_argument("--category", default="other")
+    parser.add_argument("--output-json", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = build_report(args.main_dir, category=args.category)
+    if args.output_json:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(
+            json.dumps(report, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+    print_report(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_other_residual_governance_report.py
+++ b/tests/test_build_other_residual_governance_report.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    return importlib.import_module("build_other_residual_governance_report")
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _write_skill(root: Path, name: str, body: str, metadata: dict | None = None) -> None:
+    skill_dir = root / "skills" / "other" / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
+    _write_json(skill_dir / "metadata.json", metadata or {"name": name, "category": "other"})
+
+
+def test_other_residual_report_groups_security_structure_and_semantic_items(tmp_path):
+    reporter = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir.parent, "unsafe", "# Unsafe\nNo frontmatter.")
+    _write_skill(skills_dir.parent, "bare", "---\nname: bare\n---\n")
+    _write_skill(
+        skills_dir.parent,
+        "design-helper",
+        (
+            "---\n"
+            "name: design-helper\n"
+            "description: Figma UI UX CSS component design workflow.\n"
+            "---\n"
+        ),
+    )
+    security_report = tmp_path / "security.json"
+    _write_json(
+        security_report,
+        {
+            "skills": [
+                {
+                    "path": "other/unsafe/SKILL.md",
+                    "safe": False,
+                    "issues": [{"severity": "error", "type": "no_frontmatter"}],
+                }
+            ]
+        },
+    )
+
+    report = reporter.build_report(
+        skills_dir,
+        security_report=security_report,
+        min_score=2,
+        min_delta=2,
+    )
+
+    assert report["total"] == 3
+    assert report["bucket_counts"]["security_failed"] == 1
+    assert report["bucket_counts"]["low_context"] == 1
+    assert report["bucket_counts"]["semantic_review_candidate"] == 1
+    assert report["suggested_category_counts"]["design"] == 1
+    assert report["security_issue_counts"]["no_frontmatter"] == 1
+
+
+def test_other_residual_report_marks_structure_without_security_report(tmp_path):
+    reporter = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir.parent, "unsafe", "# Unsafe\nNo frontmatter.")
+
+    report = reporter.build_report(skills_dir)
+
+    assert report["total"] == 1
+    assert report["bucket_counts"] == {"structure_review": 1}
+    assert report["frontmatter_status_counts"] == {"no_frontmatter": 1}

--- a/tests/test_build_publish_readiness_report.py
+++ b/tests/test_build_publish_readiness_report.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    return importlib.import_module("build_publish_readiness_report")
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def test_publish_readiness_report_accepts_matching_artifacts(tmp_path):
+    reporter = _load_module()
+    _write_json(
+        tmp_path / "docs" / "stats.json",
+        {
+            "archive_skill_md_count_raw": 199253,
+            "archive_metadata_count_raw": 199253,
+            "registry_skill_count_dedup": 157403,
+            "categories": 42,
+            "category_counts": [
+                {"name": "development", "count": 10},
+                {"name": "other", "count": 437},
+            ],
+        },
+    )
+    _write_json(
+        tmp_path / "docs" / "categories" / "other" / "manifest.json",
+        {"category": "other", "count": 437, "parts": []},
+    )
+    _write_json(
+        tmp_path / "registry-manifest.json",
+        {"total_count": 157403, "shards": [{"path": "registry-shards/000.json"}]},
+    )
+    _write_json(
+        tmp_path / "provenance" / "merge-source.json",
+        {"core_sha": "core123", "data_sha": "data123"},
+    )
+    _write_json(
+        tmp_path / "provenance" / "publish-status.json",
+        {"status": "passed", "checks": [{"name": "canary", "status": "passed"}]},
+    )
+
+    report = reporter.build_report(tmp_path)
+
+    assert report["readiness"] == "ready"
+    assert report["category_count"] == 437
+    assert report["provenance"]["core_sha"] == "core123"
+    assert report["publish_status"]["check_status_counts"] == {"passed": 1}
+    assert report["error_count"] == 0
+
+
+def test_publish_readiness_report_reports_count_mismatch(tmp_path):
+    reporter = _load_module()
+    _write_json(
+        tmp_path / "docs" / "stats.json",
+        {"category_counts": [{"name": "other", "count": 999}]},
+    )
+    _write_json(
+        tmp_path / "docs" / "categories" / "other" / "manifest.json",
+        {"category": "other", "count": 437},
+    )
+    _write_json(tmp_path / "registry-manifest.json", {"shards": []})
+    _write_json(tmp_path / "provenance" / "merge-source.json", {})
+    _write_json(tmp_path / "provenance" / "publish-status.json", {"status": "passed"})
+
+    report = reporter.build_report(tmp_path)
+
+    assert report["readiness"] == "not_ready"
+    assert report["error_count"] == 1
+    assert report["issues"][0]["code"] == "category-count-mismatch"


### PR DESCRIPTION
Closes #212.

## Summary
- Adds `build_publish_readiness_report.py` for report-only main artifact acceptance checks.
- Adds `build_other_residual_governance_report.py` to bucket live `other` residuals into security, structure, semantic review, low-context, and manual taxonomy queues.
- Documents both reports and updates the taxonomy governance spec.

## Important non-goal
- This does **not** implement an `other` count publish gate. Per maintainer direction, the optional gate discussion is tracked separately in #211.

## Real latest main run
Using a detached worktree at latest main `da0910a872b`:
- publish readiness: ready
- `other`: 539
- archive SKILL.md: 199,454
- registry deduped skills: 157,600
- publish status: passed
- provenance: core `ea9ce65cc6d0761c612a1212b6fa8f18ad88007c`, data `d0b98292c547a1797573dd5320c4548e7886bc11`

Residual buckets for current `other=539`:
- security_failed: 45
- semantic_review_candidate: 112
- manual_taxonomy_review: 374
- low_context: 8

## Verification
- `python -m ruff check scripts/build_publish_readiness_report.py scripts/build_other_residual_governance_report.py tests/test_build_publish_readiness_report.py tests/test_build_other_residual_governance_report.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -o addopts='' tests/test_build_publish_readiness_report.py tests/test_build_other_residual_governance_report.py -q` -> 4 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -o addopts='' -q` -> 408 passed
- `python scripts/check_taxonomy_governance.py` -> 0 errors, 0 warnings
- `git diff --check`

Note: full-repo `python -m ruff check scripts tests` still reports pre-existing lint debt in unrelated files such as `sync_and_download.py`; changed-file lint is clean.