### PR TITLE
feat(taxonomy): keyword coverage for 10 canonical categories

### DIFF
--- a/taxonomy/categories.yaml
+++ b/taxonomy/categories.yaml
@@ -157,6 +157,7 @@ categories:
     inclusion_rule: "Single-agent behavior, role design, agent instructions, or agent runtime helpers."
     exclusion_rule: "Multi-agent scheduling belongs in `orchestration`; general LLM prompting belongs in `ai-llm`."
     examples: ["agent role templates", "agent memory helpers"]
+    keywords: [agent, agentic, sub-agent, autonomous-agent, agent-role]
   - slug: ai-llm
     code: ai-llm
     parent: ai-ml
@@ -225,6 +226,7 @@ categories:
     inclusion_rule: "Context packing, memory, retrieval context, prompt context, and agent state handling."
     exclusion_rule: "General productivity memory tools belong in `productivity`."
     examples: ["context compaction", "memory search"]
+    keywords: [context, retrieval, compaction, context-window, memory]
   - slug: creative
     code: creative
     display_name: Creative
@@ -293,6 +295,7 @@ categories:
     inclusion_rule: "Investigation, evidence preservation, incident reconstruction, and forensic analysis."
     exclusion_rule: "Preventive security hardening belongs in `security`."
     examples: ["artifact triage", "incident evidence"]
+    keywords: [forensic, forensics, incident, evidence, triage]
   - slug: gaming
     code: gaming
     parent: domains
@@ -300,6 +303,7 @@ categories:
     inclusion_rule: "Game design, gameplay systems, game assets, and game-related automation."
     exclusion_rule: "General UI or creative work should use `design` or `creative`."
     examples: ["game mechanics", "game prompts"]
+    keywords: [game, gaming, gameplay, unity, godot]
   - slug: generation
     code: generation
     parent: creative
@@ -307,6 +311,7 @@ categories:
     inclusion_rule: "Generating artifacts, media, structured outputs, or reusable content assets."
     exclusion_rule: "Writing-focused prose belongs in `writing`; UI design artifacts belong in `design`."
     examples: ["image prompt", "report artifact", "media generation"]
+    keywords: [generation, generator, scaffold, codegen, boilerplate]
   - slug: integration
     code: integration
     parent: development
@@ -314,6 +319,7 @@ categories:
     inclusion_rule: "Cross-system connectors, service integrations, API composition, and platform bridges."
     exclusion_rule: "Single API usage belongs in `api`; deployment operations belong in `devops`."
     examples: ["GitHub connector", "Wix extension", "webhook"]
+    keywords: [integration, connector, webhook, oauth, zapier]
     description: "Cross-system connectors, service integrations, API composition, and platform bridges."
   - slug: language
     code: language
@@ -322,6 +328,7 @@ categories:
     inclusion_rule: "Translation, localization, grammar, linguistics, and language learning workflows."
     exclusion_rule: "Long-form authoring belongs in `writing`; LLM mechanics belong in `ai-llm`."
     examples: ["translation", "grammar checking"]
+    keywords: [translation, localization, i18n, grammar, linguistics]
   - slug: local-ai-infrastructure
     code: local-ai-infrastructure
     parent: devops
@@ -329,6 +336,7 @@ categories:
     inclusion_rule: "Local model runtimes, GPU setup, inference servers, and AI workstation infrastructure."
     exclusion_rule: "Cloud deployment belongs in `devops`; ML modeling belongs in `ai-ml`."
     examples: ["local LLM runtime", "GPU inference"]
+    keywords: [ollama, llama-cpp, local-llm, gguf, vllm]
   - slug: marketing
     code: mkt
     parent: business
@@ -367,6 +375,7 @@ categories:
     inclusion_rule: "Learning, coaching, habit change, self-review, and personal growth workflows."
     exclusion_rule: "Team productivity tools belong in `productivity`."
     examples: ["learning plan", "coaching prompts"]
+    keywords: [coaching, habit, journaling, self-improvement, mindfulness]
   - slug: planning
     code: planning
     parent: productivity
@@ -382,6 +391,7 @@ categories:
     inclusion_rule: "Platform-specific operations, device/platform automation, and platform administration."
     exclusion_rule: "Cross-system connectors belong in `integration`; deployment belongs in `devops`."
     examples: ["device automation", "platform admin"]
+    keywords: [platform, device, adb, android, ios]
   - slug: product
     code: prd
     display_name: Product


### PR DESCRIPTION
## What / Why
Follow-up to #254 / PR #255. That work aligned the 42-category taxonomy, the two-layer `parent` hierarchy, the Pages 42-code mapping, and the stratified sampling gate — but **keyword coverage was out of its scope**, leaving 18/42 categories with no keyword signals.

Ten of those keyword-less categories are substantial, coherent capabilities holding ~15k skills combined. Without keywords, the keyword classifier (`score_categories`) and `audit_category_quality` scoring cannot positively route to them — they depend entirely on source-provided or LLM-assigned categories with no deterministic cross-check.

This PR adds deterministic, exclusion-rule-respecting keywords to those 10:
`agent`, `context-management`, `forensics`, `gaming`, `generation`, `integration`, `language`, `local-ai-infrastructure`, `personal-development`, `platform`.

Coverage: **24/42 → 34/42**.

The remaining 8 keyword-less categories are intentionally left alone: `other`/`examples`/`skills`/`domains`/`system` are fallback/meta/umbrella buckets that must not attract keyword matches, and `c-level`/`travel`/`war-room` are tiny pending-demotion candidates (a taxonomy-contract decision for a human).

## Scope / Safety
- **Additive only.** Keywords feed audit scoring and the keyword classifier. They do **not** affect `resolve_category` (slug/alias/code based), the canonical category set, codes, aliases, migration targets, or any publish-gate semantics.
- No contract or enforcement surface changes. `taxonomy/categories.yaml` canonical set is unchanged (42).
- `docs/category-taxonomy.json` is generated at build-index time (not committed); the Pages UI picks up nothing new client-side (it needs only slug/code/display_name).

## Proof (local, this session)
- `check_taxonomy_governance.py`: **0 errors, 0 warnings** (42 canonical).
- `check_canonical_categories.py --docs-dir docs`: **0 errors**.
- `pytest test_category_taxonomy test_check_taxonomy_governance test_audit_category_quality test_check_category_sample_review`: **33 passed**.
- Classifier smoke test: **9/9** representative strings route to the intended category, including the sibling-overlap guard — "pytest integration e2e tests" still routes to `testing` (5) over `integration` (1), so the shared `integration` token does not regress testing.

## AI Role
AI-authored (Fable/Opus). Additive taxonomy metadata; risk **low**. Review focus: keyword–exclusion-rule fit for `integration` vs `testing`/`api`, and `context-management` vs `productivity` (both verified by the smoke test).