### PR TITLE
feat: align taxonomy reporting and category audits

### DIFF
--- a/docs/js/app-render.js
+++ b/docs/js/app-render.js
@@ -58,7 +58,7 @@ async function showLeaderboard(categoryFilter = '') {
 function createLeaderboardCard(skill, rank) {
     const name = skill.n;
     const description = skill.d;
-    const category = CATEGORY_NAMES[skill.c] || skill.c;
+    const category = categoryDisplayName(skill.c);
     const stars = skill.r;
     const install = skill.i;
     const isFavorite = state.favorites.includes(install);
@@ -153,7 +153,7 @@ function renderCategoryChart() {
         .map(category => [
             category.code,
             Number(category.count || 0),
-            category.name || CATEGORY_NAMES[category.code] || category.code
+            categoryReportingLabel(category.code)
         ])
         .filter(([, count]) => count > 0)
         .sort((a, b) => b[1] - a[1]);
@@ -254,7 +254,7 @@ function createPluginCard(plugin) {
     const commands = plugin.commands || [];
     const hooks = plugin.hooks || [];
     const tags = plugin.tags || [];
-    const category = CATEGORY_NAMES[CATEGORY_CODES_REVERSE[plugin.category]] || plugin.category || 'Other';
+    const category = categoryDisplayName(plugin.category);
 
     const skillsHtml = skills.slice(0, 6).map(s =>
         `<span class="plugin-skill-tag">${escapeHtml(s)}</span>`
@@ -388,7 +388,7 @@ function showRandomSkill() {
 function createSkillCard(skill, isFeatured = false, showFavoriteBtn = true) {
     const name = isFeatured ? skill.name : skill.n;
     const description = isFeatured ? skill.description : skill.d;
-    const category = isFeatured ? skill.category : CATEGORY_NAMES[skill.c] || skill.c;
+    const category = categoryDisplayName(isFeatured ? skill.category : skill.c);
     const categoryCode = isFeatured ? skill.category : skill.c;
     const tags = isFeatured ? (skill.tags || []) : (skill.g || []);
     const stars = isFeatured ? skill.stars : skill.r;
@@ -502,7 +502,7 @@ async function showSkillDetail(card) {
         <p style="margin-bottom: 1rem; color: var(--text-secondary);">${escapeHtml(skill.d)}</p>
 
         <div style="margin-bottom: 1rem;">
-            <strong>Category:</strong> ${CATEGORY_NAMES[skill.c] || skill.c}<br>
+            <strong>Category:</strong> ${escapeHtml(categoryDisplayName(skill.c))}<br>
             <strong>Stars:</strong> ${skill.r > 0 ? '⭐ ' + skill.r.toLocaleString() : 'N/A'}
         </div>
 

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -7,6 +7,7 @@
 const CONFIG = {
     INDEX_URL: 'search-index-lite.json',
     LEGACY_INDEX_URL: 'search-index.json',
+    TAXONOMY_URL: 'category-taxonomy.json',
     FEATURED_URL: 'featured.json',
     CATEGORIES_URL: 'categories/index.json',
     STATS_URL: 'stats.json',
@@ -28,24 +29,11 @@ const CONFIG = {
     }
 };
 
-const CATEGORY_NAMES = {
-    'dev': 'Development',
-    'ops': 'DevOps',
-    'sec': 'Security',
-    'doc': 'Documents',
-    'des': 'Design',
-    'tst': 'Testing',
-    'prd': 'Product',
-    'mkt': 'Marketing',
-    'pro': 'Productivity',
-    'dat': 'Data',
-    'off': 'Official',
-    'oth': 'Other'
-};
-
-const CATEGORY_CODES_REVERSE = Object.fromEntries(
-    Object.entries(CATEGORY_NAMES).map(([code, name]) => [name.toLowerCase(), code])
-);
+const CATEGORY_NAMES = {};
+const CATEGORY_CODES_REVERSE = {};
+const CATEGORY_META_BY_CODE = {};
+const CATEGORY_META_BY_SLUG = {};
+let DEFAULT_CATEGORY_CODE = 'oth';
 
 const CATEGORY_COLORS = {
     'dev': '#00fff2',
@@ -81,6 +69,7 @@ let state = {
     currentSourceFilter: '',
     currentTagFilters: [],
     categoryCache: {},
+    taxonomy: null,
     favorites: JSON.parse(localStorage.getItem('skillFavorites') || '[]'),
     theme: localStorage.getItem('theme') || 'dark',
     isLoading: true
@@ -143,14 +132,49 @@ async function fetchJson(url) {
 
 function normalizeCategoryCode(category) {
     if (!category) {
-        return 'oth';
+        return DEFAULT_CATEGORY_CODE;
     }
 
     const normalized = String(category).trim().toLowerCase();
+    if (!normalized) {
+        return DEFAULT_CATEGORY_CODE;
+    }
     if (CATEGORY_NAMES[normalized]) {
         return normalized;
     }
-    return CATEGORY_CODES_REVERSE[normalized] || 'oth';
+    return CATEGORY_CODES_REVERSE[normalized] || normalized;
+}
+
+function configureCategoryTaxonomy(payload) {
+    Object.keys(CATEGORY_NAMES).forEach(key => delete CATEGORY_NAMES[key]);
+    Object.keys(CATEGORY_CODES_REVERSE).forEach(key => delete CATEGORY_CODES_REVERSE[key]);
+    Object.keys(CATEGORY_META_BY_CODE).forEach(key => delete CATEGORY_META_BY_CODE[key]);
+    Object.keys(CATEGORY_META_BY_SLUG).forEach(key => delete CATEGORY_META_BY_SLUG[key]);
+
+    payload.categories.forEach(category => {
+        CATEGORY_NAMES[category.code] = category.display_name;
+        CATEGORY_CODES_REVERSE[category.slug] = category.code;
+        CATEGORY_META_BY_CODE[category.code] = category;
+        CATEGORY_META_BY_SLUG[category.slug] = category;
+    });
+    DEFAULT_CATEGORY_CODE = payload.default_code;
+}
+
+function categoryDisplayName(category) {
+    const code = normalizeCategoryCode(category);
+    return CATEGORY_NAMES[code] || String(category || CATEGORY_NAMES[DEFAULT_CATEGORY_CODE] || 'Other');
+}
+
+function categoryReportingLabel(category) {
+    const code = normalizeCategoryCode(category);
+    const metadata = CATEGORY_META_BY_CODE[code];
+    if (!metadata?.parent) {
+        return categoryDisplayName(category);
+    }
+    const parent = CATEGORY_META_BY_SLUG[metadata.parent];
+    return parent
+        ? `${parent.display_name} › ${metadata.display_name}`
+        : metadata.display_name;
 }
 
 function normalizeSkillRecord(skill) {
@@ -244,15 +268,19 @@ function updateSearchScopeDisplay() {
 
 async function init() {
     try {
-        const [indexData, featuredData, categoriesData, statsData, pluginsData] = await Promise.all([
-            loadSearchIndex(),
+        const [rawIndex, taxonomyData, featuredData, categoriesData, statsData, pluginsData] = await Promise.all([
+            fetchJson(CONFIG.INDEX_URL),
+            fetchJson(CONFIG.TAXONOMY_URL),
             fetch(CONFIG.FEATURED_URL).then(r => r.json()).catch(() => ({ skills: [] })),
             fetch(CONFIG.CATEGORIES_URL).then(r => r.json()).catch(() => ({ categories: [] })),
             fetch(CONFIG.STATS_URL).then(r => r.json()).catch(() => ({})),
             fetch(CONFIG.PLUGINS_URL).then(r => r.json()).catch(() => ({ plugins: [] }))
         ]);
 
-        state.index = indexData;
+        validateCategoryTaxonomy(taxonomyData);
+        configureCategoryTaxonomy(taxonomyData);
+        state.index = normalizeSearchIndex(rawIndex);
+        state.taxonomy = taxonomyData;
         state.featured = featuredData.skills || [];
         state.plugins = pluginsData.plugins || [];
         state.categories = categoriesData.categories || [];
@@ -285,7 +313,7 @@ function populateCategoryFilter() {
     state.categories.forEach(cat => {
         const option = document.createElement('option');
         option.value = cat.code;
-        option.textContent = `${cat.name} (${cat.count.toLocaleString()})`;
+        option.textContent = `${categoryReportingLabel(cat.code)} (${cat.count.toLocaleString()})`;
         elements.categoryFilter.appendChild(option);
     });
 }
@@ -294,7 +322,7 @@ function populateLeaderboardCategoryFilter() {
     state.categories.forEach(cat => {
         const option = document.createElement('option');
         option.value = cat.code;
-        option.textContent = `${cat.name}`;
+        option.textContent = categoryReportingLabel(cat.code);
         elements.leaderboardCategory.appendChild(option);
     });
 }

--- a/docs/js/artifact-api.js
+++ b/docs/js/artifact-api.js
@@ -19,6 +19,51 @@ function requireNonNegativeInteger(value, label) {
     }
 }
 
+function validateCategoryTaxonomy(payload) {
+    requireExactFields(payload, ['schema_version', 'taxonomy_schema_version', 'updated_at',
+        'default_category', 'default_code', 'category_count', 'categories'],
+    'Category taxonomy');
+    requireSchemaOne(payload, 'Category taxonomy');
+    requireNonNegativeInteger(payload.category_count, 'Category taxonomy category_count');
+    if (!Number.isInteger(payload.taxonomy_schema_version) ||
+        payload.taxonomy_schema_version <= 0 ||
+        typeof payload.updated_at !== 'string' || !payload.updated_at ||
+        typeof payload.default_category !== 'string' || !payload.default_category ||
+        typeof payload.default_code !== 'string' || !payload.default_code ||
+        !Array.isArray(payload.categories) ||
+        payload.categories.length !== payload.category_count) {
+        throw new Error('Category taxonomy count or identity mismatch');
+    }
+
+    const bySlug = new Map();
+    const codes = new Set();
+    payload.categories.forEach((category, index) => {
+        requireExactFields(category, ['slug', 'code', 'display_name', 'parent'],
+            `Category taxonomy entry ${index}`);
+        if (typeof category.slug !== 'string' || !category.slug ||
+            typeof category.code !== 'string' || !category.code ||
+            typeof category.display_name !== 'string' || !category.display_name ||
+            typeof category.parent !== 'string' ||
+            bySlug.has(category.slug) || codes.has(category.code)) {
+            throw new Error('Category taxonomy entry identity mismatch');
+        }
+        bySlug.set(category.slug, category);
+        codes.add(category.code);
+    });
+
+    const defaultEntry = bySlug.get(payload.default_category);
+    if (!defaultEntry || defaultEntry.code !== payload.default_code) {
+        throw new Error('Category taxonomy default mismatch');
+    }
+    payload.categories.forEach(category => {
+        if (!category.parent) return;
+        const parent = bySlug.get(category.parent);
+        if (!parent || parent.slug === category.slug || parent.parent) {
+            throw new Error('Category taxonomy parent mismatch');
+        }
+    });
+}
+
 function isSafeArtifactPath(path, prefix) {
     return typeof path === 'string' && path.startsWith(prefix) &&
         !path.startsWith('/') && !path.includes('\\') && !path.includes('://') &&

--- a/docs/js/artifact-api.js
+++ b/docs/js/artifact-api.js
@@ -25,23 +25,26 @@ function validateCategoryTaxonomy(payload) {
     'Category taxonomy');
     requireSchemaOne(payload, 'Category taxonomy');
     requireNonNegativeInteger(payload.category_count, 'Category taxonomy category_count');
-    if (!Number.isInteger(payload.taxonomy_schema_version) ||
-        payload.taxonomy_schema_version <= 0 ||
+    if (payload.taxonomy_schema_version !== 2 ||
         typeof payload.updated_at !== 'string' || !payload.updated_at ||
         typeof payload.default_category !== 'string' || !payload.default_category ||
         typeof payload.default_code !== 'string' || !payload.default_code ||
         !Array.isArray(payload.categories) ||
+        payload.category_count !== 42 ||
         payload.categories.length !== payload.category_count) {
         throw new Error('Category taxonomy count or identity mismatch');
     }
 
     const bySlug = new Map();
     const codes = new Set();
+    const canonicalIdentifier = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
     payload.categories.forEach((category, index) => {
         requireExactFields(category, ['slug', 'code', 'display_name', 'parent'],
             `Category taxonomy entry ${index}`);
-        if (typeof category.slug !== 'string' || !category.slug ||
-            typeof category.code !== 'string' || !category.code ||
+        if (typeof category.slug !== 'string' ||
+            !canonicalIdentifier.test(category.slug) ||
+            typeof category.code !== 'string' ||
+            !canonicalIdentifier.test(category.code) ||
             typeof category.display_name !== 'string' || !category.display_name ||
             typeof category.parent !== 'string' ||
             bySlug.has(category.slug) || codes.has(category.code)) {
@@ -62,6 +65,9 @@ function validateCategoryTaxonomy(payload) {
             throw new Error('Category taxonomy parent mismatch');
         }
     });
+    if (payload.categories.filter(category => !category.parent).length !== 12) {
+        throw new Error('Category taxonomy root count mismatch');
+    }
 }
 
 function isSafeArtifactPath(path, prefix) {

--- a/docs/plan/GH254/product.md
+++ b/docs/plan/GH254/product.md
@@ -1,0 +1,65 @@
+# GH254 产品规格：canonical taxonomy 展示层与分类准确率证据
+
+关联 issue: https://github.com/majiayu000/claude-skill-registry-core/issues/254
+基线: `1d307fd932e210e3d6066888c87d1761a557885b`
+状态: `Approved for implementation by implx auth_mode:auto`
+复杂度: `medium`
+
+## 背景与问题
+
+canonical taxonomy 已闭合为 42 个 active 类别，但 Pages 仍把 12 个旧类别码作为显示权威，
+导致 full-record 与 mini-record 对新类别的归一化结果不一致。taxonomy 已声明可选 `parent`
+报告关系，却没有任何实际 parent；现有分类抽样又是单一全局池，不能保证覆盖无关键词大类。
+
+## 目标
+
+- 让 42 类的 slug、code、display name 和 parent 由 taxonomy 单一来源驱动 Pages。
+- 建立两层 reporting hierarchy，不移动 skill、不改变叶子分类和过滤语义。
+- 为六个重点类别建立确定性分层样本及 fail-closed 人工准确率复核门禁。
+
+## 非目标
+
+- 不批量重分类 archive skill，不修改 data/main 仓库。
+- 不给无关键词类别补虚假关键词，不把抽样建议自动应用为迁移。
+- 不改变 category shard、search shard、安装路径或稳定去重键。
+- 不把 `other` 比例当作准确率。
+
+## 可观察行为不变量
+
+1. `B-001`：发布侧必须输出完整 42 类 taxonomy sidecar；每项包含唯一 `slug`、唯一
+   `code`、非空 `display_name` 和可选 `parent`，且 slug 与 code 可双向无损解析。
+2. `B-002`：taxonomy sidecar 缺失、字段不闭合、计数不符、重复 slug/code、未知 parent、
+   自 parent 或超过两层时，构建/Pages 必须显式失败，禁止静默回退为 `other`。
+3. `B-003`：taxonomy 必须形成 12 个顶层类别和一层子类别；`parent` 只影响报告与显示，
+   不继承计数、不移动 archive、不改变叶子过滤结果。
+4. `B-004`：Pages 对 canonical slug 或 code 输入返回同一个 canonical code；非空未知输入
+   必须保留为可见原值，只有空输入才使用 taxonomy default。
+5. `B-005`：分类质量样本必须按固定 seed、固定 quota 分层覆盖
+   `integration`、`domains`、`skills`、`context-management`、`data`、`development`；
+   输入遍历顺序变化不得改变成员、分层 digest 或总 digest。
+6. `B-006`：每条样本必须记录路径、当前类别、bounded 语义摘录、语义来源、SKILL.md
+   SHA-256 和 metadata SHA-256；源文件变化后旧复核证据必须失效。
+7. `B-007`：任一目标类别人口不足、样本缺失、重复复核、digest/hash 不匹配、expected
+   category 非 canonical 或准确率低于阈值时，复核门禁必须失败；不得静默缩减 quota。
+8. `B-008`：抽样和复核均为审计证据，不得自动修改 taxonomy、metadata 或 skill 路径；
+   既有 canonical publish/security/intake 行为保持兼容。
+
+## Boundary checklist
+
+| 边界 | 结论 |
+| --- | --- |
+| Empty / missing input | covered: `B-002`, `B-004`, `B-007` |
+| Error and failure paths | covered: `B-002`, `B-007` |
+| Authorization / permission | N/A：本变更只生成和验证本地/Pages 数据，不新增权限路径 |
+| Concurrency / ordering | covered: `B-005` |
+| Retry / idempotency | covered: `B-005`, `B-006` |
+| Illegal state transitions | covered: `B-002`, `B-007` |
+| Compatibility / migration | covered: `B-003`, `B-008` |
+| Degradation / fallback | covered: `B-002`, `B-004` |
+| Evidence and audit integrity | covered: `B-005`, `B-006`, `B-007` |
+| Cancellation / partial completion | N/A：命令是可重复执行的离线确定性检查 |
+
+## 完成条件
+
+`B-001` 至 `B-008` 均有 fresh deterministic tests；完整 pytest、lint、独立 reviewer、
+当前 CI、review threads、merge state 与 PR gate 全绿后才可合并。

--- a/docs/plan/GH254/tasks.md
+++ b/docs/plan/GH254/tasks.md
@@ -1,0 +1,53 @@
+# GH254 任务计划
+
+关联 issue: https://github.com/majiayu000/claude-skill-registry-core/issues/254
+产品规格: `docs/plan/GH254/product.md`
+技术规格: `docs/plan/GH254/tech.md`
+状态: `Approved for implementation by implx auth_mode:auto`
+
+## `SP254-T1`：闭合 taxonomy code 与两层 parent 契约
+
+- Owner: `implementation_lane`
+- Dependencies: none
+- Covers: `B-001`, `B-002`, `B-003`
+- Done when: 42 类双向唯一，恰有 12 个 root，非法 parent 图 fail closed。
+- Verify: `python -m pytest -q tests/test_category_taxonomy.py`
+
+## `SP254-T2`：生成 sidecar 并让 Pages 动态消费
+
+- Owner: `implementation_lane`
+- Dependencies: `SP254-T1`
+- Covers: `B-001`, `B-002`, `B-003`, `B-004`, `B-008`
+- Done when: sidecar exact-shape；42 类 slug/code 不丢失；unknown non-empty 可见；empty 用 default。
+- Verify: `python -m pytest -q tests/test_build_search_index.py tests/test_pages_request_budget.py`
+
+## `SP254-T3`：实现确定性分层样本与人工准确率门禁
+
+- Owner: `implementation_lane`
+- Dependencies: `SP254-T1`
+- Covers: `B-005`, `B-006`, `B-007`, `B-008`
+- Done when: 六层固定 quota/digest；证据缺失、过期、重复或低准确率均 fail closed。
+- Verify: `python -m pytest -q tests/test_audit_category_quality.py tests/test_check_category_sample_review.py`
+
+## `SP254-T4`：全量验证、独立审查与交付
+
+- Owner: `verification_owner`
+- Dependencies: `SP254-T1`, `SP254-T2`, `SP254-T3`
+- Covers: `B-001` through `B-008`
+- Done when: focused/full tests、lint、CI、review threads、独立 reviewer 和 PR gate 全绿。
+- Verify:
+
+```bash
+python scripts/check_taxonomy_governance.py --strict-canonical
+python -m pytest -q
+ruff check scripts tests
+git diff --check
+```
+
+## Coverage check
+
+Product invariant set:
+`{B-001,B-002,B-003,B-004,B-005,B-006,B-007,B-008}`.
+
+Task coverage union:
+`{B-001,B-002,B-003,B-004,B-005,B-006,B-007,B-008}`.

--- a/docs/plan/GH254/tech.md
+++ b/docs/plan/GH254/tech.md
@@ -1,0 +1,110 @@
+# GH254 技术规格：taxonomy sidecar、两层报告关系与分层复核门禁
+
+关联 issue: https://github.com/majiayu000/claude-skill-registry-core/issues/254
+产品规格: `docs/plan/GH254/product.md`
+基线: `1d307fd932e210e3d6066888c87d1761a557885b`
+状态: `Approved for implementation by implx auth_mode:auto`
+
+```json
+{
+  "specrail-planned-changes": {
+    "issue": 254,
+    "complete": true,
+    "paths": [
+      "taxonomy/categories.yaml",
+      "scripts/category_taxonomy.py",
+      "scripts/build_search_index.py",
+      "scripts/audit_category_quality.py",
+      "scripts/check_category_sample_review.py",
+      "docs/js/artifact-api.js",
+      "docs/js/app.js",
+      "docs/js/app-render.js",
+      "docs/plan/canonical-taxonomy-governance-spec.md",
+      "docs/plan/GH254/product.md",
+      "docs/plan/GH254/tech.md",
+      "docs/plan/GH254/tasks.md",
+      "tests/test_category_taxonomy.py",
+      "tests/test_build_search_index.py",
+      "tests/test_audit_category_quality.py",
+      "tests/test_check_category_sample_review.py",
+      "tests/test_pages_request_budget.py"
+    ],
+    "spec_refs": ["B-001", "B-002", "B-003", "B-004", "B-005", "B-006", "B-007", "B-008"]
+  }
+}
+```
+
+## 当前根因与代码锚点
+
+| 锚点 | 当前行为 |
+| --- | --- |
+| `scripts/category_taxonomy.py:47-123` | 只有 slug→code；未保留 code→slug 索引 |
+| `scripts/category_taxonomy.py:234-246` | parent 仅检查存在和 deprecated，不拒绝自环、环或深链 |
+| `docs/js/app.js:31-48` | Pages 手写 12 个旧 code/display name |
+| `docs/js/app.js:144-165` | 未知非空类别被转换为 `oth` |
+| `scripts/audit_category_quality.py:89-258` | 全量启发式报告，无 per-category quota 样本 |
+
+## 技术设计
+
+### 1. Canonical taxonomy contract
+
+`CategoryTaxonomy` 保存唯一 `codes` 反向索引、审计 sampling policy，并提供：
+
+- `slug_for_code()`：code→slug，未知默认拒绝；
+- `public_contract(updated_at)`：生成 versioned sidecar；
+- parent graph 验证：parent 必须 active、不得等于自身、parent 自身不得再有 parent。
+
+taxonomy 使用 12 个既有 canonical 类别作为报告根；其他类别至多声明一个 root parent。
+这是 reporting-only 元数据，`resolve()`、publishability、directory routing 和类别计数不继承。
+
+### 2. Pages sidecar 与 fail-closed 初始化
+
+`build_search_index.py` 生成 `docs/category-taxonomy.json`。Pages 启动时与 lite index 并行读取，
+先由 `artifact-api.js` 做 exact-shape、唯一性、default 与 parent 深度检查，再建立运行时映射，
+之后才归一化搜索记录。
+
+`normalizeCategoryCode()` 接受 slug 或 code；unknown non-empty 原样返回，empty 使用 sidecar
+default code。卡片、modal、filter、leaderboard 与 chart 使用动态 display name；子类别显示为
+`Parent › Child`，计数仍是叶子直接计数。
+
+### 3. 分层样本与准确率门禁
+
+`taxonomy/categories.yaml` 声明固定 seed、quota 和六个 strata。`audit_category_quality.py`
+先按路径 hash 在每层选择最小 N 项，只读取入选项的 bounded 内容，输出：
+
+- policy、population/sample count；
+- path、current category、description/excerpt、semantic sources；
+- source/metadata SHA-256、sample key；
+- per-stratum digest 和 overall digest。
+
+人口小于 quota 时 sample report 为 failed。`check_category_sample_review.py` 读取人工 review
+文件，要求 sample digest、路径集合和 source hashes 完全匹配，expected category 是 active
+canonical，并计算 overall/per-category accuracy；低于阈值或证据不完整均非零退出。
+
+### 4. 兼容与回滚
+
+sidecar 是新增小型只读产物，不改变 static artifact API v1 的既有 pointer/shard shape。
+回滚可整体 revert sidecar、动态映射、parent 与 sample gate；不需要 archive/data migration。
+
+## Product-to-test mapping
+
+| Behavior invariant | Implementation area | Verification |
+| --- | --- | --- |
+| `B-001`, `B-002` | taxonomy loader + sidecar validator | taxonomy/build/Pages invalid-shape tests |
+| `B-003` | YAML parents + parent graph validator + labels | 12 roots、单层、计数不变 tests |
+| `B-004` | Pages runtime maps | 42 类 slug/code round-trip + unknown/empty tests |
+| `B-005`, `B-006` | stratified sample builder | reversed input、hash/digest、bounded evidence tests |
+| `B-007` | sample review checker | missing/duplicate/stale/noncanonical/threshold negative fixtures |
+| `B-008` | audit-only interfaces | no write/migration contract tests and existing suite |
+
+## Deterministic checks
+
+```bash
+python -m pytest -q tests/test_category_taxonomy.py tests/test_build_search_index.py \
+  tests/test_audit_category_quality.py tests/test_check_category_sample_review.py \
+  tests/test_pages_request_budget.py
+python scripts/check_taxonomy_governance.py --strict-canonical
+python -m pytest -q
+ruff check scripts tests
+git diff --check
+```

--- a/docs/plan/canonical-taxonomy-governance-spec.md
+++ b/docs/plan/canonical-taxonomy-governance-spec.md
@@ -48,6 +48,17 @@ Each category declares:
 Only `active` categories are publishable. `other` is an active fallback bucket,
 but it should shrink through reviewed migrations.
 
+`parent` is reporting-only metadata. The current taxonomy has exactly 12 roots
+and at most one child layer. A parent must be an active root; self-parenting and
+third-level relationships are invalid. Parent relationships do not move archive
+entries, inherit counts, or change leaf-category filtering.
+
+The top-level `audit_sampling` policy declares the fixed seed, per-category
+quota, and ordered review strata. The current high-priority strata are the four
+large categories without keyword rules (`integration`, `domains`, `skills`,
+`context-management`) plus `data` and `development` as neighboring control
+groups.
+
 Legacy names live in the top-level `legacy_migrations` map, outside the
 publishable category set. Entries may define a deterministic `target` or mark
 the old slug as `review_required`. Default resolution does not use legacy
@@ -243,6 +254,13 @@ Source intake gate:
 
 Category artifact gate:
 
+- `scripts/build_search_index.py` emits `docs/category-taxonomy.json` from the
+  canonical taxonomy. Pages validates its exact shape, unique slug/code pairs,
+  default pair, count, and two-level parent relationships before normalizing
+  search records.
+- Pages uses the sidecar for all 42 display names and slug/code normalization.
+  Unknown non-empty values remain visible for diagnosis; only empty values use
+  the canonical default category.
 - `scripts/check_category_artifacts.py` verifies every
   `docs/categories/<category>.json` file is a small pointer.
 - It fails if a pointer contains `skills`, lacks `deprecated_full_payload`,
@@ -263,6 +281,21 @@ Release acceptance report:
 - The readiness report is informational. It does not implement an `other`
   count publish gate, and it must not be wired into publish as a blocker without
   a separate maintainer decision.
+
+Category accuracy evidence gate:
+
+- `scripts/audit_category_quality.py --stratified-sample` selects the smallest
+  deterministic path hashes independently within every configured stratum. It
+  fails instead of shrinking a quota when a category population is too small.
+- Each selected row records a bounded semantic excerpt, semantic field sources,
+  path, current category, sample key, and SHA-256 hashes for `SKILL.md` and
+  `metadata.json`. Per-stratum and overall digests make the artifact
+  order-independent and tamper-evident.
+- `scripts/check_category_sample_review.py` requires one human review per sample
+  path with matching digest and source hashes. Missing, duplicate, stale, extra,
+  malformed, or non-canonical evidence fails closed.
+- Accuracy is enforced both overall and per category. The check is audit-only:
+  it never changes taxonomy, metadata, or archive paths.
 
 ## Operating Flow
 
@@ -292,3 +325,8 @@ Release acceptance report:
   boundaries and blocked-label guidance for common noncanonical proposals.
 - Migration planning still produces audited review queues for unknown and legacy
   inputs.
+- The Pages taxonomy sidecar contains all 42 active categories, exactly 12
+  reporting roots, and no relationship deeper than one child layer.
+- Category quality sampling covers every configured stratum at its full quota;
+  current source hashes and complete per-category review accuracy must pass
+  before the evidence is accepted.

--- a/scripts/audit_category_quality.py
+++ b/scripts/audit_category_quality.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 from collections import Counter
@@ -16,6 +17,7 @@ from category_taxonomy import (
     category_aliases,
     category_keywords,
     category_slug,
+    get_taxonomy,
     resolve_category,
 )
 from utils import extract_frontmatter, load_metadata, skill_semantic_fields
@@ -99,6 +101,143 @@ def best_suggestion(
 
 def compact_examples(items: list[dict[str, Any]], limit: int) -> list[dict[str, Any]]:
     return items[: max(limit, 0)]
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def canonical_digest(value: Any) -> str:
+    payload = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _sample_identity(seed: str, category: str, rel: Path) -> str:
+    return hashlib.sha256(f"{seed}|{category}|{rel.as_posix()}".encode()).hexdigest()
+
+
+def build_stratified_sample(
+    skills_dir: Path,
+    *,
+    content_chars: int = 2048,
+) -> dict[str, Any]:
+    taxonomy = get_taxonomy()
+    policy = taxonomy.audit_sampling
+    eligible = set(policy.categories)
+    candidates: dict[str, list[dict[str, Any]]] = {
+        category: [] for category in policy.categories
+    }
+    errors: list[str] = []
+
+    for skill_dir, rel in iter_skill_dirs(skills_dir):
+        metadata = load_metadata(skill_dir)
+        declared = (
+            metadata.get("category")
+            if isinstance(metadata.get("category"), str)
+            else rel.parts[0] if rel.parts else taxonomy.default_category
+        )
+        current_category = resolve_category(declared, allow_unknown=True)
+        if current_category not in eligible:
+            continue
+        candidates[current_category].append(
+            {
+                "skill_dir": skill_dir,
+                "rel": rel,
+                "sample_key": _sample_identity(
+                    policy.seed,
+                    current_category,
+                    rel,
+                ),
+            }
+        )
+
+    strata: list[dict[str, Any]] = []
+    digest_inputs: list[dict[str, str]] = []
+    for category in policy.categories:
+        population = sorted(
+            candidates[category],
+            key=lambda item: (item["sample_key"], item["rel"].as_posix()),
+        )
+        if len(population) < policy.per_category:
+            errors.append(
+                f"{category}: population {len(population)} is below quota "
+                f"{policy.per_category}"
+            )
+
+        samples: list[dict[str, Any]] = []
+        for candidate in population[: policy.per_category]:
+            skill_dir = candidate["skill_dir"]
+            rel = candidate["rel"]
+            skill_path = skill_dir / "SKILL.md"
+            metadata_path = skill_dir / "metadata.json"
+            if not metadata_path.is_file():
+                errors.append(f"{rel.as_posix()}: metadata.json is missing")
+                continue
+
+            content = read_text_prefix(skill_path, max_chars=max(content_chars, 8192))
+            metadata = load_metadata(skill_dir)
+            frontmatter = extract_frontmatter(content)
+            semantics = skill_semantic_fields(
+                skill_dir,
+                metadata=metadata,
+                frontmatter=frontmatter,
+                rel=rel,
+                content=content,
+                content_chars=content_chars,
+            )
+            excerpt = " ".join(content[:content_chars].split())
+            samples.append(
+                {
+                    "path": rel.as_posix(),
+                    "name": semantics["name"],
+                    "current_category": category,
+                    "description": semantics["description"],
+                    "content_excerpt": excerpt,
+                    "semantic_sources": semantics["sources"],
+                    "source_sha256": file_sha256(skill_path),
+                    "metadata_sha256": file_sha256(metadata_path),
+                    "sample_key": candidate["sample_key"],
+                }
+            )
+
+        stratum_digest = canonical_digest(samples)
+        digest_inputs.append({"category": category, "digest": stratum_digest})
+        strata.append(
+            {
+                "category": category,
+                "population_count": len(population),
+                "sample_count": len(samples),
+                "quota": policy.per_category,
+                "digest": stratum_digest,
+                "samples": samples,
+            }
+        )
+
+    overall_digest = canonical_digest(digest_inputs)
+    return {
+        "schema_version": policy.schema_version,
+        "status": "failed" if errors else "complete",
+        "skills_dir": str(skills_dir),
+        "policy": {
+            "seed": policy.seed,
+            "per_category": policy.per_category,
+            "categories": list(policy.categories),
+            "content_chars": content_chars,
+        },
+        "sample_count": sum(stratum["sample_count"] for stratum in strata),
+        "digest": overall_digest,
+        "strata": strata,
+        "errors": errors,
+    }
 
 
 def build_report(
@@ -267,28 +406,39 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--small-category-threshold", type=int, default=10)
     parser.add_argument("--limit-candidates", type=int, default=100)
     parser.add_argument("--limit-examples", type=int, default=20)
+    parser.add_argument(
+        "--stratified-sample",
+        action="store_true",
+        help="Emit the deterministic per-category review sample instead of the heuristic report.",
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    report = build_report(
-        args.skills_dir,
-        include_frontmatter=args.include_frontmatter,
-        content_chars=args.content_chars,
-        min_score=args.min_score,
-        min_delta=args.min_delta,
-        small_category_threshold=args.small_category_threshold,
-        limit_candidates=args.limit_candidates,
-        limit_examples=args.limit_examples,
-    )
+    if args.stratified_sample:
+        report = build_stratified_sample(
+            args.skills_dir,
+            content_chars=args.content_chars or 2048,
+        )
+    else:
+        report = build_report(
+            args.skills_dir,
+            include_frontmatter=args.include_frontmatter,
+            content_chars=args.content_chars,
+            min_score=args.min_score,
+            min_delta=args.min_delta,
+            small_category_threshold=args.small_category_threshold,
+            limit_candidates=args.limit_candidates,
+            limit_examples=args.limit_examples,
+        )
     payload = json.dumps(report, indent=2, ensure_ascii=False)
     if args.output:
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(payload + "\n", encoding="utf-8")
     else:
         print(payload)
-    return 0
+    return 1 if report.get("status") == "failed" else 0
 
 
 if __name__ == "__main__":

--- a/scripts/audit_category_quality.py
+++ b/scripts/audit_category_quality.py
@@ -129,8 +129,9 @@ def build_stratified_sample(
     skills_dir: Path,
     *,
     content_chars: int = 2048,
+    taxonomy: Any | None = None,
 ) -> dict[str, Any]:
-    taxonomy = get_taxonomy()
+    taxonomy = taxonomy or get_taxonomy()
     policy = taxonomy.audit_sampling
     eligible = set(policy.categories)
     candidates: dict[str, list[dict[str, Any]]] = {

--- a/scripts/build_search_index.py
+++ b/scripts/build_search_index.py
@@ -24,9 +24,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from category_taxonomy import get_category_code, resolve_category
+from category_taxonomy import get_category_code, get_taxonomy, resolve_category
 from index_artifacts import write_category_artifacts, write_search_artifacts, write_signal_artifacts
 from plugin_index import build_plugins_index, load_plugins_with_fallback
+from rebuild_registry import safe_write_json
 from search_sources import (
     count_named_files,
     load_from_registry,
@@ -464,6 +465,10 @@ def build_search_index(
     output_dir.mkdir(parents=True, exist_ok=True)
     categories_dir = output_dir / "categories"
     categories_dir.mkdir(exist_ok=True)
+    safe_write_json(
+        output_dir / "category-taxonomy.json",
+        get_taxonomy().public_contract(updated_at=utc_now_isoformat()),
+    )
 
     search_artifacts = write_search_artifacts(
         search_index["s"],

--- a/scripts/category_taxonomy.py
+++ b/scripts/category_taxonomy.py
@@ -44,12 +44,22 @@ class LegacyCategoryMigration:
 
 
 @dataclass(frozen=True)
+class AuditSamplingPolicy:
+    schema_version: int
+    seed: str
+    per_category: int
+    categories: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class CategoryTaxonomy:
     schema_version: int
     default_category: str
     categories: dict[str, CategoryDefinition]
+    codes: dict[str, str]
     aliases: dict[str, str]
     legacy_migrations: dict[str, LegacyCategoryMigration]
+    audit_sampling: AuditSamplingPolicy
 
     def resolve(
         self,
@@ -73,6 +83,16 @@ class CategoryTaxonomy:
         slug = self.resolve(raw_category, allow_unknown=True, allow_alias=True)
         definition = self.categories.get(slug)
         return definition.code if definition else slug
+
+    def slug_for_code(self, raw_code: str | None, *, allow_unknown: bool = False) -> str:
+        code = category_slug(raw_code or "")
+        if not code:
+            return self.default_category
+        if code in self.codes:
+            return self.codes[code]
+        if allow_unknown:
+            return code
+        raise UnknownCategoryError(f"Unknown category code: {raw_code!r}")
 
     def is_known(self, raw_category: str | None) -> bool:
         slug = category_slug(raw_category or "")
@@ -121,6 +141,25 @@ class CategoryTaxonomy:
             return definition.migrate_to or None
         migration = self.legacy_migrations.get(slug)
         return migration.target if migration else None
+
+    def public_contract(self, *, updated_at: str) -> dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "taxonomy_schema_version": self.schema_version,
+            "updated_at": updated_at,
+            "default_category": self.default_category,
+            "default_code": self.code_for(self.default_category),
+            "category_count": len(self.categories),
+            "categories": [
+                {
+                    "slug": definition.slug,
+                    "code": definition.code,
+                    "display_name": definition.display_name,
+                    "parent": definition.parent,
+                }
+                for definition in self.categories.values()
+            ],
+        }
 
 
 def category_slug(raw_category: str | None) -> str:
@@ -239,9 +278,16 @@ def load_taxonomy(path: Path = DEFAULT_TAXONOMY_PATH) -> CategoryTaxonomy:
                     f"taxonomy category {slug!r} has unknown parent "
                     f"{definition.parent!r}"
                 )
-            if parent_definition.status == "deprecated":
+            if parent_definition.status != "active":
                 raise ValueError(
-                    f"taxonomy category {slug!r} has deprecated parent "
+                    f"taxonomy category {slug!r} has non-active parent "
+                    f"{definition.parent!r}"
+                )
+            if definition.parent == slug:
+                raise ValueError(f"taxonomy category {slug!r} must not parent itself")
+            if parent_definition.parent:
+                raise ValueError(
+                    f"taxonomy category {slug!r} exceeds two reporting levels via "
                     f"{definition.parent!r}"
                 )
         if definition.migrate_to:
@@ -300,12 +346,47 @@ def load_taxonomy(path: Path = DEFAULT_TAXONOMY_PATH) -> CategoryTaxonomy:
             reason=reason,
         )
 
+    sampling_raw = payload.get("audit_sampling")
+    if not isinstance(sampling_raw, dict):
+        raise ValueError("taxonomy audit_sampling must contain an object")
+    sampling_schema_version = sampling_raw.get("schema_version")
+    if sampling_schema_version != 1:
+        raise ValueError("taxonomy audit_sampling schema_version must be 1")
+    sampling_seed = str(sampling_raw.get("seed") or "").strip()
+    if not sampling_seed:
+        raise ValueError("taxonomy audit_sampling seed must be non-empty")
+    sampling_quota = sampling_raw.get("per_category")
+    if (
+        isinstance(sampling_quota, bool)
+        or not isinstance(sampling_quota, int)
+        or sampling_quota <= 0
+    ):
+        raise ValueError("taxonomy audit_sampling per_category must be a positive integer")
+    sampling_categories = _as_string_list(sampling_raw.get("categories"))
+    if not sampling_categories or len(set(sampling_categories)) != len(sampling_categories):
+        raise ValueError("taxonomy audit_sampling categories must be unique and non-empty")
+    for sampling_category in sampling_categories:
+        definition = categories.get(sampling_category)
+        if definition is None or definition.status != "active":
+            raise ValueError(
+                "taxonomy audit_sampling category must be active: "
+                f"{sampling_category!r}"
+            )
+    audit_sampling = AuditSamplingPolicy(
+        schema_version=sampling_schema_version,
+        seed=sampling_seed,
+        per_category=sampling_quota,
+        categories=sampling_categories,
+    )
+
     return CategoryTaxonomy(
         schema_version=int(payload.get("schema_version", 1)),
         default_category=default_category,
         categories=categories,
+        codes=codes,
         aliases=aliases,
         legacy_migrations=legacy_migrations,
+        audit_sampling=audit_sampling,
     )
 
 
@@ -349,6 +430,12 @@ def resolve_category(
 
 def get_category_code(raw_category: str | None, *, allow_alias: bool = False) -> str:
     return get_taxonomy().code_for(raw_category, allow_alias=allow_alias)
+
+
+def get_category_slug_from_code(
+    raw_code: str | None, *, allow_unknown: bool = False
+) -> str:
+    return get_taxonomy().slug_for_code(raw_code, allow_unknown=allow_unknown)
 
 
 def category_keywords() -> dict[str, list[str]]:

--- a/scripts/check_category_sample_review.py
+++ b/scripts/check_category_sample_review.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Fail closed unless a category sample has complete, fresh human review evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from audit_category_quality import canonical_digest, file_sha256
+from category_taxonomy import get_taxonomy
+
+
+class ReviewEvidenceError(ValueError):
+    """Raised when review evidence is incomplete, stale, or non-canonical."""
+
+
+def _exact_fields(value: Any, fields: set[str], label: str) -> None:
+    if not isinstance(value, dict) or set(value) != fields:
+        raise ReviewEvidenceError(f"{label} shape mismatch")
+
+
+def _sample_rows(sample: dict[str, Any]) -> list[dict[str, Any]]:
+    _exact_fields(
+        sample,
+        {
+            "schema_version",
+            "status",
+            "skills_dir",
+            "policy",
+            "sample_count",
+            "digest",
+            "strata",
+            "errors",
+        },
+        "sample",
+    )
+    if sample["schema_version"] != 1 or sample["status"] != "complete":
+        raise ReviewEvidenceError("sample is not complete schema v1")
+    if sample["errors"] or not isinstance(sample["strata"], list):
+        raise ReviewEvidenceError("sample contains errors or invalid strata")
+    _exact_fields(
+        sample["policy"],
+        {"seed", "per_category", "categories", "content_chars"},
+        "sample policy",
+    )
+    policy = sample["policy"]
+    if (
+        not isinstance(policy["seed"], str)
+        or not policy["seed"]
+        or not isinstance(policy["per_category"], int)
+        or policy["per_category"] <= 0
+        or not isinstance(policy["categories"], list)
+        or not policy["categories"]
+        or len(set(policy["categories"])) != len(policy["categories"])
+        or not isinstance(policy["content_chars"], int)
+        or policy["content_chars"] <= 0
+    ):
+        raise ReviewEvidenceError("sample policy identity mismatch")
+
+    rows: list[dict[str, Any]] = []
+    digest_inputs: list[dict[str, str]] = []
+    stratum_categories: list[str] = []
+    sample_fields = {
+        "path",
+        "name",
+        "current_category",
+        "description",
+        "content_excerpt",
+        "semantic_sources",
+        "source_sha256",
+        "metadata_sha256",
+        "sample_key",
+    }
+    for index, stratum in enumerate(sample["strata"]):
+        _exact_fields(
+            stratum,
+            {
+                "category",
+                "population_count",
+                "sample_count",
+                "quota",
+                "digest",
+                "samples",
+            },
+            f"sample stratum {index}",
+        )
+        if not isinstance(stratum["samples"], list):
+            raise ReviewEvidenceError("sample stratum samples must be a list")
+        if (
+            stratum["sample_count"] != len(stratum["samples"])
+            or stratum["quota"] != policy["per_category"]
+            or stratum["sample_count"] != stratum["quota"]
+            or stratum["population_count"] < stratum["quota"]
+        ):
+            raise ReviewEvidenceError("sample stratum count mismatch")
+        for row_index, row in enumerate(stratum["samples"]):
+            _exact_fields(row, sample_fields, f"sample row {index}:{row_index}")
+            if row["current_category"] != stratum["category"]:
+                raise ReviewEvidenceError("sample row category mismatch")
+            for hash_field in ("source_sha256", "metadata_sha256", "sample_key"):
+                if (
+                    not isinstance(row[hash_field], str)
+                    or len(row[hash_field]) != 64
+                    or any(char not in "0123456789abcdef" for char in row[hash_field])
+                ):
+                    raise ReviewEvidenceError(f"sample row invalid {hash_field}")
+        calculated_digest = canonical_digest(stratum["samples"])
+        if stratum["digest"] != calculated_digest:
+            raise ReviewEvidenceError("sample stratum digest mismatch")
+        stratum_categories.append(stratum["category"])
+        digest_inputs.append(
+            {"category": stratum["category"], "digest": calculated_digest}
+        )
+        rows.extend(stratum["samples"])
+    if stratum_categories != policy["categories"]:
+        raise ReviewEvidenceError("sample strata do not match policy categories")
+    if sample["sample_count"] != len(rows):
+        raise ReviewEvidenceError("sample total count mismatch")
+    if sample["digest"] != canonical_digest(digest_inputs):
+        raise ReviewEvidenceError("sample overall digest mismatch")
+    return rows
+
+
+def check_review(
+    sample: dict[str, Any],
+    review: dict[str, Any],
+    *,
+    min_accuracy: float,
+) -> dict[str, Any]:
+    if not 0 <= min_accuracy <= 1:
+        raise ReviewEvidenceError("min_accuracy must be between 0 and 1")
+    rows = _sample_rows(sample)
+    policy = get_taxonomy().audit_sampling
+    if (
+        sample["schema_version"] != policy.schema_version
+        or sample["policy"]["seed"] != policy.seed
+        or sample["policy"]["per_category"] != policy.per_category
+        or sample["policy"]["categories"] != list(policy.categories)
+    ):
+        raise ReviewEvidenceError("sample policy does not match canonical taxonomy")
+
+    skills_dir = Path(sample["skills_dir"]).resolve()
+    for row in rows:
+        rel = Path(row["path"])
+        if (
+            rel.is_absolute()
+            or ".." in rel.parts
+            or rel.name != "SKILL.md"
+        ):
+            raise ReviewEvidenceError(f"unsafe sample path: {row['path']}")
+        source_path = skills_dir / rel
+        metadata_path = source_path.parent / "metadata.json"
+        if not source_path.is_file() or not metadata_path.is_file():
+            raise ReviewEvidenceError(f"sample source is missing: {row['path']}")
+        if (
+            file_sha256(source_path) != row["source_sha256"]
+            or file_sha256(metadata_path) != row["metadata_sha256"]
+        ):
+            raise ReviewEvidenceError(f"sample source changed: {row['path']}")
+
+    _exact_fields(review, {"schema_version", "sample_digest", "reviews"}, "review")
+    if review["schema_version"] != 1 or review["sample_digest"] != sample["digest"]:
+        raise ReviewEvidenceError("review digest does not match sample")
+    if not isinstance(review["reviews"], list):
+        raise ReviewEvidenceError("reviews must be a list")
+
+    sample_by_path = {row.get("path"): row for row in rows}
+    if len(sample_by_path) != len(rows) or None in sample_by_path:
+        raise ReviewEvidenceError("sample paths must be unique and non-empty")
+
+    reviewed: dict[str, dict[str, Any]] = {}
+    active = get_taxonomy().publishable_categories()
+    for index, item in enumerate(review["reviews"]):
+        _exact_fields(
+            item,
+            {"path", "source_sha256", "metadata_sha256", "expected_category"},
+            f"review entry {index}",
+        )
+        path = item["path"]
+        if path in reviewed:
+            raise ReviewEvidenceError(f"duplicate review path: {path}")
+        sample_row = sample_by_path.get(path)
+        if sample_row is None:
+            raise ReviewEvidenceError(f"review path is not sampled: {path}")
+        if (
+            item["source_sha256"] != sample_row.get("source_sha256")
+            or item["metadata_sha256"] != sample_row.get("metadata_sha256")
+        ):
+            raise ReviewEvidenceError(f"stale source hashes for: {path}")
+        if item["expected_category"] not in active:
+            raise ReviewEvidenceError(
+                f"non-canonical expected category for: {path}"
+            )
+        reviewed[path] = item
+
+    missing = sorted(set(sample_by_path) - set(reviewed))
+    if missing:
+        raise ReviewEvidenceError(f"missing review paths: {', '.join(missing[:3])}")
+
+    correct_by_category: Counter[str] = Counter()
+    total_by_category: Counter[str] = Counter()
+    for path, sample_row in sample_by_path.items():
+        category = sample_row["current_category"]
+        total_by_category[category] += 1
+        if reviewed[path]["expected_category"] == category:
+            correct_by_category[category] += 1
+
+    per_category = {}
+    for category in sorted(total_by_category):
+        total = total_by_category[category]
+        accuracy = correct_by_category[category] / total
+        per_category[category] = {
+            "correct": correct_by_category[category],
+            "total": total,
+            "accuracy": accuracy,
+        }
+        if accuracy < min_accuracy:
+            raise ReviewEvidenceError(
+                f"{category} accuracy {accuracy:.3f} is below {min_accuracy:.3f}"
+            )
+
+    overall_correct = sum(correct_by_category.values())
+    overall_accuracy = overall_correct / len(rows) if rows else 0.0
+    if overall_accuracy < min_accuracy:
+        raise ReviewEvidenceError(
+            f"overall accuracy {overall_accuracy:.3f} is below {min_accuracy:.3f}"
+        )
+    return {
+        "schema_version": 1,
+        "status": "passed",
+        "sample_digest": sample["digest"],
+        "min_accuracy": min_accuracy,
+        "correct": overall_correct,
+        "total": len(rows),
+        "accuracy": overall_accuracy,
+        "categories": per_category,
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sample", type=Path, required=True)
+    parser.add_argument("--review", type=Path, required=True)
+    parser.add_argument("--min-accuracy", type=float, default=0.8)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        result = check_review(
+            json.loads(args.sample.read_text(encoding="utf-8")),
+            json.loads(args.review.read_text(encoding="utf-8")),
+            min_accuracy=args.min_accuracy,
+        )
+    except (OSError, json.JSONDecodeError, ReviewEvidenceError) as error:
+        print(json.dumps({"status": "failed", "error": str(error)}, ensure_ascii=False))
+        return 1
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_category_sample_review.py
+++ b/scripts/check_category_sample_review.py
@@ -9,7 +9,11 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
-from audit_category_quality import canonical_digest, file_sha256
+from audit_category_quality import (
+    build_stratified_sample,
+    canonical_digest,
+    file_sha256,
+)
 from category_taxonomy import get_taxonomy
 
 
@@ -143,6 +147,19 @@ def check_review(
         raise ReviewEvidenceError("sample policy does not match canonical taxonomy")
 
     skills_dir = Path(sample["skills_dir"]).resolve()
+    fresh_sample = build_stratified_sample(
+        skills_dir,
+        content_chars=sample["policy"]["content_chars"],
+        taxonomy=get_taxonomy(),
+    )
+    if fresh_sample["status"] != "complete":
+        raise ReviewEvidenceError("current sample population is incomplete")
+    if (
+        fresh_sample["digest"] != sample["digest"]
+        or fresh_sample["strata"] != sample["strata"]
+    ):
+        raise ReviewEvidenceError("sample no longer matches current population")
+
     for row in rows:
         rel = Path(row["path"])
         if (

--- a/taxonomy/categories.yaml
+++ b/taxonomy/categories.yaml
@@ -8,6 +8,17 @@ governance:
     high: "score >= 4 and delta >= 3, or a deterministic legacy migration target"
     medium: "score >= 3 with a clear target but not enough evidence to apply"
     low: "weak signal or conflicting category sources"
+audit_sampling:
+  schema_version: 1
+  seed: canonical-category-quality-v1
+  per_category: 50
+  categories:
+    - integration
+    - domains
+    - skills
+    - context-management
+    - data
+    - development
 legacy_migrations:
   - slug: machine-learning
     target: ai-ml
@@ -141,12 +152,14 @@ legacy_migrations:
 categories:
   - slug: agent
     code: agent
+    parent: ai-ml
     display_name: Agent
     inclusion_rule: "Single-agent behavior, role design, agent instructions, or agent runtime helpers."
     exclusion_rule: "Multi-agent scheduling belongs in `orchestration`; general LLM prompting belongs in `ai-llm`."
     examples: ["agent role templates", "agent memory helpers"]
   - slug: ai-llm
     code: ai-llm
+    parent: ai-ml
     display_name: AI / LLM
     inclusion_rule: "LLM prompting, model use, assistants, chat workflows, and language-model evaluation."
     exclusion_rule: "Model training or ML pipelines belong in `ai-ml`; agent orchestration belongs in `orchestration`."
@@ -161,6 +174,7 @@ categories:
     keywords: [ai, ml, machine-learning, model, training]
   - slug: analysis
     code: analysis
+    parent: data
     display_name: Analysis
     inclusion_rule: "Analysis, synthesis, inspection, reporting, and evidence extraction workflows."
     exclusion_rule: "Data pipelines belong in `data`; product analytics tied to PRDs can use `product`."
@@ -168,6 +182,7 @@ categories:
     keywords: [analysis, analyze, insights]
   - slug: api
     code: api
+    parent: development
     display_name: API
     inclusion_rule: "API design, SDK usage, endpoint work, schema contracts, and OpenAPI-like tasks."
     exclusion_rule: "Cross-product connector workflows belong in `integration`."
@@ -175,6 +190,7 @@ categories:
     keywords: [api, sdk, endpoint, openapi]
   - slug: bash
     code: bash
+    parent: development
     display_name: Bash
     inclusion_rule: "Shell scripting, command-line automation, POSIX tooling, and terminal workflows."
     exclusion_rule: "Application build/debug tasks belong in `development`; deployment automation belongs in `devops`."
@@ -189,12 +205,14 @@ categories:
     keywords: [business, operations, strategy]
   - slug: c-level
     code: c-level
+    parent: business
     display_name: C-Level
     inclusion_rule: "Executive communication, board-level summaries, leadership decisions, and strategic briefs."
     exclusion_rule: "General business process work belongs in `business`."
     examples: ["CEO memo", "board update"]
   - slug: communication
     code: communication
+    parent: creative
     display_name: Communication
     inclusion_rule: "Human communication workflows including email, messaging, announcements, and conversation drafting."
     exclusion_rule: "Marketing campaigns belong in `marketing`; writing craft belongs in `writing`."
@@ -202,6 +220,7 @@ categories:
     keywords: [communication, messaging, email, chat]
   - slug: context-management
     code: context-management
+    parent: ai-ml
     display_name: Context Management
     inclusion_rule: "Context packing, memory, retrieval context, prompt context, and agent state handling."
     exclusion_rule: "General productivity memory tools belong in `productivity`."
@@ -247,6 +266,7 @@ categories:
     keywords: [devops, ci, cd, docker, kubernetes, deploy, infra, infrastructure]
   - slug: documents
     code: doc
+    parent: data
     display_name: Documents
     inclusion_rule: "Document creation, conversion, summarization, office formats, markdown, and PDFs."
     exclusion_rule: "General writing craft belongs in `writing`; document data extraction can use `data` when data pipeline work dominates."
@@ -261,30 +281,35 @@ categories:
     examples: ["legal workflow", "recruiting workflow"]
   - slug: examples
     code: examples
+    parent: development
     display_name: Examples
     inclusion_rule: "Example packs, demos, sample projects, and reusable reference implementations."
     exclusion_rule: "Production development workflows belong in `development`; documentation belongs in `documents`."
     examples: ["sample app", "demo skill"]
   - slug: forensics
     code: forensics
+    parent: security
     display_name: Forensics
     inclusion_rule: "Investigation, evidence preservation, incident reconstruction, and forensic analysis."
     exclusion_rule: "Preventive security hardening belongs in `security`."
     examples: ["artifact triage", "incident evidence"]
   - slug: gaming
     code: gaming
+    parent: domains
     display_name: Gaming
     inclusion_rule: "Game design, gameplay systems, game assets, and game-related automation."
     exclusion_rule: "General UI or creative work should use `design` or `creative`."
     examples: ["game mechanics", "game prompts"]
   - slug: generation
     code: generation
+    parent: creative
     display_name: Generation
     inclusion_rule: "Generating artifacts, media, structured outputs, or reusable content assets."
     exclusion_rule: "Writing-focused prose belongs in `writing`; UI design artifacts belong in `design`."
     examples: ["image prompt", "report artifact", "media generation"]
   - slug: integration
     code: integration
+    parent: development
     display_name: Integration
     inclusion_rule: "Cross-system connectors, service integrations, API composition, and platform bridges."
     exclusion_rule: "Single API usage belongs in `api`; deployment operations belong in `devops`."
@@ -292,18 +317,21 @@ categories:
     description: "Cross-system connectors, service integrations, API composition, and platform bridges."
   - slug: language
     code: language
+    parent: creative
     display_name: Language
     inclusion_rule: "Translation, localization, grammar, linguistics, and language learning workflows."
     exclusion_rule: "Long-form authoring belongs in `writing`; LLM mechanics belong in `ai-llm`."
     examples: ["translation", "grammar checking"]
   - slug: local-ai-infrastructure
     code: local-ai-infrastructure
+    parent: devops
     display_name: Local AI Infrastructure
     inclusion_rule: "Local model runtimes, GPU setup, inference servers, and AI workstation infrastructure."
     exclusion_rule: "Cloud deployment belongs in `devops`; ML modeling belongs in `ai-ml`."
     examples: ["local LLM runtime", "GPU inference"]
   - slug: marketing
     code: mkt
+    parent: business
     display_name: Marketing
     inclusion_rule: "Campaigns, SEO, social content, brand positioning, and growth workflows."
     exclusion_rule: "Product planning belongs in `product`; general business strategy belongs in `business`."
@@ -311,6 +339,7 @@ categories:
     keywords: [marketing, seo, content, social, campaign, brand]
   - slug: orchestration
     code: orchestration
+    parent: ai-ml
     display_name: Orchestration
     inclusion_rule: "Multi-step or multi-agent coordination, scheduling, routing, and workflow control."
     exclusion_rule: "Simple productivity automations belong in `workflow` or `productivity`."
@@ -325,6 +354,7 @@ categories:
     description: "Fallback bucket for unclassified skills; should shrink through reviewed migrations."
   - slug: performance
     code: performance
+    parent: development
     display_name: Performance
     inclusion_rule: "Speed, latency, benchmarking, profiling, and optimization workflows."
     exclusion_rule: "General code cleanup belongs in `development`."
@@ -332,12 +362,14 @@ categories:
     keywords: [performance, optimize, latency, speed, benchmark]
   - slug: personal-development
     code: personal-development
+    parent: domains
     display_name: Personal Development
     inclusion_rule: "Learning, coaching, habit change, self-review, and personal growth workflows."
     exclusion_rule: "Team productivity tools belong in `productivity`."
     examples: ["learning plan", "coaching prompts"]
   - slug: planning
     code: planning
+    parent: productivity
     display_name: Planning
     inclusion_rule: "Planning, roadmaps, schedules, project sequencing, and task breakdown workflows."
     exclusion_rule: "Product requirements belong in `product`; executive strategy belongs in `business`."
@@ -345,6 +377,7 @@ categories:
     keywords: [planning, plan, roadmap]
   - slug: platform
     code: platform
+    parent: devops
     display_name: Platform
     inclusion_rule: "Platform-specific operations, device/platform automation, and platform administration."
     exclusion_rule: "Cross-system connectors belong in `integration`; deployment belongs in `devops`."
@@ -367,6 +400,7 @@ categories:
     keywords: [productivity, automation, workflow, task, planning, memory]
   - slug: quality
     code: quality
+    parent: development
     display_name: Quality
     inclusion_rule: "Linting, review, validation, QA process, and quality gates."
     exclusion_rule: "Test implementation belongs in `testing`; security review belongs in `security`."
@@ -382,18 +416,21 @@ categories:
     keywords: [security, auth, crypto, vulnerability, audit, owasp, pentest, fuzzing]
   - slug: skills
     code: skills
+    parent: development
     display_name: Skills
     inclusion_rule: "Skill authoring, registry maintenance, skill packaging, and skill ecosystem workflows."
     exclusion_rule: "General coding belongs in `development`; docs belong in `documents`."
     examples: ["SKILL.md authoring", "skill registry tooling"]
   - slug: system
     code: system
+    parent: devops
     display_name: System
     inclusion_rule: "Operating-system, local machine, environment, process, and hardware workflows."
     exclusion_rule: "Infrastructure deployment belongs in `devops`; security hardening belongs in `security`."
     examples: ["system diagnosis", "process inspection"]
   - slug: testing
     code: tst
+    parent: development
     display_name: Testing
     inclusion_rule: "Testing, QA, TDD, unit/integration/e2e testing, browser automation, and test tooling."
     exclusion_rule: "Static quality review belongs in `quality`; security testing belongs in `security`."
@@ -402,18 +439,21 @@ categories:
     keywords: [test, qa, tdd, jest, pytest, unittest, integration, e2e, playwright, cypress]
   - slug: travel
     code: travel
+    parent: domains
     display_name: Travel
     inclusion_rule: "Trip planning, itineraries, logistics, bookings, and destination research."
     exclusion_rule: "General planning without travel belongs in `planning`."
     examples: ["itinerary", "flight plan"]
   - slug: war-room
     code: war-room
+    parent: devops
     display_name: War Room
     inclusion_rule: "Incident response rooms, crisis coordination, launch rooms, and high-urgency operations."
     exclusion_rule: "Normal project planning belongs in `planning`; security incidents can use `security` if security dominates."
     examples: ["incident room", "launch room"]
   - slug: workflow
     code: workflow
+    parent: productivity
     display_name: Workflow
     inclusion_rule: "Repeatable process automation, operating procedures, workflow design, and non-CI pipelines."
     exclusion_rule: "CI/CD belongs in `devops`; personal task aids belong in `productivity`."
@@ -421,6 +461,7 @@ categories:
     keywords: [workflow, process, automation, pipeline]
   - slug: writing
     code: writing
+    parent: creative
     display_name: Writing
     inclusion_rule: "Writing, editing, copy, blogs, articles, prose polish, and narrative composition."
     exclusion_rule: "Marketing distribution belongs in `marketing`; document format conversion belongs in `documents`."

--- a/tests/test_audit_category_quality.py
+++ b/tests/test_audit_category_quality.py
@@ -4,6 +4,7 @@ import importlib
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 
 def _load_module():
@@ -130,3 +131,103 @@ def test_audit_uses_frontmatter_description_when_metadata_description_missing(tm
     }
 
     assert candidates["other/frontmatter-devops/SKILL.md"]["suggested_category"] == "devops"
+
+
+def test_stratified_sample_is_deterministic_and_records_fresh_evidence(
+    tmp_path,
+    monkeypatch,
+):
+    audit = _load_module()
+    skills_dir = tmp_path / "skills"
+    for category in ("integration", "data"):
+        for index in range(3):
+            _write_skill(
+                skills_dir,
+                category,
+                f"{category}-{index}",
+                {
+                    "name": f"{category}-{index}",
+                    "category": category,
+                    "description": f"{category} semantic description {index}",
+                },
+                (
+                    "---\n"
+                    f"name: {category}-{index}\n"
+                    f"description: {category} frontmatter description {index}\n"
+                    "---\n\n"
+                    + ("bounded body " * 100)
+                ),
+            )
+
+    policy = SimpleNamespace(
+        schema_version=1,
+        seed="test-seed",
+        per_category=2,
+        categories=("integration", "data"),
+    )
+    monkeypatch.setattr(
+        audit,
+        "get_taxonomy",
+        lambda: SimpleNamespace(audit_sampling=policy, default_category="other"),
+    )
+
+    first = audit.build_stratified_sample(skills_dir, content_chars=32)
+    original_iter = audit.iter_skill_dirs
+    monkeypatch.setattr(
+        audit,
+        "iter_skill_dirs",
+        lambda root: iter(reversed(list(original_iter(root)))),
+    )
+    second = audit.build_stratified_sample(skills_dir, content_chars=32)
+
+    assert first["status"] == "complete"
+    assert first["sample_count"] == 4
+    assert first["digest"] == second["digest"]
+    assert [
+        item["path"]
+        for stratum in first["strata"]
+        for item in stratum["samples"]
+    ] == [
+        item["path"]
+        for stratum in second["strata"]
+        for item in stratum["samples"]
+    ]
+    for stratum in first["strata"]:
+        assert stratum["sample_count"] == stratum["quota"] == 2
+        for item in stratum["samples"]:
+            assert len(item["source_sha256"]) == 64
+            assert len(item["metadata_sha256"]) == 64
+            assert len(item["sample_key"]) == 64
+            assert len(item["content_excerpt"]) <= 32
+            assert item["semantic_sources"]["description"] == "frontmatter"
+
+
+def test_stratified_sample_fails_when_population_is_below_quota(
+    tmp_path,
+    monkeypatch,
+):
+    audit = _load_module()
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "integration",
+        "only-one",
+        {"name": "only-one", "category": "integration"},
+        "---\nname: only-one\n---\n",
+    )
+    policy = SimpleNamespace(
+        schema_version=1,
+        seed="test-seed",
+        per_category=2,
+        categories=("integration",),
+    )
+    monkeypatch.setattr(
+        audit,
+        "get_taxonomy",
+        lambda: SimpleNamespace(audit_sampling=policy, default_category="other"),
+    )
+
+    report = audit.build_stratified_sample(skills_dir)
+    assert report["status"] == "failed"
+    assert report["strata"][0]["population_count"] == 1
+    assert "below quota" in report["errors"][0]

--- a/tests/test_build_search_index.py
+++ b/tests/test_build_search_index.py
@@ -358,3 +358,18 @@ def test_build_search_index_requires_security_decision_when_required(tmp_path):
             output_dir,
             require_security_evidence=True,
         )
+
+
+def test_build_emits_complete_category_taxonomy_sidecar(tmp_path):
+    output_dir = tmp_path / "docs"
+    build_search_index([], output_dir)
+
+    sidecar = json.loads((output_dir / "category-taxonomy.json").read_text())
+    assert sidecar["schema_version"] == 1
+    assert sidecar["taxonomy_schema_version"] == 2
+    assert sidecar["category_count"] == 42
+    assert sidecar["default_category"] == "other"
+    assert sidecar["default_code"] == "oth"
+    assert len({item["slug"] for item in sidecar["categories"]}) == 42
+    assert len({item["code"] for item in sidecar["categories"]}) == 42
+    assert len([item for item in sidecar["categories"] if not item["parent"]]) == 12

--- a/tests/test_category_taxonomy.py
+++ b/tests/test_category_taxonomy.py
@@ -29,6 +29,25 @@ def test_taxonomy_loads_current_category_set():
     assert loaded.migration_target("docs") == "documents"
     assert loaded.legacy_migration("docs").target == "documents"
     assert loaded.legacy_migration("applied").review_required is True
+    assert len(loaded.categories) == 42
+    assert len([item for item in loaded.categories.values() if not item.parent]) == 12
+    assert loaded.audit_sampling.per_category == 50
+    assert loaded.audit_sampling.categories == (
+        "integration",
+        "domains",
+        "skills",
+        "context-management",
+        "data",
+        "development",
+    )
+    for slug, definition in loaded.categories.items():
+        assert loaded.slug_for_code(definition.code) == slug
+
+    contract = loaded.public_contract(updated_at="2026-07-23T00:00:00Z")
+    assert contract["category_count"] == 42
+    assert contract["default_code"] == "oth"
+    assert len({item["slug"] for item in contract["categories"]}) == 42
+    assert len({item["code"] for item in contract["categories"]}) == 42
 
 
 def test_taxonomy_rejects_aliases_by_default_and_codes():
@@ -143,4 +162,74 @@ categories:
         encoding="utf-8",
     )
     with pytest.raises(ValueError, match="unknown parent"):
+        taxonomy.load_taxonomy(taxonomy_file)
+
+
+def test_taxonomy_rejects_self_parent_and_third_reporting_level(tmp_path):
+    taxonomy = _load_module()
+    self_parent = tmp_path / "self.yaml"
+    self_parent.write_text(
+        """
+schema_version: 2
+default_category: other
+categories:
+  - slug: other
+    code: oth
+    parent: other
+audit_sampling:
+  schema_version: 1
+  seed: test
+  per_category: 1
+  categories: [other]
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="must not parent itself"):
+        taxonomy.load_taxonomy(self_parent)
+
+    deep = tmp_path / "deep.yaml"
+    deep.write_text(
+        """
+schema_version: 2
+default_category: other
+categories:
+  - slug: other
+    code: oth
+  - slug: child
+    code: child
+    parent: other
+  - slug: grandchild
+    code: grandchild
+    parent: child
+audit_sampling:
+  schema_version: 1
+  seed: test
+  per_category: 1
+  categories: [other]
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="exceeds two reporting levels"):
+        taxonomy.load_taxonomy(deep)
+
+
+def test_taxonomy_rejects_invalid_sampling_policy(tmp_path):
+    taxonomy = _load_module()
+    taxonomy_file = tmp_path / "categories.yaml"
+    taxonomy_file.write_text(
+        """
+schema_version: 2
+default_category: other
+categories:
+  - slug: other
+    code: oth
+audit_sampling:
+  schema_version: 1
+  seed: test
+  per_category: 0
+  categories: [other]
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="positive integer"):
         taxonomy.load_taxonomy(taxonomy_file)

--- a/tests/test_check_category_sample_review.py
+++ b/tests/test_check_category_sample_review.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import copy
+import importlib
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def _load_modules():
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    return (
+        importlib.import_module("audit_category_quality"),
+        importlib.import_module("check_category_sample_review"),
+    )
+
+
+def _evidence(tmp_path):
+    audit, _ = _load_modules()
+    skills_dir = tmp_path / "skills"
+    rows = []
+    for index in range(2):
+        skill_dir = skills_dir / "integration" / f"skill-{index}"
+        skill_dir.mkdir(parents=True)
+        skill_path = skill_dir / "SKILL.md"
+        metadata_path = skill_dir / "metadata.json"
+        skill_path.write_text(f"---\nname: skill-{index}\n---\n", encoding="utf-8")
+        metadata_path.write_text(
+            f'{{"name":"skill-{index}","category":"integration"}}\n',
+            encoding="utf-8",
+        )
+        rows.append(
+            {
+                "path": f"integration/skill-{index}/SKILL.md",
+                "name": f"skill-{index}",
+                "current_category": "integration",
+                "description": "integration helper",
+                "content_excerpt": "bounded excerpt",
+                "semantic_sources": {"name": "frontmatter"},
+                "source_sha256": audit.file_sha256(skill_path),
+                "metadata_sha256": audit.file_sha256(metadata_path),
+                "sample_key": str(index + 5) * 64,
+            }
+        )
+    stratum_digest = audit.canonical_digest(rows)
+    sample_digest = audit.canonical_digest(
+        [{"category": "integration", "digest": stratum_digest}]
+    )
+    sample = {
+        "schema_version": 1,
+        "status": "complete",
+        "skills_dir": str(skills_dir),
+        "policy": {
+            "seed": "test",
+            "per_category": 2,
+            "categories": ["integration"],
+            "content_chars": 128,
+        },
+        "sample_count": 2,
+        "digest": sample_digest,
+        "strata": [
+            {
+                "category": "integration",
+                "population_count": 3,
+                "sample_count": 2,
+                "quota": 2,
+                "digest": stratum_digest,
+                "samples": rows,
+            }
+        ],
+        "errors": [],
+    }
+    review = {
+        "schema_version": 1,
+        "sample_digest": sample_digest,
+        "reviews": [
+            {
+                "path": row["path"],
+                "source_sha256": row["source_sha256"],
+                "metadata_sha256": row["metadata_sha256"],
+                "expected_category": "integration",
+            }
+            for row in rows
+        ],
+    }
+    return sample, review
+
+
+def _use_test_policy(checker, monkeypatch):
+    policy = SimpleNamespace(
+        schema_version=1,
+        seed="test",
+        per_category=2,
+        categories=("integration",),
+    )
+    taxonomy = SimpleNamespace(
+        audit_sampling=policy,
+        publishable_categories=lambda: {"integration", "data"},
+    )
+    monkeypatch.setattr(checker, "get_taxonomy", lambda: taxonomy)
+
+
+def test_review_gate_accepts_complete_fresh_review(tmp_path, monkeypatch):
+    _, checker = _load_modules()
+    _use_test_policy(checker, monkeypatch)
+    sample, review = _evidence(tmp_path)
+    result = checker.check_review(sample, review, min_accuracy=0.8)
+    assert result["status"] == "passed"
+    assert result["accuracy"] == 1
+    assert result["categories"]["integration"]["total"] == 2
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda sample, review: review["reviews"].pop(), "missing review paths"),
+        (
+            lambda sample, review: review["reviews"].append(
+                copy.deepcopy(review["reviews"][0])
+            ),
+            "duplicate review path",
+        ),
+        (
+            lambda sample, review: review["reviews"][0].update(
+                source_sha256="f" * 64
+            ),
+            "stale source hashes",
+        ),
+        (
+            lambda sample, review: review["reviews"][0].update(
+                expected_category="not-canonical"
+            ),
+            "non-canonical expected category",
+        ),
+        (
+            lambda sample, review: sample["strata"][0]["samples"][0].update(
+                description="tampered"
+            ),
+            "sample stratum digest mismatch",
+        ),
+        (
+            lambda sample, review: review.update(sample_digest="0" * 64),
+            "review digest does not match sample",
+        ),
+    ],
+)
+def test_review_gate_rejects_incomplete_or_stale_evidence(
+    mutation,
+    message,
+    tmp_path,
+    monkeypatch,
+):
+    _, checker = _load_modules()
+    _use_test_policy(checker, monkeypatch)
+    sample, review = _evidence(tmp_path)
+    mutation(sample, review)
+    with pytest.raises(checker.ReviewEvidenceError, match=message):
+        checker.check_review(sample, review, min_accuracy=0.8)
+
+
+def test_review_gate_rejects_low_per_category_accuracy(tmp_path, monkeypatch):
+    _, checker = _load_modules()
+    _use_test_policy(checker, monkeypatch)
+    sample, review = _evidence(tmp_path)
+    review["reviews"][0]["expected_category"] = "data"
+    with pytest.raises(checker.ReviewEvidenceError, match="accuracy.*below"):
+        checker.check_review(sample, review, min_accuracy=0.8)
+
+
+def test_review_gate_rejects_sources_changed_after_sampling(tmp_path, monkeypatch):
+    _, checker = _load_modules()
+    _use_test_policy(checker, monkeypatch)
+    sample, review = _evidence(tmp_path)
+    source_path = Path(sample["skills_dir"]) / sample["strata"][0]["samples"][0]["path"]
+    source_path.write_text("changed after review\n", encoding="utf-8")
+
+    with pytest.raises(checker.ReviewEvidenceError, match="sample source changed"):
+        checker.check_review(sample, review, min_accuracy=0.8)
+
+
+def test_review_gate_rejects_noncanonical_sampling_policy(tmp_path):
+    _, checker = _load_modules()
+    sample, review = _evidence(tmp_path)
+    with pytest.raises(
+        checker.ReviewEvidenceError,
+        match="sample policy does not match canonical taxonomy",
+    ):
+        checker.check_review(sample, review, min_accuracy=0.8)
+
+
+def test_review_gate_cli_reports_pass_and_failure(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    _, checker = _load_modules()
+    _use_test_policy(checker, monkeypatch)
+    sample, review = _evidence(tmp_path)
+    sample_path = tmp_path / "sample.json"
+    review_path = tmp_path / "review.json"
+    sample_path.write_text(json.dumps(sample), encoding="utf-8")
+    review_path.write_text(json.dumps(review), encoding="utf-8")
+
+    assert checker.main(
+        ["--sample", str(sample_path), "--review", str(review_path)]
+    ) == 0
+    assert json.loads(capsys.readouterr().out)["status"] == "passed"
+
+    review["reviews"].pop()
+    review_path.write_text(json.dumps(review), encoding="utf-8")
+    assert checker.main(
+        ["--sample", str(sample_path), "--review", str(review_path)]
+    ) == 1
+    assert json.loads(capsys.readouterr().out)["status"] == "failed"

--- a/tests/test_check_category_sample_review.py
+++ b/tests/test_check_category_sample_review.py
@@ -20,10 +20,23 @@ def _load_modules():
     )
 
 
-def _evidence(tmp_path):
+def _test_taxonomy():
+    policy = SimpleNamespace(
+        schema_version=1,
+        seed="test",
+        per_category=2,
+        categories=("integration",),
+    )
+    return SimpleNamespace(
+        audit_sampling=policy,
+        default_category="other",
+        publishable_categories=lambda: {"integration", "data"},
+    )
+
+
+def _evidence(tmp_path, taxonomy=None):
     audit, _ = _load_modules()
     skills_dir = tmp_path / "skills"
-    rows = []
     for index in range(2):
         skill_dir = skills_dir / "integration" / f"skill-{index}"
         skill_dir.mkdir(parents=True)
@@ -34,50 +47,15 @@ def _evidence(tmp_path):
             f'{{"name":"skill-{index}","category":"integration"}}\n',
             encoding="utf-8",
         )
-        rows.append(
-            {
-                "path": f"integration/skill-{index}/SKILL.md",
-                "name": f"skill-{index}",
-                "current_category": "integration",
-                "description": "integration helper",
-                "content_excerpt": "bounded excerpt",
-                "semantic_sources": {"name": "frontmatter"},
-                "source_sha256": audit.file_sha256(skill_path),
-                "metadata_sha256": audit.file_sha256(metadata_path),
-                "sample_key": str(index + 5) * 64,
-            }
-        )
-    stratum_digest = audit.canonical_digest(rows)
-    sample_digest = audit.canonical_digest(
-        [{"category": "integration", "digest": stratum_digest}]
+    sample = audit.build_stratified_sample(
+        skills_dir,
+        content_chars=128,
+        taxonomy=taxonomy or _test_taxonomy(),
     )
-    sample = {
-        "schema_version": 1,
-        "status": "complete",
-        "skills_dir": str(skills_dir),
-        "policy": {
-            "seed": "test",
-            "per_category": 2,
-            "categories": ["integration"],
-            "content_chars": 128,
-        },
-        "sample_count": 2,
-        "digest": sample_digest,
-        "strata": [
-            {
-                "category": "integration",
-                "population_count": 3,
-                "sample_count": 2,
-                "quota": 2,
-                "digest": stratum_digest,
-                "samples": rows,
-            }
-        ],
-        "errors": [],
-    }
+    rows = sample["strata"][0]["samples"]
     review = {
         "schema_version": 1,
-        "sample_digest": sample_digest,
+        "sample_digest": sample["digest"],
         "reviews": [
             {
                 "path": row["path"],
@@ -92,23 +70,17 @@ def _evidence(tmp_path):
 
 
 def _use_test_policy(checker, monkeypatch):
-    policy = SimpleNamespace(
-        schema_version=1,
-        seed="test",
-        per_category=2,
-        categories=("integration",),
-    )
-    taxonomy = SimpleNamespace(
-        audit_sampling=policy,
-        publishable_categories=lambda: {"integration", "data"},
-    )
+    audit, _ = _load_modules()
+    taxonomy = _test_taxonomy()
+    monkeypatch.setattr(audit, "get_taxonomy", lambda: taxonomy)
     monkeypatch.setattr(checker, "get_taxonomy", lambda: taxonomy)
+    return taxonomy
 
 
 def test_review_gate_accepts_complete_fresh_review(tmp_path, monkeypatch):
     _, checker = _load_modules()
-    _use_test_policy(checker, monkeypatch)
-    sample, review = _evidence(tmp_path)
+    taxonomy = _use_test_policy(checker, monkeypatch)
+    sample, review = _evidence(tmp_path, taxonomy)
     result = checker.check_review(sample, review, min_accuracy=0.8)
     assert result["status"] == "passed"
     assert result["accuracy"] == 1
@@ -156,8 +128,8 @@ def test_review_gate_rejects_incomplete_or_stale_evidence(
     monkeypatch,
 ):
     _, checker = _load_modules()
-    _use_test_policy(checker, monkeypatch)
-    sample, review = _evidence(tmp_path)
+    taxonomy = _use_test_policy(checker, monkeypatch)
+    sample, review = _evidence(tmp_path, taxonomy)
     mutation(sample, review)
     with pytest.raises(checker.ReviewEvidenceError, match=message):
         checker.check_review(sample, review, min_accuracy=0.8)
@@ -165,8 +137,8 @@ def test_review_gate_rejects_incomplete_or_stale_evidence(
 
 def test_review_gate_rejects_low_per_category_accuracy(tmp_path, monkeypatch):
     _, checker = _load_modules()
-    _use_test_policy(checker, monkeypatch)
-    sample, review = _evidence(tmp_path)
+    taxonomy = _use_test_policy(checker, monkeypatch)
+    sample, review = _evidence(tmp_path, taxonomy)
     review["reviews"][0]["expected_category"] = "data"
     with pytest.raises(checker.ReviewEvidenceError, match="accuracy.*below"):
         checker.check_review(sample, review, min_accuracy=0.8)
@@ -174,18 +146,21 @@ def test_review_gate_rejects_low_per_category_accuracy(tmp_path, monkeypatch):
 
 def test_review_gate_rejects_sources_changed_after_sampling(tmp_path, monkeypatch):
     _, checker = _load_modules()
-    _use_test_policy(checker, monkeypatch)
-    sample, review = _evidence(tmp_path)
+    taxonomy = _use_test_policy(checker, monkeypatch)
+    sample, review = _evidence(tmp_path, taxonomy)
     source_path = Path(sample["skills_dir"]) / sample["strata"][0]["samples"][0]["path"]
     source_path.write_text("changed after review\n", encoding="utf-8")
 
-    with pytest.raises(checker.ReviewEvidenceError, match="sample source changed"):
+    with pytest.raises(
+        checker.ReviewEvidenceError,
+        match="sample no longer matches current population",
+    ):
         checker.check_review(sample, review, min_accuracy=0.8)
 
 
 def test_review_gate_rejects_noncanonical_sampling_policy(tmp_path):
     _, checker = _load_modules()
-    sample, review = _evidence(tmp_path)
+    sample, review = _evidence(tmp_path, _test_taxonomy())
     with pytest.raises(
         checker.ReviewEvidenceError,
         match="sample policy does not match canonical taxonomy",
@@ -199,8 +174,8 @@ def test_review_gate_cli_reports_pass_and_failure(
     capsys,
 ):
     _, checker = _load_modules()
-    _use_test_policy(checker, monkeypatch)
-    sample, review = _evidence(tmp_path)
+    taxonomy = _use_test_policy(checker, monkeypatch)
+    sample, review = _evidence(tmp_path, taxonomy)
     sample_path = tmp_path / "sample.json"
     review_path = tmp_path / "review.json"
     sample_path.write_text(json.dumps(sample), encoding="utf-8")
@@ -217,3 +192,25 @@ def test_review_gate_cli_reports_pass_and_failure(
         ["--sample", str(sample_path), "--review", str(review_path)]
     ) == 1
     assert json.loads(capsys.readouterr().out)["status"] == "failed"
+
+
+def test_review_gate_rejects_archive_population_changes(tmp_path, monkeypatch):
+    _, checker = _load_modules()
+    taxonomy = _use_test_policy(checker, monkeypatch)
+    sample, review = _evidence(tmp_path, taxonomy)
+    new_skill = Path(sample["skills_dir"]) / "integration" / "new-skill"
+    new_skill.mkdir(parents=True)
+    (new_skill / "SKILL.md").write_text(
+        "---\nname: new-skill\n---\n",
+        encoding="utf-8",
+    )
+    (new_skill / "metadata.json").write_text(
+        '{"name":"new-skill","category":"integration"}\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        checker.ReviewEvidenceError,
+        match="sample no longer matches current population",
+    ):
+        checker.check_review(sample, review, min_accuracy=0.8)

--- a/tests/test_check_taxonomy_governance.py
+++ b/tests/test_check_taxonomy_governance.py
@@ -41,6 +41,11 @@ def test_governance_reports_old_schema_error(tmp_path):
         """
 schema_version: 1
 default_category: other
+audit_sampling:
+  schema_version: 1
+  seed: test
+  per_category: 1
+  categories: [other]
 categories:
   - slug: other
     code: oth
@@ -80,6 +85,11 @@ def test_governance_requires_active_category_rules(tmp_path):
         """
 schema_version: 2
 default_category: other
+audit_sampling:
+  schema_version: 1
+  seed: test
+  per_category: 1
+  categories: [other]
 categories:
   - slug: other
     code: oth
@@ -115,6 +125,11 @@ def test_governance_strict_canonical_rejects_transitional_definitions(tmp_path):
         """
 schema_version: 2
 default_category: other
+audit_sampling:
+  schema_version: 1
+  seed: test
+  per_category: 1
+  categories: [other]
 categories:
   - slug: other
     code: oth

--- a/tests/test_pages_request_budget.py
+++ b/tests/test_pages_request_budget.py
@@ -9,6 +9,7 @@ if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
 from build_search_index import build_search_index  # noqa: E402
+from category_taxonomy import get_taxonomy  # noqa: E402
 
 
 def run_node_harness(script: str, *args: str) -> dict:
@@ -77,6 +78,7 @@ const CONFIG = {
 };
 const CATEGORY_NAMES = { dev: 'Development', oth: 'Other' };
 const CATEGORY_CODES_REVERSE = { development: 'dev', other: 'oth' };
+let DEFAULT_CATEGORY_CODE = 'oth';
 let state = {
   index: null, fullIndex: null, categories: [], categoryCache: {}, featured: [],
   leaderboardRequestToken: 0,
@@ -463,7 +465,9 @@ global.fetch = async url => {
   return { ok: true, status: 200, json: async () => JSON.parse(fs.readFileSync(artifactPath)) };
 };
 const CONFIG = { LEGACY_INDEX_URL: 'search-index.json' };
+const CATEGORY_NAMES = { dev: 'Development', oth: 'Other' };
 const CATEGORY_CODES_REVERSE = { development: 'dev', other: 'oth' };
+let DEFAULT_CATEGORY_CODE = 'oth';
 let state = { index: { isLite: true }, fullIndex: null };
 eval(extract(app, 'fetchJson'));
 eval(extract(app, 'normalizeCategoryCode'));
@@ -513,3 +517,94 @@ def test_generated_stable_key_winner_is_order_independent_for_equal_scores(tmp_p
         winners.append((shard["s"][0]["n"], lite["skills"][0]["name"]))
 
     assert winners == [("Beta", "Beta"), ("Beta", "Beta")]
+
+
+def test_pages_taxonomy_contract_drives_all_category_mappings():
+    contract = get_taxonomy().public_contract(updated_at="2026-07-23T00:00:00Z")
+    result = run_node_harness(
+        r"""
+const fs = require('fs');
+const assert = require('assert');
+const app = fs.readFileSync('docs/js/app.js', 'utf8');
+const artifactApi = fs.readFileSync('docs/js/artifact-api.js', 'utf8');
+const payload = JSON.parse(process.argv[1]);
+
+function extract(source, name) {
+  const start = source.indexOf(`function ${name}(`);
+  assert(start >= 0, `missing function ${name}`);
+  const bodyStart = source.indexOf('{', start);
+  let depth = 0;
+  let quote = null;
+  let escaped = false;
+  for (let i = bodyStart; i < source.length; i += 1) {
+    const char = source[i];
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (char === '\\') escaped = true;
+      else if (char === quote) quote = null;
+      continue;
+    }
+    if (char === "'" || char === '"' || char === '`') quote = char;
+    else if (char === '{') depth += 1;
+    else if (char === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+  }
+  throw new Error(`unterminated function ${name}`);
+}
+
+const CATEGORY_NAMES = {};
+const CATEGORY_CODES_REVERSE = {};
+const CATEGORY_META_BY_CODE = {};
+const CATEGORY_META_BY_SLUG = {};
+let DEFAULT_CATEGORY_CODE = 'oth';
+eval(extract(artifactApi, 'requireExactFields'));
+eval(extract(artifactApi, 'requireSchemaOne'));
+eval(extract(artifactApi, 'requireNonNegativeInteger'));
+eval(extract(artifactApi, 'validateCategoryTaxonomy'));
+eval(extract(app, 'normalizeCategoryCode'));
+eval(extract(app, 'configureCategoryTaxonomy'));
+eval(extract(app, 'categoryDisplayName'));
+eval(extract(app, 'categoryReportingLabel'));
+
+validateCategoryTaxonomy(payload);
+configureCategoryTaxonomy(payload);
+for (const category of payload.categories) {
+  assert.strictEqual(normalizeCategoryCode(category.slug), category.code);
+  assert.strictEqual(normalizeCategoryCode(category.code), category.code);
+  assert.strictEqual(categoryDisplayName(category.slug), category.display_name);
+}
+assert.strictEqual(normalizeCategoryCode('future-category'), 'future-category');
+assert.strictEqual(categoryDisplayName('future-category'), 'future-category');
+assert.strictEqual(normalizeCategoryCode(''), payload.default_code);
+const child = payload.categories.find(category => category.parent);
+const parent = payload.categories.find(category => category.slug === child.parent);
+assert.strictEqual(
+  categoryReportingLabel(child.code),
+  `${parent.display_name} › ${child.display_name}`
+);
+
+const duplicate = structuredClone(payload);
+duplicate.categories[1].code = duplicate.categories[0].code;
+assert.throws(() => validateCategoryTaxonomy(duplicate), /identity mismatch/);
+const deep = structuredClone(payload);
+const childIndex = deep.categories.findIndex(category => category.parent);
+const secondChildIndex = deep.categories.findIndex(
+  (category, index) => category.parent && index !== childIndex
+);
+deep.categories[secondChildIndex].parent = deep.categories[childIndex].slug;
+assert.throws(() => validateCategoryTaxonomy(deep), /parent mismatch/);
+const unknownField = structuredClone(payload);
+unknownField.extra = true;
+assert.throws(() => validateCategoryTaxonomy(unknownField), /shape mismatch/);
+
+process.stdout.write(JSON.stringify({
+  count: payload.category_count,
+  roots: payload.categories.filter(category => !category.parent).length,
+  unknown: normalizeCategoryCode('future-category')
+}));
+""",
+        json.dumps(contract),
+    )
+    assert result == {"count": 42, "roots": 12, "unknown": "future-category"}

--- a/tests/test_pages_request_budget.py
+++ b/tests/test_pages_request_budget.py
@@ -588,6 +588,13 @@ assert.strictEqual(
 const duplicate = structuredClone(payload);
 duplicate.categories[1].code = duplicate.categories[0].code;
 assert.throws(() => validateCategoryTaxonomy(duplicate), /identity mismatch/);
+const truncated = structuredClone(payload);
+truncated.categories = truncated.categories.slice(0, 1);
+truncated.category_count = 1;
+assert.throws(() => validateCategoryTaxonomy(truncated), /count or identity mismatch/);
+const noncanonical = structuredClone(payload);
+noncanonical.categories[0].slug = `${noncanonical.categories[0].slug} `;
+assert.throws(() => validateCategoryTaxonomy(noncanonical), /identity mismatch/);
 const deep = structuredClone(payload);
 const childIndex = deep.categories.findIndex(category => category.parent);
 const secondChildIndex = deep.categories.findIndex(
@@ -595,6 +602,9 @@ const secondChildIndex = deep.categories.findIndex(
 );
 deep.categories[secondChildIndex].parent = deep.categories[childIndex].slug;
 assert.throws(() => validateCategoryTaxonomy(deep), /parent mismatch/);
+const wrongRootCount = structuredClone(payload);
+wrongRootCount.categories[childIndex].parent = '';
+assert.throws(() => validateCategoryTaxonomy(wrongRootCount), /root count mismatch/);
 const unknownField = structuredClone(payload);
 unknownField.extra = true;
 assert.throws(() => validateCategoryTaxonomy(unknownField), /shape mismatch/);


### PR DESCRIPTION
## Summary

- publish the canonical 42-category taxonomy as a validated Pages sidecar and replace the legacy hardcoded UI mapping
- add a two-level, reporting-only hierarchy with exactly 12 roots; leaf routing, counts, filters, and archive paths remain unchanged
- add deterministic six-stratum category samples plus fail-closed human review evidence with digest and live source-hash validation
- document the GH254 product/technical/task contracts and governance commands

## Verification

- `python -m pytest -q --cov-report=xml:coverage.xml --cov-report=json:/private/tmp/csrc-gh254-coverage.json` — 665 passed
- `python scripts/check_taxonomy_governance.py --strict-canonical` — 42 canonical, 0 errors, 0 warnings
- coverage ratchet — passed
- changed-line coverage — 84%
- scoped `ruff check` for every changed Python file — passed
- `node --check` for changed Pages JavaScript — passed
- `git diff --check` — passed

## Baseline note

The literal repository-wide `ruff check scripts tests` command remains red on 47 pre-existing findings in unchanged files on `origin/main`. This PR does not expand into those unrelated synchronization/normalization modules; all Python files changed here pass ruff.

Fixes #254
