### PR TITLE
docs: document local validation for submitted skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,36 @@ Common category codes include:
 
 3. Submit a PR to `majiayu000/claude-skill-registry-core` (not `claude-skill-registry`, which is a generated publish artifact)
 
+### Validate a submitted skill locally
+
+Before opening an issue or PR, confirm that the source repository is public and
+that its `SKILL.md` starts with YAML frontmatter containing non-empty `name` and
+`description` values:
+
+```yaml
+---
+name: your-skill-name
+description: A concise description of what the skill does.
+---
+```
+
+Remove secrets, tokens, and private endpoints from the skill and any bundled
+files. From a core checkout with the repository requirements installed, run:
+
+```bash
+# If the PR updates sources/community.json, validate the source entry
+python scripts/validate_sources.py community.json
+
+# Scan the checked-out skill directory, including bundled files
+python scripts/security_scanner.py /path/to/skill-directory
+```
+
+These are the normal community-submission checks. The
+`python scripts/rebuild_registry.py --help` and
+`python scripts/build_search_index.py --help` interfaces are archive-wide
+maintainer references; rebuilding the registry or indexes is not a normal
+submission prerequisite.
+
 ### Report Issues
 
 We welcome feedback! Please open an issue for:

--- a/docs/CONTRIBUTION_GUIDE.md
+++ b/docs/CONTRIBUTION_GUIDE.md
@@ -40,6 +40,33 @@ Registry 通过 GitHub Code Search 和预设仓库列表自动发现 SKILL.md �
 1. 将仓库 URL 加入 `REPOS_TO_CLONE`
 2. 下一次爬取周期自动收录
 
+### 在本地验证提交的 Skill
+
+提交 Issue 或 PR 前，请确认源仓库公开且无需登录即可访问，并确认
+`SKILL.md` 以 YAML frontmatter 开头，其中 `name` 和 `description` 均为非空值：
+
+```yaml
+---
+name: your-skill-name
+description: 清楚说明这个 Skill 的用途。
+---
+```
+
+Skill 及其随附文件不得包含密钥、令牌或私有端点。在已安装本仓库依赖的
+core checkout 中运行：
+
+```bash
+# PR 修改 sources/community.json 时，验证来源条目
+python scripts/validate_sources.py community.json
+
+# 扫描本地检出的 Skill 目录及其随附文件
+python scripts/security_scanner.py /path/to/skill-directory
+```
+
+以上是普通社区提交所需的检查。`python scripts/rebuild_registry.py --help` 和
+`python scripts/build_search_index.py --help` 仅用于了解维护者的全量归档构建接口；
+普通提交不需要在本地重建 registry 或搜索索引。
+
 ## Plugin 收录流程
 
 Plugin 是 Claude Code 的打包扩展，包含多个 skills、commands、hooks 等。


### PR DESCRIPTION
## 摘要

- 在 README 增加普通社区 Skill 提交的本地验证入口
- 在中文贡献指南增加对应说明
- 明确公开来源、必需 frontmatter、禁止 secrets/private endpoints
- 区分常规提交检查与维护者的全量 registry/index 构建接口

## 验证

- `python scripts/validate_sources.py --help`
- `python scripts/rebuild_registry.py --help`
- `python scripts/build_search_index.py --help`
- `python -m pytest -q tests/test_validate_sources.py tests/test_security_scanner.py`（44 passed）
- `git diff --check`

Fixes #227
