### PR TITLE
Skip bundled support SKILL files in security targets

### DIFF
--- a/scripts/security_scanner.py
+++ b/scripts/security_scanner.py
@@ -25,6 +25,7 @@ from security_rules import (
     OBFUSCATION_EXEC_PATTERNS,
     SENSITIVE_PATHS,
 )
+from utils import is_declared_bundled_skill_file
 
 # Load schema
 SCHEMA_PATH = Path(__file__).parent.parent / "schema" / "skill.schema.json"
@@ -488,7 +489,7 @@ def resolve_scan_file_list(skills_dir: Path, file_list_path: Path) -> List[Path]
         current = candidate if candidate.is_dir() else candidate.parent
         while True:
             skill_file = current / "SKILL.md"
-            if skill_file.is_file():
+            if skill_file.is_file() and not is_declared_bundled_skill_file(skill_file, skills_root):
                 return skill_file
             if current == skills_root:
                 return None
@@ -513,7 +514,7 @@ def resolve_scan_file_list(skills_dir: Path, file_list_path: Path) -> List[Path]
         if not candidate.exists():
             continue
 
-        skill_file = candidate if candidate.name == "SKILL.md" else owning_skill_file(candidate)
+        skill_file = owning_skill_file(candidate)
         if not skill_file:
             continue
 
@@ -554,7 +555,11 @@ def scan_directory(
     }
 
     if selected_files is None:
-        scan_targets = skills_dir.rglob("SKILL.md")
+        scan_targets = (
+            skill_file
+            for skill_file in skills_dir.rglob("SKILL.md")
+            if not is_declared_bundled_skill_file(skill_file, skills_root)
+        )
     else:
         scan_targets = selected_files
 

--- a/tests/test_security_scanner.py
+++ b/tests/test_security_scanner.py
@@ -388,6 +388,77 @@ description: Demo skill used to verify file list ownership.
     assert selected == [(skill_dir / "SKILL.md").resolve()]
 
 
+def test_file_list_maps_declared_bundled_skill_markdown_to_owner_skill(tmp_path):
+    module = load_module()
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "design" / "deterministic-design"
+    bundled_dir = skill_dir / "design-spatial"
+    bundled_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: deterministic-design
+description: Demo skill used to verify bundled SKILL.md ownership.
+---
+
+# Deterministic Design
+""",
+        encoding="utf-8",
+    )
+    (skill_dir / "metadata.json").write_text(
+        json.dumps({"bundled_files": ["design-spatial/SKILL.md"]}),
+        encoding="utf-8",
+    )
+    (bundled_dir / "SKILL.md").write_text(
+        "---\ndescription: Broken support frontmatter: not an archive skill\n---\n",
+        encoding="utf-8",
+    )
+    file_list = tmp_path / "changed-files.txt"
+    file_list.write_text(
+        "design/deterministic-design/design-spatial/SKILL.md\n",
+        encoding="utf-8",
+    )
+
+    selected = module.resolve_scan_file_list(skills_dir, file_list)
+    report = module.scan_directory(skills_dir, quiet=True, selected_files=selected)
+
+    assert selected == [(skill_dir / "SKILL.md").resolve()]
+    assert report["total"] == 1
+    assert report["failed"] == 0
+    assert report["skills"][0]["path"] == "design/deterministic-design/SKILL.md"
+
+
+def test_directory_scan_skips_declared_bundled_skill_markdown_as_archive_target(tmp_path):
+    module = load_module()
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "design" / "deterministic-design"
+    bundled_dir = skill_dir / "design-spatial"
+    bundled_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: deterministic-design
+description: Demo skill used to verify bundled SKILL.md target filtering.
+---
+
+# Deterministic Design
+""",
+        encoding="utf-8",
+    )
+    (skill_dir / "metadata.json").write_text(
+        json.dumps({"bundled_files": ["design-spatial/SKILL.md"]}),
+        encoding="utf-8",
+    )
+    (bundled_dir / "SKILL.md").write_text(
+        "---\ndescription: Broken support frontmatter: not an archive skill\n---\n",
+        encoding="utf-8",
+    )
+
+    report = module.scan_directory(skills_dir, quiet=True)
+
+    assert report["total"] == 1
+    assert report["failed"] == 0
+    assert report["skills"][0]["path"] == "design/deterministic-design/SKILL.md"
+
+
 def test_scanner_checks_all_archived_support_dirs(tmp_path):
     module = load_module()
     skill_dir = tmp_path / "demo"


### PR DESCRIPTION
## Summary
- map changed declared bundled `SKILL.md` support files to their owning archive skill during incremental security scans
- skip declared bundled support `SKILL.md` files as standalone archive targets during full directory scans
- add regressions for the deterministic-design `design-spatial/SKILL.md` failure shape

## Verification
- `/tmp/csr-core-security-venv/bin/python -m pytest -o addopts='' -q`
- `/tmp/csr-core-security-venv/bin/python -m ruff check scripts/security_scanner.py tests/test_security_scanner.py`
- `/tmp/csr-core-security-venv/bin/python -m black --check scripts/security_scanner.py tests/test_security_scanner.py`
