### PR TITLE
Fix bundled SKILL.md layout gates

### DIFF
--- a/.github/workflows/build-index.yml
+++ b/.github/workflows/build-index.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'registry.json'
       - 'scripts/build_search_index.py'
+      - 'scripts/search_sources.py'
       - 'scripts/check_canonical_categories.py'
       - 'scripts/security_blocklist.py'
       - 'scripts/security_scanner.py'

--- a/scripts/build_search_index.py
+++ b/scripts/build_search_index.py
@@ -27,7 +27,12 @@ from typing import Any, Dict, List, Optional
 from category_taxonomy import get_category_code, resolve_category
 from index_artifacts import write_category_artifacts, write_search_artifacts, write_signal_artifacts
 from plugin_index import build_plugins_index, load_plugins_from_registry, load_plugins_from_source
-from utils import extract_description, get_repo_suffix, load_metadata
+from search_sources import (
+    count_named_files,
+    load_from_registry,
+    load_registry_count,
+    scan_skills_v2,
+)
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger(__name__)
@@ -243,124 +248,6 @@ def score_skill_trust(
         + (15 if security_status == "passed" else 0)
         + (10 if stars > 0 else 0),
     )
-
-
-def scan_skills_v2(skills_dir: Path) -> List[Dict]:
-    """Recursively scan archive root and index one entry per SKILL.md file."""
-    skills = []
-
-    if not skills_dir.exists():
-        logger.warning(f"Skills directory not found: {skills_dir}")
-        return skills
-
-    for skill_md in skills_dir.rglob("SKILL.md"):
-        skill_dir = skill_md.parent
-        rel_parts = skill_dir.relative_to(skills_dir).parts
-        category_name = rel_parts[0] if rel_parts else "other"
-        metadata = load_metadata(skill_dir)
-        dir_name = skill_dir.name
-
-        # Get skill name (from metadata or directory)
-        name = metadata.get("name") or dir_name
-
-        # Remove repo suffix from dir_name if metadata repo is available
-        if name == dir_name:
-            repo_for_suffix = metadata.get("repo", "")
-            suffix = get_repo_suffix(repo_for_suffix)
-            if suffix and dir_name.endswith(f"-{suffix}"):
-                name = dir_name[: -(len(suffix) + 1)]
-
-        # Get description
-        description = metadata.get("description", "")
-        if not description:
-            try:
-                content = skill_md.read_text(encoding="utf-8")
-                description = extract_description(content)
-            except Exception:
-                pass
-        if not description:
-            description = f"Skill: {name}"
-
-        # Get category through the canonical taxonomy. Unknown categories are
-        # preserved as explicit slugs so they remain auditable instead of
-        # silently collapsing into "other".
-        category = resolve_category(metadata.get("category", category_name), allow_unknown=True)
-
-        # Build install path
-        repo = metadata.get("repo", "")
-        github_path = metadata.get("github_path") or metadata.get("path") or "/".join(rel_parts)
-        github_branch = metadata.get("github_branch") or metadata.get("branch") or "main"
-
-        if github_path and repo:
-            install = f"{repo}/{github_path}"
-        elif repo:
-            install = repo
-        else:
-            install = f"local/{'/'.join(rel_parts)}" if rel_parts else f"local/{name}"
-
-        tags = metadata.get("tags", [])
-        if not isinstance(tags, list):
-            tags = []
-
-        stars = metadata.get("stars", 0)
-        try:
-            stars = int(stars)
-        except (TypeError, ValueError):
-            stars = 0
-
-        skill_entry = {
-            "name": name,
-            "dir_name": dir_name,
-            "description": description,
-            "repo": repo,
-            "path": github_path,
-            "archive_path": skill_md.relative_to(skills_dir).as_posix(),
-            "branch": github_branch,
-            "category": category,
-            "tags": tags,
-            "stars": stars,
-            "source": metadata.get("source", "downloaded"),
-            "install": install,
-        }
-
-        skills.append(skill_entry)
-
-    return skills
-
-
-def load_registry_count(registry_path: Path) -> Optional[int]:
-    """Load deduplicated skill count from registry.json."""
-    if not registry_path.exists():
-        return None
-    try:
-        with open(registry_path, "r", encoding="utf-8") as f:
-            registry = json.load(f)
-    except Exception:
-        return None
-
-    total = registry.get("registry_skill_count_dedup")
-    if isinstance(total, int):
-        return total
-
-    total = registry.get("total_count")
-    if isinstance(total, int):
-        return total
-
-    skills = registry.get("skills")
-    if isinstance(skills, list):
-        return len(skills)
-
-    return None
-
-
-def count_named_files(skills_dir: Path, filename: str) -> Optional[int]:
-    """Count matching files recursively without full metadata parsing."""
-    if not skills_dir.exists():
-        return None
-    try:
-        return sum(1 for _ in skills_dir.rglob(filename))
-    except Exception:
-        return None
 
 
 def build_search_index(
@@ -795,69 +682,6 @@ def build_search_index(
     logger.info(f"  Categories: {len(categories)}")
 
     return stats
-
-
-def resolve_registry_artifact(base_dir: Path, artifact_ref: str) -> Path:
-    """Resolve a registry artifact path relative to a manifest or registry directory."""
-    artifact_path = Path(artifact_ref)
-    if artifact_path.is_absolute():
-        return artifact_path
-    return (base_dir / artifact_path).resolve()
-
-
-def load_registry_manifest_shards(registry_path: Path, registry: Dict) -> List[Dict]:
-    """Load full registry skills from a compatibility registry manifest pointer."""
-    manifest_ref = registry.get("manifest")
-    if not isinstance(manifest_ref, str) or not manifest_ref.strip():
-        return []
-
-    manifest_path = resolve_registry_artifact(registry_path.parent, manifest_ref)
-    with open(manifest_path, "r", encoding="utf-8") as f:
-        manifest = json.load(f)
-
-    skills: List[Dict] = []
-    for shard in manifest.get("shards", []):
-        shard_ref = shard.get("path") if isinstance(shard, dict) else None
-        if not isinstance(shard_ref, str) or not shard_ref.strip():
-            raise ValueError(f"Invalid registry shard reference in {manifest_path}: {shard!r}")
-        shard_path = resolve_registry_artifact(manifest_path.parent, shard_ref)
-        with open(shard_path, "r", encoding="utf-8") as f:
-            shard_payload = json.load(f)
-        shard_skills = shard_payload.get("skills")
-        if not isinstance(shard_skills, list):
-            raise ValueError(f"Registry shard is missing skills array: {shard_path}")
-        skills.extend(shard_skills)
-    return skills
-
-
-def add_registry_install_fields(skills: List[Dict]) -> List[Dict]:
-    """Populate install fields for registry fallback rows."""
-    for skill in skills:
-        repo = skill.get("repo", "")
-        path = skill.get("path", "")
-        name = skill.get("name", "unknown")
-        if repo and path:
-            skill["install"] = f"{repo}/{path}"
-        elif repo:
-            skill["install"] = repo
-        elif path:
-            skill["install"] = f"local/{path}"
-        else:
-            skill["install"] = f"local/{name}"
-
-    return skills
-
-
-def load_from_registry(registry_path: Path) -> List[Dict]:
-    """Load skills from registry.json or its manifest shards (fallback mode)."""
-    with open(registry_path, "r", encoding="utf-8") as f:
-        registry = json.load(f)
-
-    skills = registry.get("skills")
-    if not isinstance(skills, list):
-        skills = load_registry_manifest_shards(registry_path, registry)
-
-    return add_registry_install_fields(skills)
 
 
 def main():

--- a/scripts/check_canonical_categories.py
+++ b/scripts/check_canonical_categories.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from category_taxonomy import CategoryTaxonomy, category_slug, get_taxonomy
+from utils import is_declared_bundled_skill_file
 
 
 @dataclass(frozen=True)
@@ -226,6 +227,8 @@ def check_skills_dir(skills_dir: Path, gate: CategoryGate) -> list[CategoryIssue
         return [CategoryIssue("skills-dir-missing", str(skills_dir), "skills directory missing")]
 
     for skill_md in sorted(skills_dir.rglob("SKILL.md")):
+        if is_declared_bundled_skill_file(skill_md, skills_dir):
+            continue
         skill_dir = skill_md.parent
         rel_parts = skill_md.relative_to(skills_dir).parts
         label = _record_path(skill_md, skills_dir)
@@ -333,7 +336,9 @@ def _check_category_entry(
     issues: list[CategoryIssue],
 ) -> str | None:
     if not isinstance(entry, dict):
-        issues.append(CategoryIssue("category-entry-shape", path, "category entry must be an object"))
+        issues.append(
+            CategoryIssue("category-entry-shape", path, "category entry must be an object")
+        )
         return None
     slug = gate.check_category(entry.get("name"), path=path, field="category.name", issues=issues)
     if "code" in entry:

--- a/scripts/normalize_skill_depth.py
+++ b/scripts/normalize_skill_depth.py
@@ -23,6 +23,7 @@ from utils import (
     build_skill_key,
     canonical_metadata_identity,
     get_repo_suffix,
+    is_declared_bundled_skill_file,
     load_metadata,
     normalize_category,
     normalize_name,
@@ -52,6 +53,8 @@ def is_standard(rel_parts: tuple[str, ...]) -> bool:
 
 def iter_nonstandard_skill_dirs(skills_dir: Path):
     for skill_md in sorted(skills_dir.rglob("SKILL.md")):
+        if is_declared_bundled_skill_file(skill_md, skills_dir):
+            continue
         rel = skill_md.relative_to(skills_dir)
         if any(part.startswith(".") for part in rel.parts):
             continue

--- a/scripts/rebuild_registry.py
+++ b/scripts/rebuild_registry.py
@@ -13,9 +13,14 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 
-from utils import extract_description, load_metadata, normalize_category
+from utils import (
+    extract_description,
+    is_declared_bundled_skill_file,
+    load_metadata,
+    normalize_category,
+)
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(message)s')
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 
@@ -26,7 +31,7 @@ def utc_now_isoformat() -> str:
 
 def safe_write_registry(registry_path: Path, registry: dict) -> bool:
     """Safely write registry.json with atomic operation"""
-    temp_path = registry_path.with_suffix('.json.tmp')
+    temp_path = registry_path.with_suffix(".json.tmp")
     try:
         with open(temp_path, "w", encoding="utf-8") as f:
             json.dump(registry, f, ensure_ascii=False, separators=(",", ":"))
@@ -235,6 +240,8 @@ def scan_skills(skills_dir: Path) -> list:
         return skills
 
     for skill_md in skills_dir.rglob("SKILL.md"):
+        if is_declared_bundled_skill_file(skill_md, skills_dir):
+            continue
         skill_dir = skill_md.parent
         rel_dir = skill_dir.relative_to(skills_dir)
         rel_parts = rel_dir.parts
@@ -261,16 +268,8 @@ def scan_skills(skills_dir: Path) -> list:
 
         # Repo/path/branch normalization across different metadata formats
         repo = metadata.get("repo", "")
-        github_path = (
-            metadata.get("github_path")
-            or metadata.get("path")
-            or "/".join(rel_parts)
-        )
-        github_branch = (
-            metadata.get("github_branch")
-            or metadata.get("branch")
-            or "main"
-        )
+        github_path = metadata.get("github_path") or metadata.get("path") or "/".join(rel_parts)
+        github_branch = metadata.get("github_branch") or metadata.get("branch") or "main"
 
         skill_entry = {
             "name": name,
@@ -348,9 +347,8 @@ def build_category_indexes(skills: list, output_dir: Path):
     index = {
         "updated_at": utc_now_isoformat(),
         "categories": [
-            {"name": cat, "count": len(skills)}
-            for cat, skills in sorted(categories.items())
-        ]
+            {"name": cat, "count": len(skills)} for cat, skills in sorted(categories.items())
+        ],
     }
     with open(output_dir / "index.json", "w", encoding="utf-8") as f:
         json.dump(index, f, indent=2)
@@ -376,10 +374,18 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Rebuild registry.json from downloaded skills")
     parser.add_argument("--skills-dir", default="skills", help="Skills directory to scan")
     parser.add_argument("--registry", default="registry.json", help="Output registry.json path")
-    parser.add_argument("--manifest", default="registry-manifest.json", help="Output shard manifest path")
-    parser.add_argument("--shards-dir", default="registry-shards", help="Output registry shards directory")
-    parser.add_argument("--categories-dir", default="categories", help="Output categories directory")
-    parser.add_argument("--skip-categories", action="store_true", help="Do not write category index files")
+    parser.add_argument(
+        "--manifest", default="registry-manifest.json", help="Output shard manifest path"
+    )
+    parser.add_argument(
+        "--shards-dir", default="registry-shards", help="Output registry shards directory"
+    )
+    parser.add_argument(
+        "--categories-dir", default="categories", help="Output categories directory"
+    )
+    parser.add_argument(
+        "--skip-categories", action="store_true", help="Do not write category index files"
+    )
     parser.add_argument(
         "--compat-manifest-pointer",
         action="store_true",

--- a/scripts/search_sources.py
+++ b/scripts/search_sources.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Source loaders for search index generation."""
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from category_taxonomy import resolve_category
+from utils import (
+    extract_description,
+    get_repo_suffix,
+    is_declared_bundled_skill_file,
+    load_metadata,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def scan_skills_v2(skills_dir: Path) -> List[Dict]:
+    """Recursively scan archive root and index one entry per archive skill."""
+    skills = []
+
+    if not skills_dir.exists():
+        logger.warning(f"Skills directory not found: {skills_dir}")
+        return skills
+
+    for skill_md in skills_dir.rglob("SKILL.md"):
+        if is_declared_bundled_skill_file(skill_md, skills_dir):
+            continue
+        skill_dir = skill_md.parent
+        rel_parts = skill_dir.relative_to(skills_dir).parts
+        category_name = rel_parts[0] if rel_parts else "other"
+        metadata = load_metadata(skill_dir)
+        dir_name = skill_dir.name
+
+        name = metadata.get("name") or dir_name
+
+        if name == dir_name:
+            repo_for_suffix = metadata.get("repo", "")
+            suffix = get_repo_suffix(repo_for_suffix)
+            if suffix and dir_name.endswith(f"-{suffix}"):
+                name = dir_name[: -(len(suffix) + 1)]
+
+        description = metadata.get("description", "")
+        if not description:
+            try:
+                content = skill_md.read_text(encoding="utf-8")
+                description = extract_description(content)
+            except Exception as exc:
+                logger.warning("Failed to extract description from %s: %s", skill_md, exc)
+        if not description:
+            description = f"Skill: {name}"
+
+        category = resolve_category(metadata.get("category", category_name), allow_unknown=True)
+
+        repo = metadata.get("repo", "")
+        github_path = metadata.get("github_path") or metadata.get("path") or "/".join(rel_parts)
+        github_branch = metadata.get("github_branch") or metadata.get("branch") or "main"
+
+        if github_path and repo:
+            install = f"{repo}/{github_path}"
+        elif repo:
+            install = repo
+        else:
+            install = f"local/{'/'.join(rel_parts)}" if rel_parts else f"local/{name}"
+
+        tags = metadata.get("tags", [])
+        if not isinstance(tags, list):
+            tags = []
+
+        stars = metadata.get("stars", 0)
+        try:
+            stars = int(stars)
+        except (TypeError, ValueError):
+            stars = 0
+
+        skill_entry = {
+            "name": name,
+            "dir_name": dir_name,
+            "description": description,
+            "repo": repo,
+            "path": github_path,
+            "archive_path": skill_md.relative_to(skills_dir).as_posix(),
+            "branch": github_branch,
+            "category": category,
+            "tags": tags,
+            "stars": stars,
+            "source": metadata.get("source", "downloaded"),
+            "install": install,
+        }
+
+        skills.append(skill_entry)
+
+    return skills
+
+
+def load_registry_count(registry_path: Path) -> Optional[int]:
+    """Load deduplicated skill count from registry.json."""
+    if not registry_path.exists():
+        return None
+    try:
+        with open(registry_path, "r", encoding="utf-8") as f:
+            registry = json.load(f)
+    except Exception:
+        return None
+
+    total = registry.get("registry_skill_count_dedup")
+    if isinstance(total, int):
+        return total
+
+    total = registry.get("total_count")
+    if isinstance(total, int):
+        return total
+
+    skills = registry.get("skills")
+    if isinstance(skills, list):
+        return len(skills)
+
+    return None
+
+
+def count_named_files(skills_dir: Path, filename: str) -> Optional[int]:
+    """Count matching files recursively without full metadata parsing."""
+    if not skills_dir.exists():
+        return None
+    try:
+        return sum(1 for _ in skills_dir.rglob(filename))
+    except Exception:
+        return None
+
+
+def resolve_registry_artifact(base_dir: Path, artifact_ref: str) -> Path:
+    """Resolve a registry artifact path relative to a manifest or registry directory."""
+    artifact_path = Path(artifact_ref)
+    if artifact_path.is_absolute():
+        return artifact_path
+    return (base_dir / artifact_path).resolve()
+
+
+def load_registry_manifest_shards(registry_path: Path, registry: Dict) -> List[Dict]:
+    """Load full registry skills from a compatibility registry manifest pointer."""
+    manifest_ref = registry.get("manifest")
+    if not isinstance(manifest_ref, str) or not manifest_ref.strip():
+        return []
+
+    manifest_path = resolve_registry_artifact(registry_path.parent, manifest_ref)
+    with open(manifest_path, "r", encoding="utf-8") as f:
+        manifest = json.load(f)
+
+    skills: List[Dict] = []
+    for shard in manifest.get("shards", []):
+        shard_ref = shard.get("path") if isinstance(shard, dict) else None
+        if not isinstance(shard_ref, str) or not shard_ref.strip():
+            raise ValueError(f"Invalid registry shard reference in {manifest_path}: {shard!r}")
+        shard_path = resolve_registry_artifact(manifest_path.parent, shard_ref)
+        with open(shard_path, "r", encoding="utf-8") as f:
+            shard_payload = json.load(f)
+        shard_skills = shard_payload.get("skills")
+        if not isinstance(shard_skills, list):
+            raise ValueError(f"Registry shard is missing skills array: {shard_path}")
+        skills.extend(shard_skills)
+    return skills
+
+
+def add_registry_install_fields(skills: List[Dict]) -> List[Dict]:
+    """Populate install fields for registry fallback rows."""
+    for skill in skills:
+        repo = skill.get("repo", "")
+        path = skill.get("path", "")
+        name = skill.get("name", "unknown")
+        if repo and path:
+            skill["install"] = f"{repo}/{path}"
+        elif repo:
+            skill["install"] = repo
+        elif path:
+            skill["install"] = f"local/{path}"
+        else:
+            skill["install"] = f"local/{name}"
+
+    return skills
+
+
+def load_from_registry(registry_path: Path) -> List[Dict]:
+    """Load skills from registry.json or its manifest shards (fallback mode)."""
+    with open(registry_path, "r", encoding="utf-8") as f:
+        registry = json.load(f)
+
+    skills = registry.get("skills")
+    if not isinstance(skills, list):
+        skills = load_registry_manifest_shards(registry_path, registry)
+
+    return add_registry_install_fields(skills)

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -269,7 +269,9 @@ def build_skill_key(repo: str = "", path: str = "", name: str = "", category: st
     return ""
 
 
-def canonical_metadata_identity(metadata: dict[str, Any], fields: tuple[str, ...]) -> dict[str, Any]:
+def canonical_metadata_identity(
+    metadata: dict[str, Any], fields: tuple[str, ...]
+) -> dict[str, Any]:
     """Build metadata identity while treating known source aliases as equivalent."""
     identity: dict[str, Any] = {}
     alias_groups = {
@@ -663,8 +665,7 @@ def classify_category_from_semantics(
         "method": "taxonomy_keyword_v1",
         "confidence": confidence,
         "reason": (
-            f"matched taxonomy keywords for {top_category}: "
-            f"{', '.join(top['signals'])}"
+            f"matched taxonomy keywords for {top_category}: " f"{', '.join(top['signals'])}"
         ),
         "score": top_score,
         "runner_up": runner_category,
@@ -684,6 +685,62 @@ def load_metadata(skill_dir: Path) -> dict:
     except (json.JSONDecodeError, OSError) as e:
         logger.warning("Failed to load %s: %s", meta_path, e)
         return {}
+
+
+def _normalize_bundled_file_path(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip().replace("\\", "/").strip("/")
+    if not text:
+        return None
+    parts = text.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        return None
+    return "/".join(parts)
+
+
+def is_declared_bundled_skill_file(skill_md: Path, skills_dir: Path) -> bool:
+    """
+    Return True for nested SKILL.md files explicitly declared by the parent skill.
+
+    The archive layout treats skills/<category>/<skill>/SKILL.md as the only
+    skill entry. Some upstream skills also bundle support SKILL.md files under
+    that directory; those are valid only when parent metadata.json lists them in
+    bundled_files.
+    """
+    try:
+        rel_parts = skill_md.relative_to(skills_dir).parts
+    except ValueError:
+        return False
+
+    if len(rel_parts) <= 3 or rel_parts[-1] != "SKILL.md":
+        return False
+    if any(part.startswith(".") for part in rel_parts):
+        return False
+
+    parent_dir = skills_dir / rel_parts[0] / rel_parts[1]
+    parent_skill = parent_dir / "SKILL.md"
+    parent_metadata = parent_dir / "metadata.json"
+    if not parent_skill.exists() or not parent_metadata.exists():
+        return False
+
+    try:
+        metadata = json.loads(parent_metadata.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Failed to inspect bundled files in %s: %s", parent_metadata, exc)
+        return False
+    if not isinstance(metadata, dict):
+        return False
+
+    bundled_files = metadata.get("bundled_files")
+    if not isinstance(bundled_files, list):
+        return False
+
+    nested_rel = Path(*rel_parts[2:]).as_posix()
+    declared_files = {
+        normalized for item in bundled_files if (normalized := _normalize_bundled_file_path(item))
+    }
+    return nested_rel in declared_files
 
 
 def write_metadata(skill_dir: Path, meta: dict) -> None:

--- a/tests/test_check_canonical_categories.py
+++ b/tests/test_check_canonical_categories.py
@@ -42,6 +42,57 @@ def test_skills_dir_rejects_legacy_directory_and_metadata_mismatch(tmp_path):
     assert "category-mismatch" in codes
 
 
+def test_skills_dir_accepts_declared_bundled_skill_markdown(tmp_path):
+    gate = _load_module()
+    skills_dir = tmp_path / "skills"
+    parent = skills_dir / "design" / "deterministic-design"
+    parent.mkdir(parents=True)
+    (parent / "SKILL.md").write_text("# Deterministic Design\n", encoding="utf-8")
+    _write_json(
+        parent / "metadata.json",
+        {
+            "name": "deterministic-design",
+            "category": "design",
+            "repo": "connerkward/deterministic-design-skill",
+            "bundled_files": ["design-spatial/SKILL.md", "design-ux/SKILL.md"],
+        },
+    )
+    (parent / "design-spatial").mkdir()
+    (parent / "design-spatial" / "SKILL.md").write_text("# Spatial\n", encoding="utf-8")
+    (parent / "design-ux").mkdir()
+    (parent / "design-ux" / "SKILL.md").write_text("# UX\n", encoding="utf-8")
+
+    report = gate.build_report(skills_dirs=[skills_dir])
+
+    assert report["error_count"] == 0
+
+
+def test_skills_dir_rejects_undeclared_nested_skill_markdown(tmp_path):
+    gate = _load_module()
+    skills_dir = tmp_path / "skills"
+    parent = skills_dir / "design" / "deterministic-design"
+    parent.mkdir(parents=True)
+    (parent / "SKILL.md").write_text("# Deterministic Design\n", encoding="utf-8")
+    _write_json(
+        parent / "metadata.json",
+        {
+            "name": "deterministic-design",
+            "category": "design",
+            "repo": "connerkward/deterministic-design-skill",
+            "bundled_files": [],
+        },
+    )
+    (parent / "design-spatial").mkdir()
+    (parent / "design-spatial" / "SKILL.md").write_text("# Spatial\n", encoding="utf-8")
+
+    report = gate.build_report(skills_dirs=[skills_dir])
+
+    assert [item["code"] for item in report["errors"]] == ["file-missing"]
+    assert report["errors"][0]["path"].endswith(
+        "design/deterministic-design/design-spatial/metadata.json"
+    )
+
+
 def test_registry_shards_reject_noncanonical_categories(tmp_path):
     gate = _load_module()
     shards_dir = tmp_path / "registry-shards"

--- a/tests/test_normalize_skill_depth.py
+++ b/tests/test_normalize_skill_depth.py
@@ -91,6 +91,53 @@ def test_depth_plan_uses_category_after_skills_prefix(tmp_path):
     assert plan["moves"][0]["target_path"] == "documents/doc-helper"
 
 
+def test_depth_plan_ignores_declared_bundled_skill_markdown(tmp_path):
+    module = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "design/deterministic-design",
+        {
+            "name": "deterministic-design",
+            "category": "design",
+            "repo": "connerkward/deterministic-design-skill",
+            "bundled_files": ["design-spatial/SKILL.md"],
+        },
+    )
+    bundled_dir = skills_dir / "design" / "deterministic-design" / "design-spatial"
+    bundled_dir.mkdir()
+    (bundled_dir / "SKILL.md").write_text("# Spatial helper\n", encoding="utf-8")
+
+    plan = module.build_depth_plan(skills_dir)
+
+    assert plan["move_count"] == 0
+    assert plan["moves"] == []
+
+
+def test_depth_plan_moves_undeclared_nested_skill_markdown(tmp_path):
+    module = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "design/deterministic-design",
+        {
+            "name": "deterministic-design",
+            "category": "design",
+            "repo": "connerkward/deterministic-design-skill",
+            "bundled_files": [],
+        },
+    )
+    nested_dir = skills_dir / "design" / "deterministic-design" / "design-spatial"
+    nested_dir.mkdir()
+    (nested_dir / "SKILL.md").write_text("# Spatial helper\n", encoding="utf-8")
+
+    plan = module.build_depth_plan(skills_dir)
+
+    assert plan["move_count"] == 1
+    assert plan["moves"][0]["source_path"] == "design/deterministic-design/design-spatial"
+    assert plan["moves"][0]["target_path"] == "design/design-spatial"
+
+
 def test_apply_depth_plan_preserves_existing_target_with_suffix(tmp_path):
     module = _load_module()
     skills_dir = tmp_path / "skills"

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -201,6 +201,8 @@ def test_build_index_generates_security_report_for_checked_out_data():
     assert "unzip -o security-report.zip -d docs || true" not in build_steps
     assert "test -f \"$RUNNER_TEMP/security-report.json\"" in build_steps
     assert "--allow-missing-security-evidence" not in build_steps
+    assert "'scripts/build_search_index.py'" in workflow
+    assert "'scripts/search_sources.py'" in workflow
     assert "'scripts/security_scanner.py'" in workflow
     assert "'scripts/security_blocklist.py'" in workflow
     assert "'sources/security_blocklist.json'" in workflow

--- a/tests/test_plugin_contract.py
+++ b/tests/test_plugin_contract.py
@@ -83,14 +83,14 @@ def test_build_plugins_index_and_stats_use_plugin_keys(tmp_path):
     search_manifest = json.loads(
         (output_dir / "search-index-manifest.json").read_text(encoding="utf-8")
     )
-    category_index = json.loads((output_dir / "categories" / "index.json").read_text(encoding="utf-8"))
+    category_index = json.loads(
+        (output_dir / "categories" / "index.json").read_text(encoding="utf-8")
+    )
     category_pointer = json.loads(
         (output_dir / "categories" / "development.json").read_text(encoding="utf-8")
     )
     category_manifest = json.loads(
-        (output_dir / "categories" / "development" / "manifest.json").read_text(
-            encoding="utf-8"
-        )
+        (output_dir / "categories" / "development" / "manifest.json").read_text(encoding="utf-8")
     )
     quality_pointer = json.loads((output_dir / "quality-index.json").read_text(encoding="utf-8"))
     quality_manifest = json.loads(
@@ -136,9 +136,7 @@ def test_build_plugins_index_and_stats_use_plugin_keys(tmp_path):
     assert stats_data["quality_largest_shard_bytes"] > 0
     assert stats_data["security_largest_shard_bytes"] > 0
     assert stats_data["ranking_largest_shard_bytes"] > 0
-    assert stats_data["category_counts"] == [
-        {"name": "development", "code": "dev", "count": 1}
-    ]
+    assert stats_data["category_counts"] == [{"name": "development", "code": "dev", "count": 1}]
     assert stats_data["unique_repo_count"] == 1
     assert stats_data["official_skill_count"] == 0
     assert stats_data["top_repositories"] == [{"repo": "owner/repo", "count": 1}]
@@ -337,6 +335,36 @@ def test_scan_skills_v2_is_recursive_and_metadata_optional(tmp_path):
     assert by_dir["skill-beta"]["category"] == "development"
 
 
+def test_declared_bundled_skill_markdown_is_not_indexed_as_archive_skill(tmp_path):
+    skills_dir = tmp_path / "skills"
+    parent = skills_dir / "design" / "deterministic-design"
+    parent.mkdir(parents=True)
+    (parent / "SKILL.md").write_text("# Deterministic Design\n", encoding="utf-8")
+    (parent / "metadata.json").write_text(
+        json.dumps(
+            {
+                "name": "deterministic-design",
+                "category": "design",
+                "repo": "connerkward/deterministic-design-skill",
+                "path": "",
+                "bundled_files": ["design-spatial/SKILL.md", "design-ux/SKILL.md"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    for bundled_dir_name in ("design-spatial", "design-ux"):
+        bundled_dir = parent / bundled_dir_name
+        bundled_dir.mkdir()
+        (bundled_dir / "SKILL.md").write_text(f"# {bundled_dir_name}\n", encoding="utf-8")
+
+    search_records = build_search_index.scan_skills_v2(skills_dir)
+    registry_records = rebuild_registry.scan_skills(skills_dir)
+
+    assert [record["name"] for record in search_records] == ["deterministic-design"]
+    assert [record["name"] for record in registry_records] == ["deterministic-design"]
+    assert search_records[0]["archive_path"] == "design/deterministic-design/SKILL.md"
+
+
 def test_rebuild_registry_omits_derived_and_empty_optional_fields(tmp_path):
     skills_dir = tmp_path / "skills"
     skill_dir = skills_dir / "development" / "skill-beta"
@@ -469,12 +497,8 @@ def test_build_category_indexes_normalizes_control_character_categories(tmp_path
 
     rebuild_registry.build_category_indexes(skills, output_dir)
 
-    category_files = [
-        path for path in output_dir.iterdir() if path.name != "index.json"
-    ]
-    assert [path.name for path in category_files] == [
-        "nestjs-validation-and-pipes.json"
-    ]
+    category_files = [path for path in output_dir.iterdir() if path.name != "index.json"]
+    assert [path.name for path in category_files] == ["nestjs-validation-and-pipes.json"]
     assert not any("\n" in path.name for path in category_files)
     category_data = json.loads(category_files[0].read_text(encoding="utf-8"))
     assert category_data["category"] == "nestjs-validation-and-pipes"


### PR DESCRIPTION
## Summary
- Treat nested `SKILL.md` files as bundled support files only when the parent archive skill metadata explicitly lists them in `bundled_files`.
- Apply that archive semantics consistently across canonical category checks, depth normalization, registry rebuild, and search index scanning.
- Move search source loading helpers out of `build_search_index.py` so the required scanner fix stays under the file-size guard.

## Root cause
The scheduled sync failed after downloading `connerkward/deterministic-design-skill`: the parent skill bundled `design-spatial/SKILL.md` and `design-ux/SKILL.md`, but recursive archive scanners treated those nested files as standalone skills without sibling `metadata.json`.

Latest failed scheduled run observed: `28277273906` on 2026-06-27, with:
- `file-missing skills/design/deterministic-design/design-spatial/metadata.json`
- `file-missing skills/design/deterministic-design/design-ux/metadata.json`

## Verification
- `uv run --extra dev black --check scripts/build_search_index.py scripts/search_sources.py scripts/rebuild_registry.py scripts/utils.py scripts/check_canonical_categories.py scripts/normalize_skill_depth.py tests/test_check_canonical_categories.py tests/test_normalize_skill_depth.py tests/test_plugin_contract.py`
- `uv run --extra dev ruff check scripts/build_search_index.py scripts/search_sources.py scripts/rebuild_registry.py scripts/utils.py scripts/check_canonical_categories.py scripts/normalize_skill_depth.py tests/test_check_canonical_categories.py tests/test_normalize_skill_depth.py tests/test_plugin_contract.py`
- `uv run --extra dev python -m pytest`
- `PYTEST_ADDOPTS='-p no:cacheprovider --no-cov' uv run --extra dev pytest -q tests/test_build_search_index.py tests/test_plugin_contract.py tests/test_check_canonical_categories.py tests/test_normalize_skill_depth.py`
- Pipeline-shaped fixture: canonical gate errors `0`, normalize `move_count: 0`, registry total `1`, search total `1`, with raw archive `SKILL.md` count `3`.
