### PR TITLE
ci: make cross-repo sync main-only and replayable

### DIFF
--- a/.github/workflows/sync-data.yml
+++ b/.github/workflows/sync-data.yml
@@ -68,7 +68,7 @@ jobs:
           invalid = [name for name, value in repos.items() if not repo_pattern.fullmatch(value)]
           if invalid:
               raise SystemExit(f"Invalid owner/name repository configuration: {', '.join(invalid)}")
-          if len(set(repos.values())) != len(repos):
+          if len({value.casefold() for value in repos.values()}) != len(repos):
               raise SystemExit("Core, data, and main repositories must be distinct")
           PY
 

--- a/.github/workflows/sync-data.yml
+++ b/.github/workflows/sync-data.yml
@@ -24,30 +24,163 @@ permissions:
 
 concurrency:
   group: sync-data-pipeline
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require main branch authority
+        env:
+          GITHUB_REF_VALUE: ${{ github.ref }}
+        run: |
+          if [ "$GITHUB_REF_VALUE" != "refs/heads/main" ]; then
+            echo "sync-data may only run from refs/heads/main (got $GITHUB_REF_VALUE)."
+            exit 1
+          fi
+
+      - name: Validate target repositories and write permissions
+        env:
+          CORE_REPO: ${{ github.repository }}
+          REGISTRY_DATA_REPO: ${{ vars.REGISTRY_DATA_REPO }}
+          DATA_REPO_TOKEN: ${{ secrets.DATA_REPO_TOKEN }}
+          REGISTRY_MAIN_REPO: ${{ vars.REGISTRY_MAIN_REPO }}
+          MAIN_REPO_TOKEN: ${{ secrets.MAIN_REPO_TOKEN }}
+        run: |
+          set -euo pipefail
+          for name in REGISTRY_DATA_REPO DATA_REPO_TOKEN REGISTRY_MAIN_REPO MAIN_REPO_TOKEN; do
+            if [ -z "${!name:-}" ]; then
+              echo "Missing required sync-data configuration: $name"
+              exit 1
+            fi
+          done
+
+          python - <<'PY'
+          import os
+          import re
+
+          repo_pattern = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+          repos = {
+              "CORE_REPO": os.environ["CORE_REPO"],
+              "REGISTRY_DATA_REPO": os.environ["REGISTRY_DATA_REPO"],
+              "REGISTRY_MAIN_REPO": os.environ["REGISTRY_MAIN_REPO"],
+          }
+          invalid = [name for name, value in repos.items() if not repo_pattern.fullmatch(value)]
+          if invalid:
+              raise SystemExit(f"Invalid owner/name repository configuration: {', '.join(invalid)}")
+          if len(set(repos.values())) != len(repos):
+              raise SystemExit("Core, data, and main repositories must be distinct")
+          PY
+
+          validate_repo() {
+            local repo="$1"
+            local token="$2"
+            local response="$RUNNER_TEMP/repo-$3.json"
+            curl --silent --show-error --fail-with-body \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $token" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              --output "$response" \
+              "https://api.github.com/repos/$repo"
+            REPO_RESPONSE="$response" REPO_NAME="$repo" python - <<'PY'
+          import json
+          import os
+
+          with open(os.environ["REPO_RESPONSE"], encoding="utf-8") as handle:
+              response = json.load(handle)
+          repo = os.environ["REPO_NAME"]
+          if response.get("full_name", "").casefold() != repo.casefold():
+              raise SystemExit(f"Repository API identity mismatch for {repo}")
+          if response.get("default_branch") != "main":
+              raise SystemExit(f"Repository {repo} default branch must be main")
+          if response.get("permissions", {}).get("push") is not True:
+              raise SystemExit(f"Credential does not have push permission for {repo}")
+          PY
+          }
+
+          validate_repo "$REGISTRY_DATA_REPO" "$DATA_REPO_TOKEN" data
+          validate_repo "$REGISTRY_MAIN_REPO" "$MAIN_REPO_TOKEN" main
+
+      - name: Download replay handoff
+        if: github.run_attempt > 1
+        uses: actions/download-artifact@v7
+        with:
+          # No run-id/repository override: restore only from this workflow run.
+          name: sync-publish-handoff
+          path: replay-handoff
+
+      - name: Validate replay handoff before mutation boundary
+        if: github.run_attempt > 1
+        env:
+          EXPECTED_RUN_ID: ${{ github.run_id }}
+          EXPECTED_CORE_REPO: ${{ github.repository }}
+          EXPECTED_DATA_REPO: ${{ vars.REGISTRY_DATA_REPO }}
+          EXPECTED_TARGET_REPO: ${{ vars.REGISTRY_MAIN_REPO }}
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          root = Path("replay-handoff")
+          payload_path = root / "publish-dispatch-payload.json"
+          evidence_path = root / "publish-dispatch-evidence.json"
+          if not payload_path.is_file() or not evidence_path.is_file():
+              raise SystemExit("Rerun requires both handoff files from the original attempt")
+
+          payload_bytes = payload_path.read_bytes()
+          payload = json.loads(payload_bytes)
+          evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+          payload_keys = {"event_type", "client_payload"}
+          client_keys = {"core_repo", "core_sha", "data_repo", "data_sha"}
+          evidence_keys = {
+              "schema_version", "run_id", "run_attempt", "target_repo", "core_repo",
+              "core_sha", "data_repo", "data_sha", "event_type", "payload_sha256",
+          }
+          if set(payload) != payload_keys or set(payload.get("client_payload", {})) != client_keys:
+              raise SystemExit("Replay payload has unexpected or missing fields")
+          if set(evidence) != evidence_keys:
+              raise SystemExit("Replay evidence has unexpected or missing fields")
+          expected = {
+              "schema_version": 1,
+              "run_id": os.environ["EXPECTED_RUN_ID"],
+              "run_attempt": 1,
+              "target_repo": os.environ["EXPECTED_TARGET_REPO"],
+              "core_repo": os.environ["EXPECTED_CORE_REPO"],
+              "data_repo": os.environ["EXPECTED_DATA_REPO"],
+              "event_type": "publish_from_core",
+          }
+          for key, value in expected.items():
+              if evidence.get(key) != value:
+                  raise SystemExit(f"Replay evidence mismatch: {key}")
+          client = payload["client_payload"]
+          for key in client_keys:
+              if client.get(key) != evidence.get(key):
+                  raise SystemExit(f"Replay payload/evidence mismatch: {key}")
+          if payload["event_type"] != evidence["event_type"]:
+              raise SystemExit("Replay event_type mismatch")
+          if not re.fullmatch(r"[0-9a-f]{40}", evidence["core_sha"]):
+              raise SystemExit("Invalid replay core SHA")
+          if not re.fullmatch(r"[0-9a-f]{40}", evidence["data_sha"]):
+              raise SystemExit("Invalid replay data SHA")
+          digest = hashlib.sha256(payload_bytes).hexdigest()
+          if digest != evidence["payload_sha256"]:
+              raise SystemExit("Replay payload hash mismatch")
+          print(f"Validated replay handoff for run {evidence['run_id']} ({digest})")
+          PY
+
   sync:
+    needs: preflight
+    if: github.run_attempt == 1
     runs-on: ubuntu-latest
     steps:
       - name: Checkout core
         uses: actions/checkout@v6
         with:
+          ref: main
           fetch-depth: 0
-
-      - name: Validate data repo config
-        env:
-          REGISTRY_DATA_REPO: ${{ vars.REGISTRY_DATA_REPO }}
-          DATA_REPO_TOKEN: ${{ secrets.DATA_REPO_TOKEN }}
-        run: |
-          if [ -z "$REGISTRY_DATA_REPO" ]; then
-            echo "Missing repo variable: REGISTRY_DATA_REPO (e.g. yourname/claude-skill-registry-data)"
-            exit 1
-          fi
-          if [ -z "$DATA_REPO_TOKEN" ]; then
-            echo "Missing secret: DATA_REPO_TOKEN (PAT that can push to the data repo)"
-            exit 1
-          fi
 
       - name: Checkout data repo to ./skills
         uses: actions/checkout@v6
@@ -55,6 +188,7 @@ jobs:
           repository: ${{ vars.REGISTRY_DATA_REPO }}
           token: ${{ secrets.DATA_REPO_TOKEN }}
           path: skills
+          ref: main
           fetch-depth: 0
 
       - name: Set up Python
@@ -496,7 +630,7 @@ jobs:
           else
             git commit -m "chore: update skills archive $(date -u +%Y-%m-%d)"
             for attempt in 1 2 3; do
-              if git push; then
+              if git push origin HEAD:main; then
                 echo "Data push succeeded on attempt $attempt"
                 break
               fi
@@ -528,7 +662,7 @@ jobs:
             COUNT=$(python3 -c "import json; print(json.load(open('registry_summary.json')).get('total_count', 0))")
             git commit -m "chore: sync registry ($COUNT skills) $(date -u +%Y-%m-%d)"
             for attempt in 1 2 3; do
-              if git push; then
+              if git push origin HEAD:main; then
                 echo "Core push succeeded on attempt $attempt"
                 break
               fi
@@ -553,47 +687,186 @@ jobs:
           echo "core_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           echo "data_sha=$(git -C skills rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Validate main publish config
-        id: maincfg
+      - name: Build immutable publish handoff
         env:
-          REGISTRY_MAIN_REPO: ${{ vars.REGISTRY_MAIN_REPO }}
-          MAIN_REPO_TOKEN: ${{ secrets.MAIN_REPO_TOKEN }}
-        run: |
-          if [ -z "$REGISTRY_MAIN_REPO" ]; then
-            echo "::warning::Missing repo variable REGISTRY_MAIN_REPO; skipping main publish dispatch."
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [ -z "$MAIN_REPO_TOKEN" ]; then
-            echo "::warning::Missing secret MAIN_REPO_TOKEN; skipping main publish dispatch."
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "ready=true" >> "$GITHUB_OUTPUT"
-
-      - name: Dispatch main publish workflow
-        if: steps.maincfg.outputs.ready == 'true'
-        env:
-          REGISTRY_MAIN_REPO: ${{ vars.REGISTRY_MAIN_REPO }}
-          MAIN_REPO_TOKEN: ${{ secrets.MAIN_REPO_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
           CORE_REPO: ${{ github.repository }}
           CORE_SHA: ${{ steps.refs.outputs.core_sha }}
           DATA_REPO: ${{ vars.REGISTRY_DATA_REPO }}
           DATA_SHA: ${{ steps.refs.outputs.data_sha }}
+          REGISTRY_MAIN_REPO: ${{ vars.REGISTRY_MAIN_REPO }}
         run: |
-          PAYLOAD=$(cat <<JSON
-          {"event_type":"publish_from_core","client_payload":{"core_repo":"$CORE_REPO","core_sha":"$CORE_SHA","data_repo":"$DATA_REPO","data_sha":"$DATA_SHA"}}
-          JSON
+          mkdir -p sync-publish-handoff
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          sha_pattern = re.compile(r"[0-9a-f]{40}")
+          core_sha = os.environ["CORE_SHA"]
+          data_sha = os.environ["DATA_SHA"]
+          if not sha_pattern.fullmatch(core_sha) or not sha_pattern.fullmatch(data_sha):
+              raise SystemExit("Cannot build handoff from invalid source SHA")
+
+          payload = {
+              "event_type": "publish_from_core",
+              "client_payload": {
+                  "core_repo": os.environ["CORE_REPO"],
+                  "core_sha": core_sha,
+                  "data_repo": os.environ["DATA_REPO"],
+                  "data_sha": data_sha,
+              },
+          }
+          root = Path("sync-publish-handoff")
+          payload_path = root / "publish-dispatch-payload.json"
+          payload_bytes = (json.dumps(payload, separators=(",", ":")) + "\n").encode()
+          payload_path.write_bytes(payload_bytes)
+          evidence = {
+              "schema_version": 1,
+              "run_id": os.environ["RUN_ID"],
+              "run_attempt": 1,
+              "target_repo": os.environ["REGISTRY_MAIN_REPO"],
+              "core_repo": os.environ["CORE_REPO"],
+              "core_sha": core_sha,
+              "data_repo": os.environ["DATA_REPO"],
+              "data_sha": data_sha,
+              "event_type": "publish_from_core",
+              "payload_sha256": hashlib.sha256(payload_bytes).hexdigest(),
+          }
+          (root / "publish-dispatch-evidence.json").write_text(
+              json.dumps(evidence, indent=2) + "\n", encoding="utf-8"
           )
-          curl --fail-with-body -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $MAIN_REPO_TOKEN" \
-            "https://api.github.com/repos/$REGISTRY_MAIN_REPO/dispatches" \
-            -d "$PAYLOAD"
-          echo "Dispatched publish: $REGISTRY_MAIN_REPO (core=$CORE_SHA data=$DATA_SHA)"
+          print(
+              "Prepared immutable publish handoff "
+              f"core={core_sha} data={data_sha} hash={evidence['payload_sha256']}"
+          )
+          PY
+
+      - name: Upload immutable publish handoff
+        uses: actions/upload-artifact@v7
+        with:
+          name: sync-publish-handoff
+          path: sync-publish-handoff/
+          if-no-files-found: error
+          retention-days: 30
+
+  publish:
+    needs: [preflight, sync]
+    if: >-
+      ${{
+        always() &&
+        needs.preflight.result == 'success' &&
+        (needs.sync.result == 'success' ||
+          (github.run_attempt > 1 && needs.sync.result == 'skipped'))
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download immutable publish handoff
+        uses: actions/download-artifact@v7
+        with:
+          # No run-id/repository override: restore only from this workflow run.
+          name: sync-publish-handoff
+          path: sync-publish-handoff
+
+      - name: Validate immutable publish handoff
+        id: handoff
+        env:
+          EXPECTED_RUN_ID: ${{ github.run_id }}
+          EXPECTED_CORE_REPO: ${{ github.repository }}
+          EXPECTED_DATA_REPO: ${{ vars.REGISTRY_DATA_REPO }}
+          EXPECTED_TARGET_REPO: ${{ vars.REGISTRY_MAIN_REPO }}
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          root = Path("sync-publish-handoff")
+          payload_path = root / "publish-dispatch-payload.json"
+          evidence_path = root / "publish-dispatch-evidence.json"
+          if not payload_path.is_file() or not evidence_path.is_file():
+              raise SystemExit("Publish handoff is missing required files")
+          payload_bytes = payload_path.read_bytes()
+          payload = json.loads(payload_bytes)
+          evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+          payload_keys = {"event_type", "client_payload"}
+          client_keys = {"core_repo", "core_sha", "data_repo", "data_sha"}
+          evidence_keys = {
+              "schema_version", "run_id", "run_attempt", "target_repo", "core_repo",
+              "core_sha", "data_repo", "data_sha", "event_type", "payload_sha256",
+          }
+          if set(payload) != payload_keys or set(payload.get("client_payload", {})) != client_keys:
+              raise SystemExit("Publish payload has unexpected or missing fields")
+          if set(evidence) != evidence_keys:
+              raise SystemExit("Publish evidence has unexpected or missing fields")
+          expected = {
+              "schema_version": 1,
+              "run_id": os.environ["EXPECTED_RUN_ID"],
+              "run_attempt": 1,
+              "target_repo": os.environ["EXPECTED_TARGET_REPO"],
+              "core_repo": os.environ["EXPECTED_CORE_REPO"],
+              "data_repo": os.environ["EXPECTED_DATA_REPO"],
+              "event_type": "publish_from_core",
+          }
+          for key, value in expected.items():
+              if evidence.get(key) != value:
+                  raise SystemExit(f"Publish evidence mismatch: {key}")
+          client = payload["client_payload"]
+          for key in client_keys:
+              if client.get(key) != evidence.get(key):
+                  raise SystemExit(f"Publish payload/evidence mismatch: {key}")
+          if payload["event_type"] != evidence["event_type"]:
+              raise SystemExit("Publish event_type mismatch")
+          if not re.fullmatch(r"[0-9a-f]{40}", evidence["core_sha"]):
+              raise SystemExit("Invalid publish core SHA")
+          if not re.fullmatch(r"[0-9a-f]{40}", evidence["data_sha"]):
+              raise SystemExit("Invalid publish data SHA")
+          if hashlib.sha256(payload_bytes).hexdigest() != evidence["payload_sha256"]:
+              raise SystemExit("Publish payload hash mismatch")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              for key in ("target_repo", "core_sha", "data_sha", "payload_sha256"):
+                  output.write(f"{key}={evidence[key]}\n")
+          print(f"Validated immutable publish handoff ({evidence['payload_sha256']})")
+          PY
+
+      - name: Dispatch main publish workflow from immutable handoff
+        env:
+          MAIN_REPO_TOKEN: ${{ secrets.MAIN_REPO_TOKEN }}
+          TARGET_REPO: ${{ steps.handoff.outputs.target_repo }}
+          CORE_SHA: ${{ steps.handoff.outputs.core_sha }}
+          DATA_SHA: ${{ steps.handoff.outputs.data_sha }}
+          PAYLOAD_SHA256: ${{ steps.handoff.outputs.payload_sha256 }}
+        run: |
+          set -euo pipefail
+          PAYLOAD_FILE="sync-publish-handoff/publish-dispatch-payload.json"
+          if ! curl --fail-with-body -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $MAIN_REPO_TOKEN" \
+              -H "Content-Type: application/json" \
+              "https://api.github.com/repos/$TARGET_REPO/dispatches" \
+              --data-binary "@$PAYLOAD_FILE"; then
+            {
+              echo "## Publish dispatch failed"
+              echo ""
+              echo "- target_repo: $TARGET_REPO"
+              echo "- core_sha: $CORE_SHA"
+              echo "- data_sha: $DATA_SHA"
+              echo "- payload_sha256: $PAYLOAD_SHA256"
+              echo ""
+              echo "Replay payload:"
+              cat "$PAYLOAD_FILE"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "Publish dispatch failed: target=$TARGET_REPO core=$CORE_SHA data=$DATA_SHA hash=$PAYLOAD_SHA256"
+            cat "$PAYLOAD_FILE"
+            exit 1
+          fi
+          echo "Dispatched publish: $TARGET_REPO (core=$CORE_SHA data=$DATA_SHA hash=$PAYLOAD_SHA256)"
 
       - name: Dispatch build-index to refresh Pages
-        if: steps.maincfg.outputs.ready == 'true'
         env:
           MAIN_REPO_TOKEN: ${{ secrets.MAIN_REPO_TOKEN }}
         run: |

--- a/docs/plan/GH239/product.md
+++ b/docs/plan/GH239/product.md
@@ -1,0 +1,85 @@
+# GH239 产品规格：跨仓同步仅限 main、串行且可重放
+
+关联 issue: https://github.com/majiayu000/claude-skill-registry-core/issues/239
+状态: `Approved for implementation by implx auth_mode:auto`
+语言: `zh-CN`
+
+## 问题
+
+`sync-data` 同时写入 core、data，并把固定的 `core_sha` + `data_sha`
+分发给 main。当前手动运行可从非 `main` ref 进入流程；配置校验、跨仓 push
+和 publish dispatch 之间也没有完整的 fail-closed 与重放边界。结果可能是 data/core
+已经提交，但 main 未发布，或者运行在两次跨仓写入之间被取消。
+
+维护者需要看到一个明确结果：一次运行要么在任何写路径前被拒绝，要么形成一个可审计、
+可重放的固定 tuple；dispatch 失败不能被报告成成功，也不能通过 rerun 再生成另一组 tuple。
+
+## 目标
+
+1. 只允许 `main` ref 进入任何 checkout、discovery、commit、push 或 dispatch 路径。
+2. 在 discovery 与任一 push 前，fail closed 校验 data/main 目标和 credentials。
+3. 串行执行跨仓写路径，新的运行不得取消正在运行的写事务。
+4. 在 main dispatch 前固化完整 tuple 与不含 secret 的精确 replay payload。
+5. dispatch 失败时保留可复现证据并使 workflow 失败；同一 run 的 rerun 只重放同一 tuple。
+6. 用 deterministic workflow contract tests 固化顺序、失败语义和重放边界。
+
+## 非目标
+
+- 不提供跨 Git 仓库的原子事务或自动回滚已推送 commit。
+- 不承诺 `repository_dispatch` exactly-once；幂等性指重试使用相同 target 与 payload，
+  且不再写 core/data。
+- 不修改 data/main 仓库的 skill 内容、生成物或 main-owned workflow。
+- 不改变 discovery、download、security、metadata 或 size gate 的业务判定。
+- 不为非 `main` 增加 dry-run 例外。
+- 不自动恢复尚未形成有效 handoff 的旧 run；该情况必须 fail closed，维护者核对远端状态后
+  发起新的 `main` `workflow_dispatch`。
+
+## 可观察行为不变量
+
+1. `GH239-INV-01`：任一 `github.ref != refs/heads/main` 的运行必须失败；失败发生在第一个
+   repository checkout 之前，且该 run 不执行 discovery、commit、push 或 dispatch。
+2. `GH239-INV-02`：`REGISTRY_DATA_REPO`、`DATA_REPO_TOKEN`、
+   `REGISTRY_MAIN_REPO`、`MAIN_REPO_TOKEN` 任一缺失、格式错误、目标不可访问、目标默认分支
+   不是 `main`，或对应 credential 不具备 write 能力时，workflow 必须在 discovery 与任一
+   push 前失败；日志不得输出 credential 值。
+3. `GH239-INV-03`：core/data 的 checkout、rebase 与 push 都显式指向 `main`；不得依赖触发
+   ref、当前 tracking branch 或目标仓默认值来决定写入分支。
+4. `GH239-INV-04`：同一 `sync-data-pipeline` concurrency group 中，运行中的 workflow
+   不会被后来的 run 取消；后来的 run 只能等待写路径空闲。此契约不声明 FIFO 顺序。
+5. `GH239-INV-05`：data 与 core push 都成功（或确认无变更）后、main dispatch 前，workflow
+   必须固化完整 `core_sha`、`data_sha`、`core_repo`、`data_repo`、`target_repo`、
+   `event_type` 与精确 request payload；两个 SHA 必须是实际将被发布的完整 commit SHA。
+6. `GH239-INV-06`：main dispatch 返回非成功状态时，workflow 必须失败，并在日志/summary
+   及 retained artifact 中提供 `target_repo`、`core_sha`、`data_sha`、`payload_sha256` 与
+   replay payload；证据只允许公开仓库标识、SHA、run 标识和 payload，不得包含 token、
+   authorization header 或其他 secret。
+7. `GH239-INV-07`：同一 `github.run_id` 的 rerun 如果已有有效 handoff，必须复用完全相同的
+   target、tuple、payload bytes 与 `payload_sha256`，并跳过 checkout、discovery、commit 和
+   core/data push；dispatch 可安全重复提交。
+8. `GH239-INV-08`：`github.run_attempt > 1` 时，缺失、过期、字段不匹配、hash 不匹配或
+   repo/SHA 非法的 handoff 必须在任何新写路径前 fail closed；不得猜测当前 branch head
+   作为替代 tuple。
+9. `GH239-INV-09`：首次成功运行仍保持 canonical flow：data push → core push → 固化 tuple
+   → main `publish_from_core` dispatch → core `build-index` dispatch。main dispatch 失败时
+   不得继续 dispatch `build-index`。
+10. `GH239-INV-10`：contract tests 必须分别证明 main-only 顺序、早期配置失败、显式
+    `main` 写入、`cancel-in-progress: false`、handoff 先于 dispatch、dispatch failure、
+    rerun 跳过写路径，以及 secret-free evidence；仅检查一个关键词存在不算完整证明。
+
+## 验收场景
+
+| 场景 | 预期结果 | 覆盖 |
+| --- | --- | --- |
+| 从 feature branch 手动运行 | checkout 前失败，无外部 mutation | `GH239-INV-01` |
+| data/main 配置或权限无效 | discovery 前失败，不降级为 warning/skip | `GH239-INV-02` |
+| 两个 run 重叠 | 已运行者继续，后来的 run 等待 | `GH239-INV-04` |
+| 两次 push 后 main dispatch 返回 4xx/5xx | run 失败，安全证据可下载并可复制 payload | `GH239-INV-05`, `GH239-INV-06` |
+| 对该失败 run 执行 rerun | 不再写 core/data，只发送原 payload | `GH239-INV-07` |
+| rerun 的 handoff 缺失或被修改 | 写路径前失败，不生成新 tuple | `GH239-INV-08` |
+
+## 完成条件
+
+本次 `implx auth_mode:auto` invocation 已授权按本规格实施，无需额外等待 spec approval。
+全部 `GH239-INV-01` 至 `GH239-INV-10` 仍须有实现证据与通过的 deterministic checks；
+合并仍须具备独立 PR review、当前 CI/review threads/merge state/PR gate 证据。受控 live
+workflow dispatch 是独立的 maintainer gate，不属于本次实施授权。

--- a/docs/plan/GH239/tasks.md
+++ b/docs/plan/GH239/tasks.md
@@ -1,0 +1,102 @@
+# GH239 任务计划
+
+关联 issue: https://github.com/majiayu000/claude-skill-registry-core/issues/239
+产品规格: `docs/plan/GH239/product.md`
+技术规格: `docs/plan/GH239/tech.md`
+状态: `Approved for implementation by implx auth_mode:auto`
+
+## 执行边界
+
+- 单一顺序 lane：`implementation_lane`。任务共享 workflow/test 文件，不并行写入。
+- 本次 `implx auth_mode:auto` invocation 本身授权执行 `SP239-T1` 至 `SP239-T3`，无需再次请求
+  spec implementation approval。
+- 只允许实现阶段修改 `.github/workflows/sync-data.yml` 与
+  `tests/test_pipeline_contracts.py`。
+- 当前 spec-writer lane 仍不修改实现文件，也不执行 live workflow dispatch。后续 implx
+  implementation lane 可在当前授权内实施并形成 PR；合并必须等待独立 review 与完整、当前的
+  CI/review threads/merge state/PR gate evidence。真实 GitHub run 只由 maintainer 受控触发。
+
+## `SP239-T1`：建立 main authority、早期配置与串行边界
+
+- Owner（负责人）: `implementation_lane`
+- Dependencies（依赖）: none
+- Covers（覆盖）: `GH239-INV-01`, `GH239-INV-02`, `GH239-INV-03`, `GH239-INV-04`
+- Files（文件）: `.github/workflows/sync-data.yml`, `tests/test_pipeline_contracts.py`
+- 工作内容:
+  1. 添加无 checkout 的 `preflight` first step 与 fail-closed data/main access checks。
+  2. 将 concurrency 改为 `cancel-in-progress: false`。
+  3. 让 core/data checkout、rebase、push 显式使用 `main`。
+  4. 添加覆盖顺序、失败语义和显式 branch target 的 contract tests。
+- Done when（完成标准）:
+  - non-main/config/permission 失败路径都位于 checkout/discovery/push 前；无 warning-and-skip。
+  - active run 不可取消，所有写入目标显式为 `main`。
+  - 对应 contract tests 通过，既有 pipeline order tests 不回归。
+- Verify（验证）:
+
+```bash
+python -m pytest -q tests/test_pipeline_contracts.py -k 'sync_data'
+git diff --check
+```
+
+## `SP239-T2`：固化 tuple、拆分 publish 并实现 rerun replay
+
+- Owner（负责人）: `implementation_lane`
+- Dependencies（依赖）: `SP239-T1`
+- Covers（覆盖）: `GH239-INV-05`, `GH239-INV-06`, `GH239-INV-07`, `GH239-INV-08`, `GH239-INV-09`
+- Files（文件）: `.github/workflows/sync-data.yml`, `tests/test_pipeline_contracts.py`
+- 工作内容:
+  1. 将 mutation 与 dispatch 拆为 `sync`/`publish` jobs，并设置严格 `needs`/attempt 条件。
+  2. 在两次 push 后生成、校验并上传 `sync-publish-handoff` 的两个 JSON 文件。
+  3. 让 `publish` 只从 artifact 读取并原样发送 payload，失败时输出 secret-free replay evidence。
+  4. 覆盖 rerun failed jobs、rerun all jobs、坏/缺失 handoff 与 build-index 顺序。
+- Done when（完成标准）:
+  - 首次 run 在 dispatch 前有完整、hash 可验证、无 secret 的 handoff。
+  - 任一 rerun 不进入 core/data mutation；有效 handoff 重放相同 bytes，无效 handoff fail closed。
+  - main dispatch 非 2xx 使 workflow 失败且 `build-index` 不运行。
+- Verify（验证）:
+
+```bash
+python -m pytest -q tests/test_pipeline_contracts.py -k 'sync_data'
+git diff --check
+```
+
+## `SP239-T3`：全量验证与 human handoff
+
+- Owner（负责人）: `implementation_lane`
+- Dependencies（依赖）: `SP239-T1`, `SP239-T2`
+- Covers（覆盖）: `GH239-INV-01` through `GH239-INV-10`
+- Files（文件）: 无计划中的 production edit，仅生成 evidence/handoff
+- 工作内容:
+  1. 运行 focused 与 full test suite，确认现有 download/security/size gates 顺序未变。
+  2. 审查 diff 仅包含两个授权实现文件，且无 token、测试弱化或 main/data 直接修改。
+  3. 在 PR 中附 invariant → test evidence；合并后将受控失败 dispatch/live rerun 明确交给
+     maintainer 执行。
+- Done when（完成标准）:
+  - 所有 deterministic checks fresh pass；每个 invariant 有 test 名称或明确 live human gate。
+  - 合并前具备独立 reviewer lane 与当前 CI、review threads、merge state、PR gate evidence。
+  - live workflow dispatch 未由 implementation agent 执行；maintainer 可在受控运行中从
+    artifact 复制 payload，并确认 rerun 不产生新的 core/data SHA。
+- Verify（验证）:
+
+```bash
+python -m pytest -q tests/test_pipeline_contracts.py
+python -m pytest -q
+git diff --check
+git status --short
+```
+
+## 追踪矩阵
+
+| 不变量 | Primary task | Final gate |
+| --- | --- | --- |
+| `GH239-INV-01` - `GH239-INV-04` | `SP239-T1` | `SP239-T3` |
+| `GH239-INV-05` - `GH239-INV-09` | `SP239-T2` | `SP239-T3` |
+| `GH239-INV-10` | `SP239-T3` | maintainer review |
+
+## Human gates（人工门禁）
+
+1. 实施授权：已由本次 `implx auth_mode:auto` invocation 满足，不再等待额外 spec approval。
+2. 合并前：必须有独立 reviewer lane，并核对 contract tests、workflow job conditions、当前
+   CI、review threads、merge state 与 PR gate evidence；不得以自审替代。
+3. 上线验证：maintainer 在 `main` 受控触发，并核对失败 evidence、rerun tuple 与下游
+   publish；`implx auth_mode:auto` 不授权 implementation agent 执行该 live dispatch。

--- a/docs/plan/GH239/tech.md
+++ b/docs/plan/GH239/tech.md
@@ -1,0 +1,195 @@
+# GH239 技术规格：sync-data authority 与 replay handoff
+
+关联 issue: https://github.com/majiayu000/claude-skill-registry-core/issues/239
+产品规格: `docs/plan/GH239/product.md`
+基线: `8710eaddb2159130c6f4ccfa9792387d56f3482e`
+状态: `Approved for implementation by implx auth_mode:auto`
+
+## 约束与既有契约
+
+- `AGENTS.md` 与 `CLAUDE.md` 指定 core 是 publish orchestration authority；main 由固定的
+  `core_sha` + `data_sha` 重建，不能在 main 直接修补生成物。
+- `docs/plan/sync-download-failure-gate.md` 的 download fail-closed 与 failure artifact
+  必须保留。
+- `docs/plan/malware-supply-chain-remediation-spec.md` 的 security fail-closed 顺序不得弱化。
+- `docs/plan/registry-sharding-spec.md` 要求 size guard 位于 registry rebuild 后、data/core
+  commit 前；本改动不得移动该边界。
+- `docs/plan/release-readiness-reporting.md` 仍是 report-only，不得借本 issue 变成 publish gate。
+
+## 当前根因（基线精确证据）
+
+1. `.github/workflows/sync-data.yml:33-36` 的第一个 repository step 是 `Checkout core`；
+   workflow 没有 branch guard。`workflow_dispatch` 可选择非 `main` ref，因此 data checkout
+   仍可指向 data 默认分支，而 core checkout/push 使用触发分支，形成跨分支 tuple。
+2. `.github/workflows/sync-data.yml:38-50` 只在 core checkout 后检查 data 变量/secret 是否
+   非空；没有校验 repo 格式、默认分支、访问性或 write permission。无效 push credential
+   可能直到长时间 discovery/build 后才暴露。
+3. `.github/workflows/sync-data.yml:25-27` 使用固定 concurrency group，但
+   `cancel-in-progress: true`。后来的 run 可在 data push 与 core push/dispatch 之间取消当前 run。
+4. `.github/workflows/sync-data.yml:487-548` 先执行 data/core push，且两个 `git push` 都依赖
+   当前 tracking branch；没有显式 `origin HEAD:main` authority boundary。
+5. `.github/workflows/sync-data.yml:556-572` 在两个 push 后才校验 main 配置；缺失配置仅输出
+   warning、写 `ready=false` 并 `exit 0`，所以已提交但未 publish 的 workflow 仍可成功。
+6. `.github/workflows/sync-data.yml:574-593` 的 `curl --fail-with-body` 已能让 HTTP 非成功响应
+   失败；真正缺口是 payload 只存在于瞬时 shell variable，失败前没有持久化 target/tuple/
+   request，也没有独立 replay 路径。
+7. 所有 mutation 与 dispatch 位于同一个 `sync` job。GitHub rerun 会沿用原事件的
+   `GITHUB_SHA`/`GITHUB_REF`，重跑该 job 会再次进入 discovery 与两次 push，不能保证复用
+   已提交 tuple。行为依据：
+   https://docs.github.com/en/actions/how-tos/manage-workflow-runs/re-run-workflows-and-jobs
+8. `tests/test_pipeline_contracts.py:225-273` 只覆盖 rebuild/guard 顺序、staging、cleanup 与
+   discovery output；没有 branch、credential、concurrency、dispatch evidence 或 rerun contract。
+
+## 技术决策
+
+### 1. Workflow 级 authority 与串行化
+
+- 保留 `concurrency.group: sync-data-pipeline`，将 `cancel-in-progress` 固定为 `false`。
+- 将 workflow 拆为顺序 jobs：`preflight`、`sync`、`publish`。只有 `sync` 可 checkout 或写仓库。
+- `preflight` 的第一个用户 step 不 checkout；它断言 `github.ref == refs/heads/main`。
+  失败时后续 jobs 因 `needs` 不运行。
+- `sync` 仅在 `github.run_attempt == 1` 且没有 replay handoff 时运行。任何 rerun 都不得重新
+  进入 mutation job；无有效 handoff 的 rerun 由 `preflight`/`publish` 失败。
+
+### 2. 早期 fail-closed 配置校验
+
+`preflight` 在 checkout/discovery 前完成以下只读校验：
+
+1. 四个配置值均非空；repo 值匹配 GitHub `owner/name` 形状，core/data/main 三个 target 互异。
+2. 用 `DATA_REPO_TOKEN` 对 `REGISTRY_DATA_REPO` 执行非 mutation repository GET；要求响应成功、
+   `default_branch == "main"` 且 authenticated `permissions.push == true`。
+3. 用 `MAIN_REPO_TOKEN` 对 `REGISTRY_MAIN_REPO` 做同样检查；不发送“探测 dispatch”。
+4. 任一网络、JSON、字段或权限校验失败均 `exit 1`；response 与日志不得包含 token。
+
+presence-only 的 `Validate data repo config` 与 late `Validate main publish config` 被统一替代；
+不再保留 `ready=false`、warning 后跳过 publish 的路径。
+
+### 3. 显式 main 写入
+
+- core/data `actions/checkout` 都指定 `ref: main` 与 `fetch-depth: 0`。
+- 冲突重试继续 `fetch origin main` / `rebase origin/main`，push 改为
+  `git push origin HEAD:main`。
+- 无 staged change 时仍读取当前 `main` HEAD；有 rebase 时只在 push 成功后捕获最终 SHA。
+- 现有 discovery、download、security、metadata、rebuild 与 size guard 的相对顺序不变。
+
+### 4. Secret-free handoff contract
+
+`sync` 在 data/core push 完成后、`publish` 启动前生成并上传阻塞式 artifact
+`sync-publish-handoff`，保留 30 天，包含两个文件：
+
+`publish-dispatch-payload.json` 是将原样发送到 GitHub API 的 request body：
+
+```json
+{
+  "event_type": "publish_from_core",
+  "client_payload": {
+    "core_repo": "owner/claude-skill-registry-core",
+    "core_sha": "40-hex",
+    "data_repo": "owner/claude-skill-registry-data",
+    "data_sha": "40-hex"
+  }
+}
+```
+
+`publish-dispatch-evidence.json` 使用固定 schema：
+
+```json
+{
+  "schema_version": 1,
+  "run_id": "github.run_id",
+  "run_attempt": 1,
+  "target_repo": "owner/claude-skill-registry",
+  "core_repo": "owner/claude-skill-registry-core",
+  "core_sha": "40-hex",
+  "data_repo": "owner/claude-skill-registry-data",
+  "data_sha": "40-hex",
+  "event_type": "publish_from_core",
+  "payload_sha256": "64-hex"
+}
+```
+
+生成器只接收 repo、SHA 和 GitHub run metadata，不接收任何 token。payload 使用稳定 JSON
+编码并以实际文件 bytes 计算 SHA-256。artifact 上传失败必须阻止 `publish`。
+
+### 5. Replay state machine
+
+| 状态 | `sync` | `publish` |
+| --- | --- | --- |
+| 首次 attempt，无 handoff | 运行完整 pipeline，上传 handoff | 下载、校验并 dispatch |
+| dispatch/build-index 失败后 rerun failed jobs | 不重新运行已成功的 `sync` | 下载同一 run artifact，重放 |
+| rerun all jobs，有有效 handoff | 由 `preflight` 恢复，`sync` skipped | 重放同一 bytes |
+| 任一 rerun，无/坏/过期 handoff | 禁止 mutation，fail closed | 不猜测 tuple |
+
+恢复使用同一 `github.run_id` 范围内的 `actions/download-artifact`；artifact 名固定，因此不会
+跨 run 选错。校验必须在 dispatch 前验证：exact key allowlist、`schema_version`、`run_id`、
+repo 与当前配置一致、两个完整 40-hex SHA、payload/evidence 字段一致，以及
+`payload_sha256` 匹配。多余 key 也失败，以结构 allowlist 保证不存在 secret 字段。
+
+### 6. Dispatch 失败语义
+
+- `publish` 总是从已校验文件发送 payload，不在 shell 中重新拼 tuple。
+- 调用保留 `curl --fail-with-body`；非 2xx 明确输出安全的 `target_repo`、两个 SHA、hash 与
+  payload，写入 `GITHUB_STEP_SUMMARY` 后 `exit 1`。
+- main dispatch 成功后才 dispatch core `build-index`。若后者失败，rerun 仍重发同一 main
+  payload，再重试 build-index；上游 core/data 不变。
+- 幂等键定义为 `(target_repo, event_type, core_sha, data_sha, payload_sha256)`；本 issue
+  不要求下游 exactly-once 去重。
+
+## 影响文件
+
+| 文件 | 计划变更 |
+| --- | --- |
+| `.github/workflows/sync-data.yml` | jobs/authority/config/concurrency、显式 main push、handoff 与 replay |
+| `tests/test_pipeline_contracts.py` | 新增顺序、fail-closed、evidence 与 rerun contract tests |
+
+不修改 data/main repo，不新增 runtime script 或持久化 schema。
+
+## 不变量到实现/验证映射
+
+| 产品不变量 | 实现区域 | Deterministic evidence |
+| --- | --- | --- |
+| `GH239-INV-01` | `preflight` first step | branch guard index 早于任何 checkout；non-main 失败语义断言 |
+| `GH239-INV-02` | early config/access checks | 四值、repo shape、default branch、push permission 与顺序断言 |
+| `GH239-INV-03` | `sync` checkout/rebase/push | `ref: main` 与 `origin HEAD:main` contract test |
+| `GH239-INV-04` | workflow concurrency | group 保持且仅存在 `cancel-in-progress: false` |
+| `GH239-INV-05` | handoff generation/upload | 两次 push < capture/upload < publish 的位置断言与 schema 断言 |
+| `GH239-INV-06` | artifact/summary/error branch | non-2xx exit、safe fields、secret key absence断言 |
+| `GH239-INV-07` | job `needs` 与 rerun restore | attempt > 1 跳过 `sync`，payload 文件原样发送 |
+| `GH239-INV-08` | handoff validator | missing/invalid/hash mismatch 均在 checkout/push 前失败 |
+| `GH239-INV-09` | `sync`/`publish` dependency | data → core → handoff → main → build-index 顺序断言 |
+| `GH239-INV-10` | `tests/test_pipeline_contracts.py` | focused 与 full pytest 通过 |
+
+## 风险与缓解
+
+- GitHub concurrency 不保证无限 pending/FIFO；规格只依赖“不取消 active run”和单一 mutation
+  lane，不声明队列顺序。
+- GitHub API 或 permission metadata 暂时不可用会阻止 sync；这是预期 fail-closed，避免在
+  credential 未证明可写时开始长流程。
+- artifact 最长 30 天且可能被人工删除；rerun 窗口内缺失时阻止 mutation，维护者需核对
+  remote heads 后发起新的首次 run。
+- job 拆分条件写错可能跳过 publish；contract tests 必须同时验证 normal、skipped sync 与
+  failure dependency 条件。
+- duplicate dispatch 可产生下游重复 run，但必须绑定同一 tuple；不得以生成新 tuple规避。
+
+## 回滚
+
+1. 在尚未产生跨仓 commit 时，可 revert workflow/test commit，恢复上一版 workflow。
+2. 若新 workflow 已形成 handoff 但 dispatch 未成功，先用 artifact 中的原 payload 完成或
+   明确放弃该 tuple；不得通过回滚到旧 workflow 后 rerun 来生成替代 tuple。
+3. 回滚不涉及 data/main 数据迁移；已推送 commit 保持可审计，不 force push。
+4. 若仅 early permission probe 误判，仍保持 main-only 与 `cancel-in-progress: false`，在单独
+   follow-up 中修正 probe，不恢复 warning-and-skip 行为。
+
+## Deterministic checks
+
+```bash
+python -m pytest -q tests/test_pipeline_contracts.py
+python -m pytest -q
+git diff --check
+```
+
+本次 `implx auth_mode:auto` invocation 已授权实施本技术规格；合并仍须满足独立 reviewer
+lane 与当前 CI、review threads、merge state、PR gate evidence。真实失败 run 的
+artifact/summary 检查属于合并后的受控 live workflow dispatch human gate，用于确认 payload
+可重放且 artifact 内不存在 secret；本次授权不包含 live dispatch，该检查也不替代
+deterministic tests。

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -627,8 +627,23 @@ def test_sync_data_handoff_generator_executes_with_exact_payload_bytes_and_hash(
     "corruption",
     ["missing", "invalid_json", "hash_mismatch", "extra_key", "field_mismatch"],
 )
-def test_sync_data_handoff_validator_executes_and_rejects_corruption(tmp_path, corruption):
+@pytest.mark.parametrize(
+    ("job_name", "step_name", "handoff_dir"),
+    [
+        (
+            "preflight",
+            "Validate replay handoff before mutation boundary",
+            "replay-handoff",
+        ),
+        ("publish", "Validate immutable publish handoff", "sync-publish-handoff"),
+    ],
+)
+def test_sync_data_handoff_validators_execute_and_reject_corruption(
+    tmp_path, corruption, job_name, step_name, handoff_dir
+):
     root, payload_bytes, evidence = build_valid_handoff(tmp_path)
+    if root.name != handoff_dir:
+        root = root.rename(tmp_path / handoff_dir)
     payload_path = root / "publish-dispatch-payload.json"
     evidence_path = root / "publish-dispatch-evidence.json"
     if corruption == "missing":
@@ -648,7 +663,7 @@ def test_sync_data_handoff_validator_executes_and_rejects_corruption(tmp_path, c
         evidence["payload_sha256"] = hashlib.sha256(changed_bytes).hexdigest()
         evidence_path.write_text(json.dumps(evidence), encoding="utf-8")
 
-    step = workflow_step("publish", "Validate immutable publish handoff")
+    step = workflow_step(job_name, step_name)
     env = {
         "EXPECTED_RUN_ID": "1234",
         "EXPECTED_CORE_REPO": "Owner/Core",
@@ -658,6 +673,27 @@ def test_sync_data_handoff_validator_executes_and_rejects_corruption(tmp_path, c
     result = run_workflow_script(step, tmp_path, env)
 
     assert result.returncode != 0
+
+
+def test_sync_data_preflight_replay_validator_executes_and_accepts_valid_handoff(tmp_path):
+    root, _, _ = build_valid_handoff(tmp_path)
+    root.rename(tmp_path / "replay-handoff")
+    preflight = read_workflow(".github/workflows/sync-data.yml")["jobs"]["preflight"]
+    step = workflow_step("preflight", "Validate replay handoff before mutation boundary")
+    env = {
+        "EXPECTED_RUN_ID": "1234",
+        "EXPECTED_CORE_REPO": "Owner/Core",
+        "EXPECTED_DATA_REPO": "Owner/Data",
+        "EXPECTED_TARGET_REPO": "Owner/Main",
+    }
+
+    result = run_workflow_script(step, tmp_path, env)
+
+    assert result.returncode == 0, result.stderr
+    assert all("actions/checkout" not in candidate.get("uses", "") for candidate in preflight["steps"])
+    assert preflight["steps"].index(step) > preflight["steps"].index(
+        next(candidate for candidate in preflight["steps"] if candidate["name"] == "Download replay handoff")
+    )
 
 
 def test_sync_data_handoff_validator_executes_and_exports_verified_fields(tmp_path):

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -1,5 +1,10 @@
+import hashlib
+import json
+import os
+import subprocess
 from pathlib import Path
 
+import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -11,6 +16,104 @@ def read_repo_file(path: str) -> str:
 
 def read_workflow(path: str) -> dict:
     return yaml.safe_load(read_repo_file(path))
+
+
+def workflow_step(job_name: str, step_name: str) -> dict:
+    workflow = read_workflow(".github/workflows/sync-data.yml")
+    return next(step for step in workflow["jobs"][job_name]["steps"] if step["name"] == step_name)
+
+
+def install_fake_curl(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    fake_curl = bin_dir / "curl"
+    fake_curl.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import sys
+
+mode = os.environ.get("FAKE_CURL_MODE", "repo")
+if mode == "fail":
+    raise SystemExit(22)
+if mode == "mark":
+    Path(os.environ["FAKE_CURL_MARKER"]).write_text("called", encoding="utf-8")
+    raise SystemExit(0)
+
+args = sys.argv[1:]
+output = args[args.index("--output") + 1]
+url = next(arg for arg in args if arg.startswith("https://api.github.com/repos/"))
+repo = url.split("/repos/", 1)[1]
+response = {
+    "full_name": repo,
+    "default_branch": os.environ.get("FAKE_DEFAULT_BRANCH", "main"),
+    "permissions": {"push": os.environ.get("FAKE_PUSH", "true") == "true"},
+}
+Path(output).write_text(json.dumps(response), encoding="utf-8")
+""",
+        encoding="utf-8",
+    )
+    fake_curl.chmod(0o755)
+    return bin_dir
+
+
+def run_workflow_script(
+    step: dict,
+    tmp_path: Path,
+    env: dict[str, str] | None = None,
+    fake_curl: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    runtime_env = os.environ.copy()
+    runtime_env.update(
+        {
+            "RUNNER_TEMP": str(tmp_path / "runner-temp"),
+            "GITHUB_OUTPUT": str(tmp_path / "github-output"),
+            "GITHUB_STEP_SUMMARY": str(tmp_path / "github-summary"),
+        }
+    )
+    (tmp_path / "runner-temp").mkdir(exist_ok=True)
+    if env:
+        runtime_env.update(env)
+    if fake_curl:
+        bin_dir = install_fake_curl(tmp_path)
+        runtime_env["PATH"] = f"{bin_dir}:{runtime_env['PATH']}"
+    return subprocess.run(
+        ["bash", "-c", step["run"]],
+        cwd=tmp_path,
+        env=runtime_env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def valid_sync_env() -> dict[str, str]:
+    return {
+        "CORE_REPO": "Owner/Core",
+        "REGISTRY_DATA_REPO": "Owner/Data",
+        "DATA_REPO_TOKEN": "data-test-token",
+        "REGISTRY_MAIN_REPO": "Owner/Main",
+        "MAIN_REPO_TOKEN": "main-test-token",
+    }
+
+
+def build_valid_handoff(tmp_path: Path) -> tuple[Path, bytes, dict]:
+    step = workflow_step("sync", "Build immutable publish handoff")
+    env = {
+        "RUN_ID": "1234",
+        "CORE_REPO": "Owner/Core",
+        "CORE_SHA": "a" * 40,
+        "DATA_REPO": "Owner/Data",
+        "DATA_SHA": "b" * 40,
+        "REGISTRY_MAIN_REPO": "Owner/Main",
+    }
+    result = run_workflow_script(step, tmp_path, env)
+    assert result.returncode == 0, result.stderr
+    root = tmp_path / "sync-publish-handoff"
+    payload_bytes = (root / "publish-dispatch-payload.json").read_bytes()
+    evidence = json.loads((root / "publish-dispatch-evidence.json").read_text())
+    return root, payload_bytes, evidence
 
 
 def test_pages_app_prefers_lite_index_with_full_index_fallback():
@@ -445,6 +548,170 @@ def test_sync_data_publish_sends_exact_payload_and_fails_with_safe_replay_eviden
     assert "target=$TARGET_REPO core=$CORE_SHA data=$DATA_SHA hash=$PAYLOAD_SHA256" in dispatch["run"]
     assert "exit 1" in dispatch["run"]
     assert "actions/workflows/build-index.yml/dispatches" in build_index["run"]
+
+
+def test_sync_data_branch_guard_executes_and_rejects_non_main(tmp_path):
+    step = workflow_step("preflight", "Require main branch authority")
+
+    rejected = run_workflow_script(step, tmp_path, {"GITHUB_REF_VALUE": "refs/heads/feature"})
+    accepted = run_workflow_script(step, tmp_path, {"GITHUB_REF_VALUE": "refs/heads/main"})
+
+    assert rejected.returncode != 0
+    assert "only run from refs/heads/main" in rejected.stdout
+    assert accepted.returncode == 0
+
+
+@pytest.mark.parametrize(
+    ("updates", "expected_error"),
+    [
+        ({"DATA_REPO_TOKEN": ""}, "Missing required sync-data configuration"),
+        ({"REGISTRY_DATA_REPO": "not-a-repo"}, "Invalid owner/name repository"),
+        (
+            {"CORE_REPO": "Owner/Core", "REGISTRY_DATA_REPO": "owner/core"},
+            "Core, data, and main repositories must be distinct",
+        ),
+        ({"FAKE_PUSH": "false"}, "does not have push permission"),
+        ({"FAKE_DEFAULT_BRANCH": "develop"}, "default branch must be main"),
+    ],
+)
+def test_sync_data_config_preflight_executes_and_fails_closed(
+    tmp_path, updates, expected_error
+):
+    step = workflow_step("preflight", "Validate target repositories and write permissions")
+    env = valid_sync_env()
+    env.update(updates)
+
+    result = run_workflow_script(step, tmp_path, env, fake_curl=True)
+
+    assert result.returncode != 0
+    assert expected_error in result.stdout + result.stderr
+
+
+def test_sync_data_config_preflight_executes_with_valid_distinct_targets(tmp_path):
+    step = workflow_step("preflight", "Validate target repositories and write permissions")
+
+    result = run_workflow_script(step, tmp_path, valid_sync_env(), fake_curl=True)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_sync_data_handoff_generator_executes_with_exact_payload_bytes_and_hash(tmp_path):
+    root, payload_bytes, evidence = build_valid_handoff(tmp_path)
+    expected = (
+        b'{"event_type":"publish_from_core","client_payload":'
+        b'{"core_repo":"Owner/Core","core_sha":"' + b"a" * 40
+        + b'","data_repo":"Owner/Data","data_sha":"' + b"b" * 40
+        + b'"}}\n'
+    )
+
+    assert payload_bytes == expected
+    assert evidence == {
+        "schema_version": 1,
+        "run_id": "1234",
+        "run_attempt": 1,
+        "target_repo": "Owner/Main",
+        "core_repo": "Owner/Core",
+        "core_sha": "a" * 40,
+        "data_repo": "Owner/Data",
+        "data_sha": "b" * 40,
+        "event_type": "publish_from_core",
+        "payload_sha256": hashlib.sha256(expected).hexdigest(),
+    }
+    assert sorted(path.name for path in root.iterdir()) == [
+        "publish-dispatch-evidence.json",
+        "publish-dispatch-payload.json",
+    ]
+
+
+@pytest.mark.parametrize(
+    "corruption",
+    ["missing", "invalid_json", "hash_mismatch", "extra_key", "field_mismatch"],
+)
+def test_sync_data_handoff_validator_executes_and_rejects_corruption(tmp_path, corruption):
+    root, payload_bytes, evidence = build_valid_handoff(tmp_path)
+    payload_path = root / "publish-dispatch-payload.json"
+    evidence_path = root / "publish-dispatch-evidence.json"
+    if corruption == "missing":
+        evidence_path.unlink()
+    elif corruption == "invalid_json":
+        evidence_path.write_text("{", encoding="utf-8")
+    elif corruption == "hash_mismatch":
+        payload_path.write_bytes(payload_bytes + b" ")
+    elif corruption == "extra_key":
+        evidence["unexpected"] = "rejected"
+        evidence_path.write_text(json.dumps(evidence), encoding="utf-8")
+    else:
+        payload = json.loads(payload_bytes)
+        payload["client_payload"]["core_sha"] = "c" * 40
+        changed_bytes = (json.dumps(payload, separators=(",", ":")) + "\n").encode()
+        payload_path.write_bytes(changed_bytes)
+        evidence["payload_sha256"] = hashlib.sha256(changed_bytes).hexdigest()
+        evidence_path.write_text(json.dumps(evidence), encoding="utf-8")
+
+    step = workflow_step("publish", "Validate immutable publish handoff")
+    env = {
+        "EXPECTED_RUN_ID": "1234",
+        "EXPECTED_CORE_REPO": "Owner/Core",
+        "EXPECTED_DATA_REPO": "Owner/Data",
+        "EXPECTED_TARGET_REPO": "Owner/Main",
+    }
+    result = run_workflow_script(step, tmp_path, env)
+
+    assert result.returncode != 0
+
+
+def test_sync_data_handoff_validator_executes_and_exports_verified_fields(tmp_path):
+    _, _, evidence = build_valid_handoff(tmp_path)
+    step = workflow_step("publish", "Validate immutable publish handoff")
+    env = {
+        "EXPECTED_RUN_ID": "1234",
+        "EXPECTED_CORE_REPO": "Owner/Core",
+        "EXPECTED_DATA_REPO": "Owner/Data",
+        "EXPECTED_TARGET_REPO": "Owner/Main",
+    }
+
+    result = run_workflow_script(step, tmp_path, env)
+    outputs = dict(
+        line.split("=", 1)
+        for line in (tmp_path / "github-output").read_text(encoding="utf-8").splitlines()
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert outputs == {
+        key: str(evidence[key])
+        for key in ("target_repo", "core_sha", "data_sha", "payload_sha256")
+    }
+
+
+def test_sync_data_dispatch_non_2xx_fails_and_suppresses_build_index(tmp_path):
+    _, _, evidence = build_valid_handoff(tmp_path)
+    publish = read_workflow(".github/workflows/sync-data.yml")["jobs"]["publish"]
+    dispatch = workflow_step("publish", "Dispatch main publish workflow from immutable handoff")
+    build_index = workflow_step("publish", "Dispatch build-index to refresh Pages")
+    env = {
+        "MAIN_REPO_TOKEN": "main-test-token",
+        "TARGET_REPO": evidence["target_repo"],
+        "CORE_SHA": evidence["core_sha"],
+        "DATA_SHA": evidence["data_sha"],
+        "PAYLOAD_SHA256": evidence["payload_sha256"],
+        "FAKE_CURL_MODE": "fail",
+    }
+
+    dispatch_result = run_workflow_script(dispatch, tmp_path, env, fake_curl=True)
+    build_index_executed = False
+    if dispatch_result.returncode == 0:
+        build_index_executed = True
+        run_workflow_script(build_index, tmp_path, env, fake_curl=True)
+
+    assert dispatch_result.returncode != 0
+    assert build_index.get("if") is None
+    assert not build_index_executed
+    summary = (tmp_path / "github-summary").read_text(encoding="utf-8")
+    assert evidence["target_repo"] in summary
+    assert evidence["core_sha"] in summary
+    assert evidence["data_sha"] in summary
+    assert evidence["payload_sha256"] in summary
+    assert publish["steps"].index(dispatch) < publish["steps"].index(build_index)
 
 
 def test_metadata_compliance_refuses_unexpected_zero_target_scan():

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -1,10 +1,16 @@
 from pathlib import Path
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[1]
 
 
 def read_repo_file(path: str) -> str:
     return (ROOT / path).read_text(encoding="utf-8")
+
+
+def read_workflow(path: str) -> dict:
+    return yaml.safe_load(read_repo_file(path))
 
 
 def test_pages_app_prefers_lite_index_with_full_index_fallback():
@@ -271,6 +277,174 @@ def test_sync_data_discovery_writes_to_archive_root_not_other_category():
 
     assert "--output skills/other" not in workflow
     assert workflow.count("--output skills") == 2
+
+
+def test_sync_data_preflight_is_main_only_and_precedes_repository_checkout():
+    workflow = read_repo_file(".github/workflows/sync-data.yml")
+    parsed = read_workflow(".github/workflows/sync-data.yml")
+    preflight = parsed["jobs"]["preflight"]
+
+    assert parsed["concurrency"] == {
+        "group": "sync-data-pipeline",
+        "cancel-in-progress": False,
+    }
+    assert preflight["steps"][0]["name"] == "Require main branch authority"
+    assert "refs/heads/main" in preflight["steps"][0]["run"]
+    assert all("actions/checkout" not in step.get("uses", "") for step in preflight["steps"])
+
+    branch_guard_pos = workflow.index("Require main branch authority")
+    config_guard_pos = workflow.index("Validate target repositories and write permissions")
+    checkout_pos = workflow.index("Checkout core")
+    discovery_pos = workflow.index("Resolve discovery profile")
+    push_pos = workflow.index("Commit & push data repo changes")
+    assert branch_guard_pos < config_guard_pos < checkout_pos < discovery_pos < push_pos
+
+
+def test_sync_data_preflight_fails_closed_on_invalid_targets_or_permissions():
+    workflow = read_repo_file(".github/workflows/sync-data.yml")
+    preflight = read_workflow(".github/workflows/sync-data.yml")["jobs"]["preflight"]
+    config_step = next(
+        step
+        for step in preflight["steps"]
+        if step["name"] == "Validate target repositories and write permissions"
+    )
+    config = config_step["run"]
+
+    for name in (
+        "REGISTRY_DATA_REPO",
+        "DATA_REPO_TOKEN",
+        "REGISTRY_MAIN_REPO",
+        "MAIN_REPO_TOKEN",
+    ):
+        assert name in config_step["env"]
+        assert name in config
+    assert "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" in config
+    assert 'response.get("default_branch") != "main"' in config
+    assert 'response.get("permissions", {}).get("push") is not True' in config
+    assert "Core, data, and main repositories must be distinct" in config
+    assert "ready=false" not in workflow
+    assert "skipping main publish dispatch" not in workflow
+
+
+def test_sync_data_uses_explicit_main_checkouts_rebases_and_pushes():
+    workflow = read_repo_file(".github/workflows/sync-data.yml")
+    sync = read_workflow(".github/workflows/sync-data.yml")["jobs"]["sync"]
+    checkouts = [step for step in sync["steps"] if step.get("uses") == "actions/checkout@v6"]
+
+    assert len(checkouts) == 2
+    assert all(step["with"]["ref"] == "main" for step in checkouts)
+    assert workflow.count("git fetch origin main") == 2
+    assert workflow.count("git rebase origin/main") == 2
+    assert workflow.count("git push origin HEAD:main") == 2
+    assert "if git push; then" not in workflow
+
+
+def test_sync_data_handoff_is_immutable_secret_free_and_precedes_dispatch():
+    workflow = read_repo_file(".github/workflows/sync-data.yml")
+    sync = read_workflow(".github/workflows/sync-data.yml")["jobs"]["sync"]
+    handoff = next(
+        step for step in sync["steps"] if step["name"] == "Build immutable publish handoff"
+    )
+    upload = next(
+        step for step in sync["steps"] if step["name"] == "Upload immutable publish handoff"
+    )
+
+    data_push_pos = workflow.index("Commit & push data repo changes")
+    core_push_pos = workflow.index("Commit & push core metadata changes")
+    capture_pos = workflow.index("Capture source SHAs")
+    handoff_pos = workflow.index("Build immutable publish handoff")
+    upload_pos = workflow.index("Upload immutable publish handoff")
+    dispatch_pos = workflow.index("Dispatch main publish workflow from immutable handoff")
+    build_index_pos = workflow.index("Dispatch build-index to refresh Pages")
+    assert data_push_pos < core_push_pos < capture_pos < handoff_pos < upload_pos < dispatch_pos
+    assert dispatch_pos < build_index_pos
+
+    assert upload["with"]["name"] == "sync-publish-handoff"
+    assert upload["with"]["if-no-files-found"] == "error"
+    assert upload["with"]["retention-days"] == 30
+    for field in (
+        '"schema_version": 1',
+        '"run_id": os.environ["RUN_ID"]',
+        '"run_attempt": 1',
+        '"target_repo": os.environ["REGISTRY_MAIN_REPO"]',
+        '"event_type": "publish_from_core"',
+        '"payload_sha256": hashlib.sha256(payload_bytes).hexdigest()',
+    ):
+        assert field in handoff["run"]
+    assert "TOKEN" not in handoff["env"]
+    assert "token" not in handoff["run"].lower()
+
+
+def test_sync_data_reruns_skip_mutation_and_require_valid_original_handoff():
+    parsed = read_workflow(".github/workflows/sync-data.yml")
+    preflight = parsed["jobs"]["preflight"]
+    sync = parsed["jobs"]["sync"]
+    publish = parsed["jobs"]["publish"]
+
+    assert sync["needs"] == "preflight"
+    assert sync["if"] == "github.run_attempt == 1"
+    assert publish["needs"] == ["preflight", "sync"]
+    assert "github.run_attempt > 1" in publish["if"]
+    assert "needs.sync.result == 'skipped'" in publish["if"]
+
+    replay_download = next(
+        step for step in preflight["steps"] if step["name"] == "Download replay handoff"
+    )
+    replay_validate = next(
+        step
+        for step in preflight["steps"]
+        if step["name"] == "Validate replay handoff before mutation boundary"
+    )
+    assert replay_download["if"] == "github.run_attempt > 1"
+    assert replay_validate["if"] == "github.run_attempt > 1"
+    assert replay_download["with"]["name"] == "sync-publish-handoff"
+    assert "run-id" not in replay_download["with"]
+    assert "repository" not in replay_download["with"]
+    for contract in (
+        "set(payload) != payload_keys",
+        "set(evidence) != evidence_keys",
+        '"run_attempt": 1',
+        "Replay payload/evidence mismatch",
+        "Replay payload hash mismatch",
+    ):
+        assert contract in replay_validate["run"]
+
+
+def test_sync_data_publish_sends_exact_payload_and_fails_with_safe_replay_evidence():
+    publish = read_workflow(".github/workflows/sync-data.yml")["jobs"]["publish"]
+    download = next(
+        step for step in publish["steps"] if step["name"] == "Download immutable publish handoff"
+    )
+    validate = next(
+        step for step in publish["steps"] if step["name"] == "Validate immutable publish handoff"
+    )
+    dispatch = next(
+        step
+        for step in publish["steps"]
+        if step["name"] == "Dispatch main publish workflow from immutable handoff"
+    )
+    build_index = next(
+        step
+        for step in publish["steps"]
+        if step["name"] == "Dispatch build-index to refresh Pages"
+    )
+
+    for contract in (
+        "set(payload) != payload_keys",
+        "set(evidence) != evidence_keys",
+        "Publish payload/evidence mismatch",
+        "Publish payload hash mismatch",
+    ):
+        assert contract in validate["run"]
+    assert download["with"]["name"] == "sync-publish-handoff"
+    assert "run-id" not in download["with"]
+    assert "repository" not in download["with"]
+    assert "if ! curl --fail-with-body -X POST" in dispatch["run"]
+    assert '--data-binary "@$PAYLOAD_FILE"' in dispatch["run"]
+    assert "GITHUB_STEP_SUMMARY" in dispatch["run"]
+    assert "target=$TARGET_REPO core=$CORE_SHA data=$DATA_SHA hash=$PAYLOAD_SHA256" in dispatch["run"]
+    assert "exit 1" in dispatch["run"]
+    assert "actions/workflows/build-index.yml/dispatches" in build_index["run"]
 
 
 def test_metadata_compliance_refuses_unexpected_zero_target_scan():


### PR DESCRIPTION
## Summary

- reject non-main runs before checkout and validate data/main repository identity, default branch, and push permission before discovery
- serialize cross-repo mutations, target `main` explicitly, and persist an immutable secret-free core/data publish handoff
- make reruns replay the exact artifact payload without repeating core/data writes
- add executable contract tests for branch/config failures, repository aliases, handoff generation/corruption, and dispatch failure ordering

## Spec

- `docs/plan/GH239/product.md`
- `docs/plan/GH239/tech.md`
- `docs/plan/GH239/tasks.md`

## Verification

- focused sync-data contract tests: 32 passed
- full pytest: 447 passed
- Ruff: passed
- actionlint: 0 findings
- independent review: 3 rounds; all blocking findings resolved
- `git diff --check`: passed

## Human gate

This PR does not dispatch the live sync workflow. After merge, a maintainer should perform a controlled `main` run and verify failure evidence/replay behavior without creating a new core/data tuple.

Fixes #239
