### PR TITLE
Add Linked API linkedin skill

### DIFF
--- a/sources/community.json
+++ b/sources/community.json
@@ -2,6 +2,7 @@
   "name": "Community Skills",
   "description": "Community-contributed Claude Code skills from GitHub ecosystem",
   "skills": [
+    {"name": "linkedin", "repo": "Linked-API/linkedin-skills", "path": "linkedin", "description": "Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, comment, and run custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf.", "category": "productivity", "tags": ["linkedin", "automation"], "stars": 0},
     {"name": "superpowers", "repo": "obra/superpowers", "path": "", "description": "20+ battle-tested skills for Claude Code including TDD, debugging, and collaboration patterns", "category": "development", "tags": ["tdd", "debugging", "collaboration", "productivity"], "stars": 0, "featured": true},
     {"name": "test-driven-development", "repo": "obra/superpowers", "path": "test-driven-development", "description": "TDD discipline with RED-GREEN-REFACTOR cycle. Ensures tests genuinely verify behavior", "category": "testing", "tags": ["tdd", "testing", "red-green-refactor"], "stars": 0, "featured": true},
     {"name": "systematic-debugging", "repo": "obra/superpowers", "path": "systematic-debugging", "description": "Four-phase debugging framework for any technical issue. Prevents random fix attempts", "category": "development", "tags": ["debugging", "troubleshooting", "methodology"], "stars": 0, "featured": true},


### PR DESCRIPTION
Adds Linked API skill listing for `linkedin`.

- Skill: General LinkedIn automation
- Listing name: linkedin-skills
- Source: https://github.com/Linked-API/linkedin-skills/tree/main/linkedin
- Docs: https://linkedapi.io/skills/linkedin-skill
- Install runbook: https://linkedapi.io/skills/linkedin/install.md
- Description: Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, comment, and run custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf.
- Tags: LinkedIn, automation, social, agent-skill
- Catalog state: /Users/kiril/Documents/Work/LinkedAPI/.claude/skills/publish-skills/catalogs/majiayu000-claude-skill-registry-core.md

Publication copy:
LinkedIn Skill gives AI agents natural-language access to LinkedIn automation through Linked API. It supports profile and company research, people and company search, messaging, connection requests and management, post creation, reactions, comments, stats, Sales Navigator actions, and custom workflows. It works with Claude Code, Codex, Cursor, and Windsurf and uses dedicated cloud browsers through Linked API.

Assets:
- Logo: assets/logo.png (https://linkedapi.io/logo.png)
- Social card: assets/social-card.png (https://linkedapi.io/opengraph-image?b7d7037e63c6122a)
- Screenshot: assets/screenshots/linkedin-skill.png (https://linkedapi.io/skills/linkedin-skill)