### PR TITLE
Add Linked API linkedin-growth skill

### DIFF
--- a/sources/community.json
+++ b/sources/community.json
@@ -2,6 +2,7 @@
   "name": "Community Skills",
   "description": "Community-contributed Claude Code skills from GitHub ecosystem",
   "skills": [
+    {"name": "linkedin-growth", "repo": "Linked-API/linkedin-skills", "path": "linkedin-growth", "description": "Import leads from LinkedIn or Sales Navigator searches, qualify them against an ideal-customer profile, schedule safe connection invites across accounts, track acceptances, and withdraw stale pending requests.", "category": "productivity", "tags": ["linkedin", "automation"], "stars": 0},
     {"name": "superpowers", "repo": "obra/superpowers", "path": "", "description": "20+ battle-tested skills for Claude Code including TDD, debugging, and collaboration patterns", "category": "development", "tags": ["tdd", "debugging", "collaboration", "productivity"], "stars": 0, "featured": true},
     {"name": "test-driven-development", "repo": "obra/superpowers", "path": "test-driven-development", "description": "TDD discipline with RED-GREEN-REFACTOR cycle. Ensures tests genuinely verify behavior", "category": "testing", "tags": ["tdd", "testing", "red-green-refactor"], "stars": 0, "featured": true},
     {"name": "systematic-debugging", "repo": "obra/superpowers", "path": "systematic-debugging", "description": "Four-phase debugging framework for any technical issue. Prevents random fix attempts", "category": "development", "tags": ["debugging", "troubleshooting", "methodology"], "stars": 0, "featured": true},


### PR DESCRIPTION
Adds Linked API skill listing for `linkedin-growth`.

- Skill: Lead pipeline (import → qualify → invites)
- Listing name: linkedin-growth
- Source: https://github.com/Linked-API/linkedin-skills/tree/main/linkedin-growth
- Docs: https://linkedapi.io/skills/linkedin-growth-skill
- Install runbook: https://linkedapi.io/skills/linkedin-growth/install.md
- Description: Import leads from LinkedIn or Sales Navigator searches, qualify them against an ideal-customer profile, schedule safe connection invites across accounts, track acceptances, and withdraw stale pending requests.
- Tags: LinkedIn, lead-generation, growth, agent-skill
- Catalog state: /Users/kiril/Documents/Work/LinkedAPI/.claude/skills/publish-skills/catalogs/majiayu000-claude-skill-registry-core.md

Publication copy:
LinkedIn Growth is an agent skill for hands-off, controlled LinkedIn network growth. The user defines a LinkedIn or Sales Navigator search plus an ideal-lead profile; the skill imports candidates, qualifies every lead with recorded reasoning, stores the pipeline locally, assigns leads across one or more accounts, sends connection invites during active hours, tracks acceptances, and withdraws unanswered requests. It is built for steady qualified growth rather than one-off blasting.

Assets:
- Logo: assets/logo.png (https://linkedapi.io/logo.png)
- Social card: assets/social-card.png (https://linkedapi.io/opengraph-image?b7d7037e63c6122a)
- Screenshot: assets/screenshots/linkedin-growth-skill.png (https://linkedapi.io/skills/linkedin-growth-skill)