### PR TITLE
fix: harden secret scanner credential reports

### DIFF
--- a/scripts/security_rules.py
+++ b/scripts/security_rules.py
@@ -1,0 +1,151 @@
+"""Security scanner rule definitions."""
+
+import re
+
+
+DANGEROUS_PATTERNS = {
+    # Code execution
+    "eval": r"\beval\s*\(",
+    "exec": r"\bexec\s*\(",
+    "__import__": r"\b__import__\s*\(",
+    "compile": r"\bcompile\s*\(",
+    # Command injection
+    "os.system": r"os\.system\s*\(",
+    "subprocess.call": r"subprocess\.(call|run|Popen)\s*\(",
+    "shell=True": r"shell\s*=\s*True",
+    # File system manipulation
+    "os.remove": r"os\.(remove|unlink|rmdir)\s*\(",
+    "shutil.rmtree": r"shutil\.rmtree\s*\(",
+    # Network access (flag for review)
+    "requests": r"import\s+requests",
+    "urllib": r"import\s+urllib",
+    "socket": r"import\s+socket",
+    # YAML unsafe loading
+    "yaml.load": r"yaml\.load\s*\(",
+    "yaml.unsafe_load": r"yaml\.unsafe_load\s*\(",
+    # Prompt injection indicators
+    "ignore_previous": r"ignore\s+(previous|prior|above)",
+    "disregard": r"disregard\s+(all|previous|prior)",
+    "system_prompt": r"system[\s_-]?prompt",
+    # Node.js dangerous patterns
+    "child_process": r'require\s*\(\s*[\'"]child_process[\'"]\s*\)',
+    "child_process_exec": r"child_process\.\w+\s*\(",
+    "new_function": r"new\s+Function\s*\(",
+    # Dangerous permissions & system modification
+    "chmod_dangerous": r"chmod\s+(?:777|666|4755|[ug]\+s)",
+    "sudo_shell": r"sudo\s+(?:sh|bash)\s+-c",
+    # Untrusted package sources
+    "pip_url_install": r"pip3?\s+install\s+(?:https?://|git\+)",
+    "npm_url_install": r"npm\s+install\s+(?:https?://|git\+)",
+    # Resource abuse
+    "fork_bomb": r":\(\)\{\s*:\|:\s*&\s*\}\s*;\s*:",
+}
+
+
+CREDENTIAL_PATTERNS = {
+    "aws_key": re.compile(r"(?:AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}"),
+    "github_token": re.compile(r"gh[pousr]_[A-Za-z0-9]{36,}"),
+    "stripe_key": re.compile(r"(?:sk|pk)_(?:live|test)_[A-Za-z0-9]{24,}"),
+    "openai_compatible_api_key": re.compile(
+        r"\b(?:apiKey|api_key|OPENAI_API_KEY|openai_api_key|Authorization)\b[^\n]{0,80}"
+        r"sk-[A-Za-z0-9_-]{20,}"
+    ),
+    "google_api_key": re.compile(r"AIza[A-Za-z0-9_-]{35}"),
+    "jwt_token": re.compile(r"eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+"),
+    "private_key_pem": re.compile(r"-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----"),
+    "db_connection_string": re.compile(r"(?:mongodb|mysql|postgresql|postgres)://[^:\s]+:[^@\s]+@"),
+}
+
+
+OBFUSCATION_EXEC_PATTERNS = [
+    re.compile(
+        r"base64\s+(?:-d|--decode)\s*\|?\s*(?:bash|sh|python|eval)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"echo\s+[A-Za-z0-9+/=]{20,}\s*\|\s*base64\s+(?:-d|--decode)" r"\s*\|\s*(?:bash|sh)",
+        re.IGNORECASE,
+    ),
+]
+
+
+COMPILED_DANGEROUS_PATTERNS = {
+    name: re.compile(pattern, re.IGNORECASE) for name, pattern in DANGEROUS_PATTERNS.items()
+}
+
+
+SENSITIVE_PATHS = [
+    "/etc/passwd",
+    "/etc/shadow",
+    "~/.ssh",
+    "~/.aws",
+    "/proc/",
+    "/sys/",
+    "$HOME/.env",
+    ".env",
+]
+
+
+BUNDLED_SCAN_DIRS = (
+    "connectors",
+    "references",
+    "reference",
+    "scripts",
+    "assets",
+    "knowledge",
+    "templates",
+    "examples",
+    "prompts",
+    "rules",
+)
+BUNDLED_SCAN_ROOT_FILES = (
+    "audit.md",
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "requirements.txt",
+    "pyproject.toml",
+    "setup.md",
+    "uv.lock",
+    "README.md",
+)
+BUNDLED_SCAN_EXTENSIONS = {
+    ".bash",
+    ".css",
+    ".csv",
+    ".html",
+    ".js",
+    ".json",
+    ".jsx",
+    ".j2",
+    ".md",
+    ".mjs",
+    ".ps1",
+    ".py",
+    ".sh",
+    ".svg",
+    ".toml",
+    ".tpl",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+
+
+INJECTION_PATTERNS = [
+    re.compile(r"ignore\s+(all\s+)?(previous|prior|above)\s+(instructions|prompts)", re.IGNORECASE),
+    re.compile(r"disregard\s+(everything|all)", re.IGNORECASE),
+    re.compile(r"forget\s+(previous|all)", re.IGNORECASE),
+    re.compile(r"new\s+instructions?:", re.IGNORECASE),
+    re.compile(r"system\s*:\s*you\s+are", re.IGNORECASE),
+    re.compile(r"</system>", re.IGNORECASE),
+    re.compile(r"<\|im_start\|>", re.IGNORECASE),
+    # Concealment patterns - skill tries to hide its actions from user
+    re.compile(r"do\s+not\s+(tell|inform|mention|notify)\s+(the\s+)?user", re.IGNORECASE),
+    re.compile(r"hide\s+(this|that)\s+(action|operation|step)", re.IGNORECASE),
+    re.compile(r"keep\s+(this|that)\s+(secret|hidden)", re.IGNORECASE),
+    re.compile(r"don'?t\s+mention\s+you\s+used\s+this\s+skill", re.IGNORECASE),
+]

--- a/scripts/security_scanner.py
+++ b/scripts/security_scanner.py
@@ -6,7 +6,6 @@ Implements automated security checks for skill registry
 
 import hashlib
 import json
-import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -15,153 +14,22 @@ from typing import Dict, List, TextIO, Tuple
 import jsonschema
 import yaml
 from security_blocklist import blocked_metadata_source, load_security_blocklist
+from security_rules import (
+    BUNDLED_SCAN_DIRS,
+    BUNDLED_SCAN_EXTENSIONS,
+    BUNDLED_SCAN_ROOT_FILES,
+    COMPILED_DANGEROUS_PATTERNS,
+    CREDENTIAL_PATTERNS,
+    DANGEROUS_PATTERNS,
+    INJECTION_PATTERNS,
+    OBFUSCATION_EXEC_PATTERNS,
+    SENSITIVE_PATHS,
+)
 
 # Load schema
 SCHEMA_PATH = Path(__file__).parent.parent / "schema" / "skill.schema.json"
 SECURITY_SCANNER_NAME = "claude-skill-registry-security-scanner"
-SECURITY_SCANNER_VERSION = "1.1.0"
-
-# Dangerous patterns to detect
-DANGEROUS_PATTERNS = {
-    # Code execution
-    "eval": r"\beval\s*\(",
-    "exec": r"\bexec\s*\(",
-    "__import__": r"\b__import__\s*\(",
-    "compile": r"\bcompile\s*\(",
-    # Command injection
-    "os.system": r"os\.system\s*\(",
-    "subprocess.call": r"subprocess\.(call|run|Popen)\s*\(",
-    "shell=True": r"shell\s*=\s*True",
-    # File system manipulation
-    "os.remove": r"os\.(remove|unlink|rmdir)\s*\(",
-    "shutil.rmtree": r"shutil\.rmtree\s*\(",
-    # Network access (flag for review)
-    "requests": r"import\s+requests",
-    "urllib": r"import\s+urllib",
-    "socket": r"import\s+socket",
-    # YAML unsafe loading
-    "yaml.load": r"yaml\.load\s*\(",
-    "yaml.unsafe_load": r"yaml\.unsafe_load\s*\(",
-    # Prompt injection indicators
-    "ignore_previous": r"ignore\s+(previous|prior|above)",
-    "disregard": r"disregard\s+(all|previous|prior)",
-    "system_prompt": r"system[\s_-]?prompt",
-    # Node.js dangerous patterns
-    "child_process": r'require\s*\(\s*[\'"]child_process[\'"]\s*\)',
-    "child_process_exec": r"child_process\.\w+\s*\(",
-    "new_function": r"new\s+Function\s*\(",
-    # Dangerous permissions & system modification
-    "chmod_dangerous": r"chmod\s+(?:777|666|4755|[ug]\+s)",
-    "sudo_shell": r"sudo\s+(?:sh|bash)\s+-c",
-    # Untrusted package sources
-    "pip_url_install": r"pip3?\s+install\s+(?:https?://|git\+)",
-    "npm_url_install": r"npm\s+install\s+(?:https?://|git\+)",
-    # Resource abuse
-    "fork_bomb": r":\(\)\{\s*:\|:\s*&\s*\}\s*;\s*:",
-}
-
-# Hardcoded credential format patterns (high severity)
-CREDENTIAL_PATTERNS = {
-    "aws_key": re.compile(r"(?:AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}"),
-    "github_token": re.compile(r"gh[pousr]_[A-Za-z0-9]{36,}"),
-    "stripe_key": re.compile(r"(?:sk|pk)_(?:live|test)_[A-Za-z0-9]{24,}"),
-    "google_api_key": re.compile(r"AIza[A-Za-z0-9_-]{35}"),
-    "jwt_token": re.compile(r"eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+"),
-    "private_key_pem": re.compile(r"-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----"),
-    "db_connection_string": re.compile(r"(?:mongodb|mysql|postgresql|postgres)://[^:\s]+:[^@\s]+@"),
-}
-
-# Base64-to-execution chain patterns
-OBFUSCATION_EXEC_PATTERNS = [
-    re.compile(
-        r"base64\s+(?:-d|--decode)\s*\|?\s*(?:bash|sh|python|eval)",
-        re.IGNORECASE,
-    ),
-    re.compile(
-        r"echo\s+[A-Za-z0-9+/=]{20,}\s*\|\s*base64\s+(?:-d|--decode)" r"\s*\|\s*(?:bash|sh)",
-        re.IGNORECASE,
-    ),
-]
-
-COMPILED_DANGEROUS_PATTERNS = {
-    name: re.compile(pattern, re.IGNORECASE) for name, pattern in DANGEROUS_PATTERNS.items()
-}
-
-# Sensitive file paths
-SENSITIVE_PATHS = [
-    "/etc/passwd",
-    "/etc/shadow",
-    "~/.ssh",
-    "~/.aws",
-    "/proc/",
-    "/sys/",
-    "$HOME/.env",
-    ".env",
-]
-
-BUNDLED_SCAN_DIRS = (
-    "connectors",
-    "references",
-    "reference",
-    "scripts",
-    "assets",
-    "knowledge",
-    "templates",
-    "examples",
-    "prompts",
-    "rules",
-)
-BUNDLED_SCAN_ROOT_FILES = (
-    "audit.md",
-    "package.json",
-    "package-lock.json",
-    "pnpm-lock.yaml",
-    "yarn.lock",
-    "requirements.txt",
-    "pyproject.toml",
-    "setup.md",
-    "uv.lock",
-    "README.md",
-)
-BUNDLED_SCAN_EXTENSIONS = {
-    ".bash",
-    ".css",
-    ".csv",
-    ".html",
-    ".js",
-    ".json",
-    ".jsx",
-    ".j2",
-    ".md",
-    ".mjs",
-    ".ps1",
-    ".py",
-    ".sh",
-    ".svg",
-    ".toml",
-    ".tpl",
-    ".ts",
-    ".tsx",
-    ".txt",
-    ".yaml",
-    ".yml",
-}
-
-
-INJECTION_PATTERNS = [
-    re.compile(r"ignore\s+(all\s+)?(previous|prior|above)\s+(instructions|prompts)", re.IGNORECASE),
-    re.compile(r"disregard\s+(everything|all)", re.IGNORECASE),
-    re.compile(r"forget\s+(previous|all)", re.IGNORECASE),
-    re.compile(r"new\s+instructions?:", re.IGNORECASE),
-    re.compile(r"system\s*:\s*you\s+are", re.IGNORECASE),
-    re.compile(r"</system>", re.IGNORECASE),
-    re.compile(r"<\|im_start\|>", re.IGNORECASE),
-    # Concealment patterns - skill tries to hide its actions from user
-    re.compile(r"do\s+not\s+(tell|inform|mention|notify)\s+(the\s+)?user", re.IGNORECASE),
-    re.compile(r"hide\s+(this|that)\s+(action|operation|step)", re.IGNORECASE),
-    re.compile(r"keep\s+(this|that)\s+(secret|hidden)", re.IGNORECASE),
-    re.compile(r"don'?t\s+mention\s+you\s+used\s+this\s+skill", re.IGNORECASE),
-]
+SECURITY_SCANNER_VERSION = "1.1.1"
 
 
 def utc_now_isoformat() -> str:
@@ -552,7 +420,6 @@ class SecurityScanner:
                             "file": str(file_path),
                             "line": line_num,
                             "message": f'Hardcoded credential "{cred_name}" detected',
-                            "code": line.strip()[:120],
                         }
                     )
 

--- a/tests/test_security_scanner.py
+++ b/tests/test_security_scanner.py
@@ -199,6 +199,40 @@ eval("unsafe")
     assert "ERROR" in result.stdout
 
 
+def test_scanner_blocks_openai_compatible_key_without_echoing_secret(tmp_path):
+    module = load_module()
+    token = "sk-" + ("A" * 32)
+    skill_dir = tmp_path / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"""---
+name: demo
+description: Demo skill used to verify OpenAI-compatible key detection.
+---
+
+# Demo
+
+```java
+OpenAiApi.builder().apiKey("{token}").build();
+```
+""",
+        encoding="utf-8",
+    )
+
+    scanner = module.SecurityScanner()
+    is_safe, issues = scanner.scan_file(skill_dir / "SKILL.md")
+    serialized_issues = json.dumps(issues)
+
+    assert is_safe is False
+    assert token not in serialized_issues
+    assert any(
+        issue.get("type") == "hardcoded_credential"
+        and issue.get("pattern") == "openai_compatible_api_key"
+        and "code" not in issue
+        for issue in issues
+    )
+
+
 def test_scanner_checks_flowhunt_style_support_files(tmp_path):
     module = load_module()
     skill_dir = tmp_path / "flowhunt"


### PR DESCRIPTION
## Summary

- Split scanner rule definitions into `scripts/security_rules.py` to keep `security_scanner.py` under the 800-line guardrail.
- Add a context-bounded OpenAI-compatible `sk-...` credential detector for API-key contexts such as `apiKey(...)`, `api_key`, `OPENAI_API_KEY`, and `Authorization`.
- Stop writing the matched source line into hardcoded-credential issues so scanner JSON artifacts do not echo secrets.

## Verification

- `python3 -m pytest tests/test_security_scanner.py -q` -> 16 passed
- `git diff --check`

## Security note

This prevents future sync/publish scans from leaking credential-bearing lines in report artifacts. Already exposed credentials still require provider-side revoke/rotate outside this PR.
