### PR TITLE
fix: replace existing registry atomically

### DIFF
--- a/scripts/rebuild_registry.py
+++ b/scripts/rebuild_registry.py
@@ -40,7 +40,7 @@ def safe_write_registry(registry_path: Path, registry: dict) -> bool:
         with open(temp_path, "w", encoding="utf-8") as f:
             json.dump(registry, f, ensure_ascii=False, separators=(",", ":"))
 
-        temp_path.rename(registry_path)
+        temp_path.replace(registry_path)
         return True
     except Exception:
         logger.exception("Failed to write registry")

--- a/tests/test_plugin_contract.py
+++ b/tests/test_plugin_contract.py
@@ -477,6 +477,20 @@ def test_safe_write_registry_writes_compact_json(tmp_path):
     assert content == '{"skills":[{"name":"demo","repo":"owner/repo"}]}'
 
 
+def test_safe_write_registry_replaces_existing_file(tmp_path, monkeypatch):
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text('{"skills":["stale"]}', encoding="utf-8")
+
+    def fail_rename(self, target):
+        raise FileExistsError("Windows refuses to overwrite a target with rename")
+
+    monkeypatch.setattr(Path, "rename", fail_rename)
+
+    assert rebuild_registry.safe_write_registry(registry_path, {"skills": []})
+    assert registry_path.read_text(encoding="utf-8") == '{"skills":[]}'
+    assert not registry_path.with_suffix(".json.tmp").exists()
+
+
 def test_safe_write_registry_raises_on_write_failure(tmp_path):
     registry_path = tmp_path / "missing" / "registry.json"
 


### PR DESCRIPTION
## What changed

- Replace the temporary registry file instead of renaming it onto the destination.
- Add a cross-platform regression test that simulates Windows rename semantics for an existing target.

## Why

`Path.rename()` cannot overwrite an existing destination on Windows, so every rebuild after the first failed before updating `registry.json`.

## Checks

- `.venv\\Scripts\\python.exe -m pytest -q -o addopts='' tests\\test_plugin_contract.py`
- `.venv\\Scripts\\python.exe -m ruff check scripts\\rebuild_registry.py tests\\test_plugin_contract.py`
- `.venv\\Scripts\\python.exe -m py_compile scripts\\rebuild_registry.py`
