### PR TITLE
docs: add examples to the data-quality issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/data-quality.yml
+++ b/.github/ISSUE_TEMPLATE/data-quality.yml
@@ -28,5 +28,11 @@ body:
     attributes:
       label: Details
       description: Include the current value, expected value, and source evidence when possible.
+      placeholder: |-
+        Duplicate skill — Current: two entries point to the same skill. Expected: one canonical entry. Source evidence: links to both entries and the upstream skill.
+        Wrong category — Current: listed under “Testing”. Expected: “Security”. Source evidence: registry link and upstream description.
+        Stale metadata — Current: version is 1.2. Expected: version 1.4. Source evidence: registry metadata and upstream release.
+        Unsafe content — Current: hardcoded credential `sk-REDACTED`. Expected: read it from an environment variable. Source evidence: permalink to the affected line with credentials redacted.
+        Missing bundled file — Current: `references/setup.md` is absent. Expected: include the referenced file. Source evidence: registry archive and upstream file tree.
     validations:
       required: true


### PR DESCRIPTION
## 摘要

- 为 data-quality Issue 模板补充五类紧凑示例：重复 Skill、分类错误、元数据过期、不安全内容、缺失随附文件
- 每个示例都明确 current、expected 与 source evidence
- 保持现有字段与 required 规则不变

## 验证

- YAML `safe_load` 通过
- 字段 ID 与 required 断言通过
- `git diff --check` 通过

Fixes #228
