### PR TITLE
fix: confine category migration paths

### DIFF
--- a/scripts/apply_category_migration.py
+++ b/scripts/apply_category_migration.py
@@ -103,6 +103,11 @@ def parse_standard_relative_path(value: object, *, parts: int) -> PurePosixPath 
 
 def path_within_skills_dir(skills_dir: Path, relative_path: PurePosixPath) -> Path | None:
     path = skills_dir.joinpath(*relative_path.parts)
+    component = skills_dir
+    for part in relative_path.parts:
+        component = component / part
+        if component.is_symlink():
+            return None
     try:
         path.resolve().relative_to(skills_dir.resolve())
     except (OSError, RuntimeError, ValueError):

--- a/scripts/apply_category_migration.py
+++ b/scripts/apply_category_migration.py
@@ -9,7 +9,7 @@ import json
 from collections import Counter, defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any
 
 from category_taxonomy import get_taxonomy
@@ -85,6 +85,29 @@ def parse_confidence(value: object) -> float | None:
     if isinstance(value, bool) or not isinstance(value, int | float):
         return None
     return float(value)
+
+
+def parse_standard_relative_path(value: object, *, parts: int) -> PurePosixPath | None:
+    if not isinstance(value, str) or "\\" in value:
+        return None
+    path = PurePosixPath(value)
+    if (
+        path.is_absolute()
+        or PureWindowsPath(value).drive
+        or len(path.parts) != parts
+        or any(part in {".", ".."} for part in path.parts)
+    ):
+        return None
+    return path
+
+
+def path_within_skills_dir(skills_dir: Path, relative_path: PurePosixPath) -> Path | None:
+    path = skills_dir.joinpath(*relative_path.parts)
+    try:
+        path.resolve().relative_to(skills_dir.resolve())
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return path
 
 
 def file_sha256(path: Path) -> str:
@@ -231,16 +254,21 @@ def build_apply_plan(
             reject_reasons[reason] += 1
             continue
 
-        source_skill_rel = Path(row.path)
-        if len(source_skill_rel.parts) != 3:
+        source_skill_rel = parse_standard_relative_path(row.path, parts=3)
+        if source_skill_rel is None or source_skill_rel.name != "SKILL.md":
             reject_reasons["source path is not standard <category>/<skill>/SKILL.md"] += 1
             continue
         source_dir_rel = source_skill_rel.parent
-        source_dir = skills_dir / source_dir_rel
+        source_dir_state_rel = Path(*source_dir_rel.parts)
+        source_dir = path_within_skills_dir(skills_dir, source_dir_rel)
+        source_skill = path_within_skills_dir(skills_dir, source_skill_rel)
+        if source_dir is None or source_skill is None:
+            reject_reasons["source path escapes skills directory"] += 1
+            continue
         if not source_dir.exists():
             reject_reasons["source directory missing"] += 1
             continue
-        if not (skills_dir / source_skill_rel).is_file():
+        if not source_skill.is_file():
             reject_reasons["source SKILL.md missing"] += 1
             continue
         if reason := source_hash_mismatch(row, source_dir):
@@ -255,7 +283,7 @@ def build_apply_plan(
         key = metadata_key(source_dir, category=target_category, name=normalize_name(name))
         operation, target_dir_rel, operation_reason = select_unique_target(
             state=state,
-            source_dir_rel=source_dir_rel,
+            source_dir_rel=source_dir_state_rel,
             target_category=target_category,
             base_name=base_name,
             key=key,
@@ -266,14 +294,14 @@ def build_apply_plan(
             continue
         move = {
             "operation": operation,
-            "source_path": str(source_dir_rel),
-            "source_skill": str(source_skill_rel),
+            "source_path": source_dir_rel.as_posix(),
+            "source_skill": source_skill_rel.as_posix(),
             "source_category": source_category,
             "current_category": row.current_category,
             "target_category": target_category,
             "target_status": taxonomy.category_status(target_category),
-            "target_path": str(target_dir_rel),
-            "target_skill": str(target_dir_rel / "SKILL.md"),
+            "target_path": target_dir_rel.as_posix(),
+            "target_skill": (target_dir_rel / "SKILL.md").as_posix(),
             "name": name,
             "confidence": row.confidence,
             "key": key,
@@ -330,8 +358,14 @@ def apply_plan(skills_dir: Path, plan: dict[str, Any]) -> None:
     if blocked:
         raise ValueError(f"plan contains {len(blocked)} blocked move(s)")
     for move in plan["moves"]:
-        source = skills_dir / move["source_path"]
-        target = skills_dir / move["target_path"]
+        source_rel = parse_standard_relative_path(move.get("source_path"), parts=2)
+        target_rel = parse_standard_relative_path(move.get("target_path"), parts=2)
+        if source_rel is None or target_rel is None:
+            raise ValueError("plan contains an invalid source or target path")
+        source = path_within_skills_dir(skills_dir, source_rel)
+        target = path_within_skills_dir(skills_dir, target_rel)
+        if source is None or target is None:
+            raise ValueError("plan path escapes skills directory")
         if not source.exists():
             raise FileNotFoundError(f"planned source does not exist: {source}")
         if target.exists():

--- a/tests/test_apply_category_migration.py
+++ b/tests/test_apply_category_migration.py
@@ -316,6 +316,61 @@ def test_apply_plan_rejects_escaping_paths(tmp_path):
     assert (outside / "SKILL.md").exists()
 
 
+def test_plan_and_apply_reject_symlinked_skill_path(tmp_path, monkeypatch):
+    migrator = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "other", "victim")
+    victim_dir = skills_dir / "other" / "victim"
+    source_dir = skills_dir / "other" / "alias"
+    try:
+        source_dir.symlink_to(victim_dir, target_is_directory=True)
+    except OSError:
+        path_type = type(source_dir)
+        original_is_symlink = path_type.is_symlink
+
+        def is_symlink(path):
+            return path == source_dir or original_is_symlink(path)
+
+        monkeypatch.setattr(path_type, "is_symlink", is_symlink)
+    classification = tmp_path / "classification.jsonl"
+    _write_classification(
+        classification,
+        [
+            {
+                "path": "other/alias/SKILL.md",
+                "name": "alias",
+                "current_category": "other",
+                "llm_category": "devops",
+                "confidence": 0.95,
+                "status": "ok",
+            }
+        ],
+    )
+
+    plan = migrator.build_apply_plan(
+        skills_dir=skills_dir,
+        classification_jsonl=classification,
+    )
+
+    assert plan["summary"]["planned_move_count"] == 0
+    with pytest.raises(ValueError, match="plan path escapes skills directory"):
+        migrator.apply_plan(
+            skills_dir,
+            {
+                "moves": [
+                    {
+                        "operation": "move",
+                        "source_path": "other/alias",
+                        "target_path": "devops/alias",
+                    }
+                ]
+            },
+        )
+    metadata = json.loads((victim_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert metadata["category"] == "other"
+    assert metadata["dir_name"] == "victim"
+
+
 def test_movable_only_skips_blocked_moves_and_fills_limit(tmp_path):
     migrator = _load_module()
     skills_dir = tmp_path / "skills"

--- a/tests/test_apply_category_migration.py
+++ b/tests/test_apply_category_migration.py
@@ -254,6 +254,68 @@ def test_missing_source_skill_file_blocks_apply_plan(tmp_path):
     assert plan["summary"]["reject_reasons"] == {"source SKILL.md missing": 1}
 
 
+@pytest.mark.parametrize(
+    ("source_path", "reason"),
+    [
+        ("../outside/SKILL.md", "source path is not standard <category>/<skill>/SKILL.md"),
+        ("/outside/SKILL.md", "source path is not standard <category>/<skill>/SKILL.md"),
+        ("C:/outside/SKILL.md", "source path is not standard <category>/<skill>/SKILL.md"),
+        ("other\\outside\\SKILL.md", "classification path is not a SKILL.md path"),
+    ],
+)
+def test_plan_rejects_nonstandard_source_paths(tmp_path, source_path, reason):
+    migrator = _load_module()
+    skills_dir = tmp_path / "skills"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "SKILL.md").write_text("outside", encoding="utf-8")
+    classification = tmp_path / "classification.jsonl"
+    _write_classification(
+        classification,
+        [
+            {
+                "path": source_path,
+                "name": "outside",
+                "current_category": "other",
+                "llm_category": "devops",
+                "confidence": 0.95,
+                "status": "ok",
+            }
+        ],
+    )
+
+    plan = migrator.build_apply_plan(
+        skills_dir=skills_dir,
+        classification_jsonl=classification,
+    )
+
+    assert plan["summary"]["planned_move_count"] == 0
+    assert plan["summary"]["reject_reasons"] == {reason: 1}
+    assert (outside / "SKILL.md").exists()
+
+
+def test_apply_plan_rejects_escaping_paths(tmp_path):
+    migrator = _load_module()
+    skills_dir = tmp_path / "skills"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "SKILL.md").write_text("outside", encoding="utf-8")
+    plan = {
+        "moves": [
+            {
+                "operation": "move",
+                "source_path": "../outside",
+                "target_path": "devops/outside",
+            }
+        ]
+    }
+
+    with pytest.raises(ValueError, match="invalid source or target path"):
+        migrator.apply_plan(skills_dir, plan)
+
+    assert (outside / "SKILL.md").exists()
+
+
 def test_movable_only_skips_blocked_moves_and_fills_limit(tmp_path):
     migrator = _load_module()
     skills_dir = tmp_path / "skills"


### PR DESCRIPTION
## What changed

- Reject traversal, absolute, drive-qualified, and backslash-delimited migration paths.
- Revalidate source and target paths before applying a move, including resolved-path containment.
- Emit migration plan paths with POSIX separators.

## Why

A malformed classification JSONL entry such as `../outside/SKILL.md` could make `--apply` address a directory outside `--skills-dir`.

## Checks

- `.venv\\Scripts\\python.exe -m pytest -q -o addopts='' tests\\test_apply_category_migration.py`
- `.venv\\Scripts\\python.exe -m ruff check scripts\\apply_category_migration.py tests\\test_apply_category_migration.py`
- `.venv\\Scripts\\python.exe -m py_compile scripts\\apply_category_migration.py`
