### PR TITLE
fix: compare community intake diffs against the merge base

### DIFF
--- a/scripts/check_community_intake_diff.py
+++ b/scripts/check_community_intake_diff.py
@@ -36,6 +36,24 @@ def _git_show(ref: str, path: Path) -> str:
     return result.stdout
 
 
+def _git_merge_base(base_ref: str, head_ref: str) -> str:
+    """Resolve the fork point so entries merged into base after the branch was cut
+    are not misread as deletions made by the pull request."""
+    result = subprocess.run(
+        ["git", "merge-base", base_ref, head_ref],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or "unknown git merge-base failure"
+        raise RuntimeError(f"failed to resolve merge base of {base_ref} and {head_ref}: {stderr}")
+    merge_base = result.stdout.strip()
+    if not merge_base:
+        raise RuntimeError(f"empty merge base for {base_ref} and {head_ref}")
+    return merge_base
+
+
 def _load_payload(label: str, text: str) -> tuple[dict[str, Any] | None, list[str]]:
     try:
         payload = json.loads(text)
@@ -229,7 +247,8 @@ def validate_community_intake_text(base_text: str, head_text: str) -> list[str]:
 
 def validate_community_intake_diff(config: CommunityIntakeInput) -> list[str]:
     try:
-        base_text = _git_show(config.base_ref, config.path)
+        merge_base = _git_merge_base(config.base_ref, config.head_ref)
+        base_text = _git_show(merge_base, config.path)
         head_text = _git_show(config.head_ref, config.path)
     except RuntimeError as exc:
         return [str(exc)]

--- a/tests/test_check_community_intake_diff.py
+++ b/tests/test_check_community_intake_diff.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -7,7 +8,53 @@ SCRIPTS_DIR = ROOT / "scripts"
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
-from check_community_intake_diff import validate_community_intake_text  # noqa: E402
+from check_community_intake_diff import (  # noqa: E402
+    CommunityIntakeInput,
+    validate_community_intake_diff,
+    validate_community_intake_text,
+)
+
+CATALOG_PATH = Path("sources/community.json")
+
+
+def make_skill(name: str) -> dict[str, object]:
+    return {
+        "name": name,
+        "repo": f"acme/{name}",
+        "path": "",
+        "description": name.upper(),
+        "category": "development",
+        "tags": [name[0]],
+        "stars": 0,
+    }
+
+
+def git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def write_catalog(repo: Path, skills: list[dict[str, object]], message: str) -> None:
+    target = repo / CATALOG_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(render_catalog(skills), encoding="utf-8")
+    git(repo, "add", str(CATALOG_PATH))
+    git(repo, "commit", "-m", message)
+
+
+def init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init", "-b", "main")
+    git(repo, "config", "user.email", "test@example.com")
+    git(repo, "config", "user.name", "Test")
+    return repo
 
 
 def render_catalog(skills: list[dict[str, object]]) -> str:
@@ -445,3 +492,61 @@ def test_rejects_appended_top_level_metadata_fields():
     assert validate_community_intake_text(base, head) == [
         "top-level metadata fields other than `skills` must not change in community intake PRs"
     ]
+
+
+def test_stale_branch_is_not_treated_as_entry_removal(tmp_path, monkeypatch):
+    """A branch cut before base gained new entries must still pass: those entries
+    are missing from head because of the fork point, not because the PR removed them."""
+    repo = init_repo(tmp_path)
+    write_catalog(repo, [make_skill("alpha")], "seed")
+    fork_point = git(repo, "rev-parse", "HEAD")
+
+    git(repo, "checkout", "-b", "intake")
+    write_catalog(repo, [make_skill("alpha"), make_skill("gamma")], "add gamma")
+    head_ref = git(repo, "rev-parse", "HEAD")
+
+    git(repo, "checkout", "main")
+    write_catalog(repo, [make_skill("alpha"), make_skill("beta")], "add beta upstream")
+    base_ref = git(repo, "rev-parse", "HEAD")
+    assert base_ref != fork_point
+
+    monkeypatch.chdir(repo)
+    config = CommunityIntakeInput(base_ref=base_ref, head_ref=head_ref, path=CATALOG_PATH)
+
+    assert validate_community_intake_diff(config) == []
+
+
+def test_removal_relative_to_fork_point_is_still_rejected(tmp_path, monkeypatch):
+    repo = init_repo(tmp_path)
+    write_catalog(repo, [make_skill("alpha"), make_skill("beta")], "seed")
+
+    git(repo, "checkout", "-b", "intake")
+    write_catalog(repo, [make_skill("alpha")], "drop beta")
+    head_ref = git(repo, "rev-parse", "HEAD")
+
+    git(repo, "checkout", "main")
+    base_ref = git(repo, "rev-parse", "HEAD")
+
+    monkeypatch.chdir(repo)
+    config = CommunityIntakeInput(base_ref=base_ref, head_ref=head_ref, path=CATALOG_PATH)
+
+    assert validate_community_intake_diff(config) == [
+        "community intake PRs must not remove catalog entries"
+    ]
+
+
+def test_unrelated_histories_fail_closed(tmp_path, monkeypatch):
+    repo = init_repo(tmp_path)
+    write_catalog(repo, [make_skill("alpha")], "seed")
+    head_ref = git(repo, "rev-parse", "HEAD")
+
+    git(repo, "checkout", "--orphan", "detached")
+    write_catalog(repo, [make_skill("beta")], "unrelated root")
+    base_ref = git(repo, "rev-parse", "HEAD")
+
+    monkeypatch.chdir(repo)
+    config = CommunityIntakeInput(base_ref=base_ref, head_ref=head_ref, path=CATALOG_PATH)
+
+    errors = validate_community_intake_diff(config)
+    assert len(errors) == 1
+    assert "merge base" in errors[0]


### PR DESCRIPTION
## What/Why

`scripts/check_community_intake_diff.py` read `sources/community.json` at the **base branch head** (`git show <base.sha>:...`) instead of at the fork point. Any PR branch cut before `main` gained new catalog entries therefore looks like it deleted them, and the guard fails with `community intake PRs must not remove catalog entries`.

This is not hypothetical: #260 touches only `scripts/**` and `tests/**` — no `sources/community.json` change at all — and still fails the guard, because the branch is 23 commits behind `main` and `sync-data` appends to the catalog constantly. Every long-lived PR that touches `scripts/**` will hit this.

Fix: resolve `git merge-base <base> <head>` and read the base text from there. When the merge base cannot be determined (unrelated histories, shallow checkout without enough depth) the guard reports an error rather than falling back to the old behavior — this check exists to block noisy catalog rewrites, so it must fail closed.

## Proof

`tests/test_check_community_intake_diff.py` previously covered only the pure-text validator; the git-facing path had no tests. Added three that build real repositories:

- `test_stale_branch_is_not_treated_as_entry_removal` — reproduces #260's failure
- `test_removal_relative_to_fork_point_is_still_rejected` — real deletions are still blocked (guards against over-correcting)
- `test_unrelated_histories_fail_closed` — no silent degradation when the merge base is unresolvable

```
$ python -m pytest tests/test_check_community_intake_diff.py -q
13 passed

$ git stash push scripts/check_community_intake_diff.py   # revert the fix only
2 failed, 11 passed
   FAILED test_stale_branch_is_not_treated_as_entry_removal
   FAILED test_unrelated_histories_fail_closed
```

The removal test passes both with and without the fix, confirming the change narrows only the false-positive case.

`ruff check` clean on both files.

## Review Focus

Whether failing closed on an unresolvable merge base is right for shallow checkouts. `metadata-compliance.yml` uses `fetch-depth: 0`, so the merge base is always available in CI today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)