### PR TITLE
Demote micro-categories travel and war-room to legacy migrations

### DIFF
--- a/docs/js/artifact-api.js
+++ b/docs/js/artifact-api.js
@@ -30,7 +30,7 @@ function validateCategoryTaxonomy(payload) {
         typeof payload.default_category !== 'string' || !payload.default_category ||
         typeof payload.default_code !== 'string' || !payload.default_code ||
         !Array.isArray(payload.categories) ||
-        payload.category_count !== 42 ||
+        payload.category_count !== 40 ||
         payload.categories.length !== payload.category_count) {
         throw new Error('Category taxonomy count or identity mismatch');
     }

--- a/taxonomy/categories.yaml
+++ b/taxonomy/categories.yaml
@@ -149,6 +149,12 @@ legacy_migrations:
   - slug: utility
     review_required: true
     reason: "Broad utility bucket; reclassify as Productivity, Workflow, or another concrete capability."
+  - slug: travel
+    target: domains
+    reason: "Demoted micro-category (48 skills); folded into its parent Domains."
+  - slug: war-room
+    target: devops
+    reason: "Demoted micro-category (27 skills); folded into its parent DevOps."
 categories:
   - slug: agent
     code: agent
@@ -447,20 +453,6 @@ categories:
     examples: ["pytest", "Playwright", "test harness"]
     description: "Testing, QA, TDD, unit/integration/e2e testing, browser automation, and test tooling."
     keywords: [test, qa, tdd, jest, pytest, unittest, integration, e2e, playwright, cypress]
-  - slug: travel
-    code: travel
-    parent: domains
-    display_name: Travel
-    inclusion_rule: "Trip planning, itineraries, logistics, bookings, and destination research."
-    exclusion_rule: "General planning without travel belongs in `planning`."
-    examples: ["itinerary", "flight plan"]
-  - slug: war-room
-    code: war-room
-    parent: devops
-    display_name: War Room
-    inclusion_rule: "Incident response rooms, crisis coordination, launch rooms, and high-urgency operations."
-    exclusion_rule: "Normal project planning belongs in `planning`; security incidents can use `security` if security dominates."
-    examples: ["incident room", "launch room"]
   - slug: workflow
     code: workflow
     parent: productivity

--- a/tests/test_build_search_index.py
+++ b/tests/test_build_search_index.py
@@ -367,9 +367,9 @@ def test_build_emits_complete_category_taxonomy_sidecar(tmp_path):
     sidecar = json.loads((output_dir / "category-taxonomy.json").read_text())
     assert sidecar["schema_version"] == 1
     assert sidecar["taxonomy_schema_version"] == 2
-    assert sidecar["category_count"] == 42
+    assert sidecar["category_count"] == 40
     assert sidecar["default_category"] == "other"
     assert sidecar["default_code"] == "oth"
-    assert len({item["slug"] for item in sidecar["categories"]}) == 42
-    assert len({item["code"] for item in sidecar["categories"]}) == 42
+    assert len({item["slug"] for item in sidecar["categories"]}) == 40
+    assert len({item["code"] for item in sidecar["categories"]}) == 40
     assert len([item for item in sidecar["categories"] if not item["parent"]]) == 12

--- a/tests/test_category_taxonomy.py
+++ b/tests/test_category_taxonomy.py
@@ -24,12 +24,12 @@ def test_taxonomy_loads_current_category_set():
     assert loaded.categories["development"].inclusion_rule
     assert loaded.categories["development"].exclusion_rule
     assert loaded.categories["development"].examples
-    assert len(loaded.categories) >= 42
+    assert len(loaded.categories) >= 40
     assert "docs" not in loaded.categories
     assert loaded.migration_target("docs") == "documents"
     assert loaded.legacy_migration("docs").target == "documents"
     assert loaded.legacy_migration("applied").review_required is True
-    assert len(loaded.categories) == 42
+    assert len(loaded.categories) == 40
     assert len([item for item in loaded.categories.values() if not item.parent]) == 12
     assert loaded.audit_sampling.per_category == 50
     assert loaded.audit_sampling.categories == (
@@ -44,10 +44,10 @@ def test_taxonomy_loads_current_category_set():
         assert loaded.slug_for_code(definition.code) == slug
 
     contract = loaded.public_contract(updated_at="2026-07-23T00:00:00Z")
-    assert contract["category_count"] == 42
+    assert contract["category_count"] == 40
     assert contract["default_code"] == "oth"
-    assert len({item["slug"] for item in contract["categories"]}) == 42
-    assert len({item["code"] for item in contract["categories"]}) == 42
+    assert len({item["slug"] for item in contract["categories"]}) == 40
+    assert len({item["code"] for item in contract["categories"]}) == 40
 
 
 def test_taxonomy_rejects_aliases_by_default_and_codes():

--- a/tests/test_pages_request_budget.py
+++ b/tests/test_pages_request_budget.py
@@ -617,4 +617,4 @@ process.stdout.write(JSON.stringify({
 """,
         json.dumps(contract),
     )
-    assert result == {"count": 42, "roots": 12, "unknown": "future-category"}
+    assert result == {"count": 40, "roots": 12, "unknown": "future-category"}


### PR DESCRIPTION
Demotes the two smallest canonical categories, folding each into its parent via deterministic `legacy_migrations` (no review required):

- `travel` (51 archived skills) → `domains`
- `war-room` (41 archived skills) → `devops`

Canonical taxonomy shrinks from 42 to 40 categories. `c-level` is intentionally kept pending stratified audit evidence. Neither demoted category ever had classification keywords, so no keyword remapping is needed.

Changes:
- `taxonomy/categories.yaml`: remove the two category entries, add targeted legacy migrations.
- `docs/js/artifact-api.js`: taxonomy contract count 42 → 40.
- Tests updated for the 40-category contract (`test_category_taxonomy`, `test_build_search_index`, `test_pages_request_budget`).

Verified locally: `check_taxonomy_governance.py` clean (40 categories, 45 legacy migrations, 0 errors/warnings); 537 tests pass (modules needing `requests`/`aiohttp`/`jsonschema` not runnable locally — CI covers them; none reference the demoted categories).

Merge order: data-repo migration majiayu000/claude-skill-registry-data#102 must land first so the sync gate never sees legacy `travel/`/`war-room/` directories.