### PR TITLE
fix: align scan totals with published search set

### DIFF
--- a/scripts/build_search_index.py
+++ b/scripts/build_search_index.py
@@ -611,7 +611,10 @@ def build_search_index(
         except Exception:
             pass
 
-    indexed_skill_count_scan_shape = len(skills)
+    # The scan-shaped public set is the stable-key winner set published by the
+    # search and category artifacts. Keep the pre-dedup scan size in the
+    # explicit raw archive counters and search-index-lite.json.raw_count.
+    indexed_skill_count_scan_shape = len(search_index["s"])
     stats = {
         "schema_version": 1,
         "updated_at": utc_now_isoformat(),

--- a/tests/test_check_artifact_api.py
+++ b/tests/test_check_artifact_api.py
@@ -130,6 +130,66 @@ def test_production_writers_generate_valid_v1_fixture(tmp_path):
     }
 
 
+def test_production_writers_keep_raw_duplicate_count_out_of_same_set_totals(tmp_path):
+    docs = build_generated_fixture(tmp_path)
+    duplicate_skills = [
+        {
+            "name": "Lower-ranked duplicate",
+            "description": "short",
+            "repo": "owner/alpha",
+            "path": "skills/alpha/SKILL.md",
+            "branch": "main",
+            "category": "other",
+            "tags": ["duplicate"],
+            "stars": 1,
+            "install": "owner/alpha/skills/alpha/SKILL.md",
+            "source": "test",
+        },
+        {
+            "name": "alpha",
+            "description": "Alpha skill",
+            "repo": "owner/alpha",
+            "path": "skills/alpha/SKILL.md",
+            "branch": "main",
+            "category": "development",
+            "tags": ["demo"],
+            "stars": 2,
+            "install": "owner/alpha/skills/alpha/SKILL.md",
+            "source": "test",
+        },
+        {
+            "name": "beta",
+            "description": "Beta skill",
+            "repo": "owner/beta",
+            "path": "skills/beta/SKILL.md",
+            "branch": "main",
+            "category": "testing",
+            "tags": ["demo"],
+            "stars": 1,
+            "install": "owner/beta/skills/beta/SKILL.md",
+            "source": "test",
+        },
+    ]
+    build_search_index.build_search_index(
+        duplicate_skills,
+        docs,
+        source_name="fixture with duplicate stable key",
+        archive_skill_md_count_raw=len(duplicate_skills),
+        archive_metadata_count_raw=len(duplicate_skills),
+        registry_skill_count_dedup=2,
+    )
+
+    report = check_artifact_api.validate_artifact_api(tmp_path, docs)
+    stats = _read(docs / "stats.json")
+    lite = _read(docs / "search-index-lite.json")
+
+    assert report.errors == []
+    assert report.totals["scan"] == [2, 2, 2]
+    assert stats["indexed_skill_count_scan_shape"] == 2
+    assert stats["archive_skill_md_count_raw"] == 3
+    assert lite["raw_count"] == 3
+
+
 @pytest.mark.parametrize(
     ("path", "mutate", "expected"),
     [

--- a/tests/test_pages_request_budget.py
+++ b/tests/test_pages_request_budget.py
@@ -406,7 +406,8 @@ def test_generated_full_index_uses_lite_stable_key_winners(tmp_path):
         key: category_index["categories"][0][key] for key in ("name", "code", "count")
     } == {"name": "development", "code": "dev", "count": 1}
     assert category_manifest["count"] == 1
-    assert stats["indexed_skill_count_scan_shape"] == 2
+    assert stats["indexed_skill_count_scan_shape"] == manifest["total_count"] == 1
+    assert lite["raw_count"] == len(duplicate_skills) == 2
     assert stats["lite_index_count"] == manifest["total_count"]
     assert sum(item["count"] for item in stats["category_counts"]) == manifest["total_count"]
 


### PR DESCRIPTION
## Summary

- make `stats.json.indexed_skill_count_scan_shape` count the same stable-key winner set published by search and category artifacts
- keep the pre-dedup scan size in the existing raw archive and lite `raw_count` fields
- add duplicate-key regression coverage for both the writer and the static artifact API validator

## Root cause

The V1 artifact contract groups the search pointer, category manifests, and `indexed_skill_count_scan_shape` as the same set. The producer used raw `len(skills)` for the stats field even though search/category outputs are deduplicated by `install|branch`, causing `group_total_mismatch` on real data.

## Verification

- `python -m pytest -q` — 711 passed, coverage 70.675329%
- `git diff --check`

This does not relax the validator or the security gate.