### PR TITLE
fix: dedupe root skill downloads

### DIFF
--- a/scripts/sync_pipeline_support.py
+++ b/scripts/sync_pipeline_support.py
@@ -55,10 +55,9 @@ def sanitize_category(category: str) -> str:
 def skill_key(skill: dict) -> str:
     repo = (skill.get("repo") or "").strip()
     path = (skill.get("path") or skill.get("github_path") or "").strip()
-    if repo and path:
-        return f"{repo}:{path}"
     if repo:
-        return repo
+        normalized_key = build_skill_key(repo, path)
+        return normalized_key if normalized_key == repo else f"{repo}:{path}"
     name = skill.get("name") or ""
     category = sanitize_category(skill.get("category") or "other")
     return f"{category}:{name}"

--- a/scripts/sync_pipeline_support.py
+++ b/scripts/sync_pipeline_support.py
@@ -56,8 +56,10 @@ def skill_key(skill: dict) -> str:
     repo = (skill.get("repo") or "").strip()
     path = (skill.get("path") or skill.get("github_path") or "").strip()
     if repo:
-        normalized_key = build_skill_key(repo, path)
-        return normalized_key if normalized_key == repo else f"{repo}:{path}"
+        root_key = build_skill_key(repo, path)
+        if root_key == repo:
+            return build_skill_key(repo, path, name=skill.get("name") or "")
+        return f"{repo}:{path}"
     name = skill.get("name") or ""
     category = sanitize_category(skill.get("category") or "other")
     return f"{category}:{name}"

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -1434,6 +1434,32 @@ def test_filter_pending_skills_skips_existing_root_skill():
     assert skipped_rows == []
 
 
+def test_filter_pending_skills_keeps_pathless_skill_with_different_root_name():
+    module = load_module()
+    archived = {
+        "repo": "acme/multi",
+        "name": "root-skill",
+        "path": "SKILL.md",
+        "category": "development",
+    }
+    pending = {
+        "repo": "acme/multi",
+        "name": "nested-skill",
+        "category": "development",
+    }
+
+    filtered, skipped, skipped_rows = module.filter_pending_skills(
+        [pending],
+        existing={module.skill_key(archived)},
+        negative_cache={},
+        now_utc=module.utc_now(),
+    )
+
+    assert filtered == [pending]
+    assert skipped == {"existing": 0, "no_repo": 0, "cooldown_not_found": 0}
+    assert skipped_rows == []
+
+
 def test_sync_pipeline_category_sanitization_does_not_use_legacy_aliases():
     module = load_support_module()
     assert module.sanitize_category("dev") == "dev"

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -1417,6 +1417,23 @@ def test_filter_pending_skills_prefilters_no_repo_and_cooldown():
     assert "cooldown_not_found" in reasons
 
 
+def test_filter_pending_skills_skips_existing_root_skill():
+    module = load_module()
+    source = {"repo": "acme/root-skill", "name": "root-skill", "category": "development"}
+    archived = {**source, "path": "SKILL.md"}
+
+    filtered, skipped, skipped_rows = module.filter_pending_skills(
+        [source],
+        existing={module.skill_key(archived)},
+        negative_cache={},
+        now_utc=module.utc_now(),
+    )
+
+    assert filtered == []
+    assert skipped == {"existing": 1, "no_repo": 0, "cooldown_not_found": 0}
+    assert skipped_rows == []
+
+
 def test_sync_pipeline_category_sanitization_does_not_use_legacy_aliases():
     module = load_support_module()
     assert module.sanitize_category("dev") == "dev"


### PR DESCRIPTION
## What changed

- Canonicalize root `SKILL.md` aliases before checking whether an archive entry already exists.
- Add regression coverage for a source without `path` after the archive persisted `path: "SKILL.md"`.

## Why

The downloader saved root skills as `SKILL.md`, but later keyed them as `repo:SKILL.md` while a source without `path` used `repo`. The mismatch made already archived root skills download again.

## Checks

- `.venv\\Scripts\\python.exe -m pytest -q -o addopts='' tests\\test_sync_and_download.py`
- `.venv\\Scripts\\python.exe -m ruff check scripts\\sync_pipeline_support.py tests\\test_sync_and_download.py`
- `.venv\\Scripts\\python.exe -m py_compile scripts\\sync_pipeline_support.py`
