### PR TITLE
refactor: drop redundant RuntimeError from bare-Exception handlers

### DIFF
--- a/scripts/fetch_curated_skills.py
+++ b/scripts/fetch_curated_skills.py
@@ -77,7 +77,7 @@ def main() -> None:
     for i, (repo, repo_targets) in enumerate(sorted(by_repo.items()), 1):
         try:
             tree = fetch_repo_tree(repo)
-        except (RuntimeError, Exception) as exc:  # noqa: BLE001 — recorded per row
+        except Exception as exc:  # noqa: BLE001 — recorded per row
             report.extend({**t, "fetch": "repo_error", "error": str(exc)[:200]}
                           for t in repo_targets)
             continue

--- a/scripts/verify_upstream_assets.py
+++ b/scripts/verify_upstream_assets.py
@@ -35,7 +35,7 @@ def resolve_skill_dir(target: dict, skill_dirs: list[str]) -> str | None:
 def verify_repo(repo: str, targets: list[dict]) -> list[dict]:
     try:
         paths = fetch_repo_tree(repo)
-    except (RuntimeError, Exception) as exc:  # noqa: BLE001 — recorded per row
+    except Exception as exc:  # noqa: BLE001 — recorded per row
         return [{**t, "status": "repo_error", "error": str(exc)[:200]} for t in targets]
     skill_dirs = [os.path.dirname(p) for p in paths if os.path.basename(p) == "SKILL.md"]
     rows = []


### PR DESCRIPTION
## What/Why

Follow-up to #260. Both upstream-facing loops were written as:

```python
except (RuntimeError, Exception) as exc:  # noqa: BLE001 — recorded per row
```

`RuntimeError` is a subclass of `Exception`, so the tuple is exactly equivalent to `except Exception` — but it reads as if the handler were scoped to the `RuntimeError` that `fetch_repo_tree` raises, which is a narrower contract than the code actually has.

The broad catch is deliberate and stays: a single unreachable repo must not abort a 348-repo verification run, and both sites record the failure as a `repo_error` row rather than swallowing it. Only the misleading tuple is removed.

## Proof

```
$ python -m pytest tests/test_skill_asset_pipeline.py tests/test_skill_asset_audit.py -q
38 passed
```

`test_tree_failure_marks_every_target` and `TestFetchMain::test_skips_unverified_rows_and_writes_report` both exercise these handlers and assert the `repo_error` rows still come through.

`ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)