### PR TITLE
fix: remediate strict archive security backlog

### DIFF
--- a/docs/SECURITY_GUIDE.md
+++ b/docs/SECURITY_GUIDE.md
@@ -93,6 +93,48 @@ python scripts/security_scanner.py skills/ --strict
   - network_access: Imports requests module
 ```
 
+### Archive Remediation (`scripts/remediate_archive_security.py`)
+
+Maintainers can repair a failing data archive without weakening the scanner.
+The remediation tool is dry-run by default and accepts only a full report from
+the same scanner version and ruleset, generated with `--require-metadata`.
+
+```bash
+# 1. Produce the authoritative report from the core checkout.
+python scripts/security_scanner.py \
+  ../claude-skill-registry-data \
+  --quiet \
+  --require-metadata \
+  --output /tmp/archive-security-report.json
+
+# 2. Review a bounded audit plan. This does not modify the data checkout.
+python scripts/remediate_archive_security.py \
+  --skills-dir ../claude-skill-registry-data \
+  --security-report /tmp/archive-security-report.json \
+  --output /tmp/archive-remediation-plan.json
+
+# 3. Apply the same validated plan and write the result outside the archive.
+python scripts/remediate_archive_security.py \
+  --skills-dir ../claude-skill-registry-data \
+  --security-report /tmp/archive-security-report.json \
+  --output /tmp/archive-remediation-result.json \
+  --apply
+
+# 4. Prove that the strict publication scan is clean.
+python scripts/security_scanner.py \
+  ../claude-skill-registry-data \
+  --quiet \
+  --require-metadata \
+  --output /tmp/archive-security-report-after.json
+```
+
+Entries failing only frontmatter parsing are normalized. Entries with any
+security error are removed from the data checkout, where the change remains
+reviewable and recoverable through Git. Before the first mutation, the tool
+validates every content hash and pre-scans every normalized result. The audit
+contains paths, error types, hashes, and source identity, but no raw finding
+snippets that could expose credentials.
+
 ### 3. GitHub Actions Workflow
 
 Automatically runs on:

--- a/docs/SECURITY_SYSTEM_OVERVIEW.md
+++ b/docs/SECURITY_SYSTEM_OVERVIEW.md
@@ -99,6 +99,8 @@ claude-skill-registry-core/
 │   └── skill.schema.json           # JSON Schema 定义
 ├── scripts/
 │   ├── security_scanner.py         # 安全扫描器
+│   ├── remediate_archive_security.py # 归档修复与隔离工具
+│   ├── skill_frontmatter.py        # 统一 frontmatter 规范化
 │   └── test_discovery.py           # 测试脚本
 ├── .github/workflows/
 │   ├── sync-data.yml               # 数据同步

--- a/scripts/remediate_archive_security.py
+++ b/scripts/remediate_archive_security.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Repair format-only scan failures and quarantine security failures."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from security_scanner import (
+    SECURITY_SCANNER_NAME,
+    SECURITY_SCANNER_VERSION,
+    SecurityScanner,
+    security_ruleset_hash,
+    source_content_hash,
+)
+from skill_frontmatter import normalize_skill_frontmatter
+
+FORMAT_ONLY_ERRORS = frozenset({"no_frontmatter", "yaml_parse_error"})
+
+
+@dataclass(frozen=True)
+class Remediation:
+    path: str
+    action: str
+    error_types: tuple[str, ...]
+    content_sha256: str
+    source_repo: str
+    source_path: str
+    source_ref: str
+
+
+def _load_json_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Cannot read {label}: {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a JSON object: {path}")
+    return value
+
+
+def _safe_skill_path(skills_dir: Path, relative_path: str) -> Path:
+    if not relative_path or Path(relative_path).is_absolute():
+        raise ValueError(f"Invalid report skill path: {relative_path!r}")
+    skill_path = (skills_dir / relative_path).resolve()
+    try:
+        skill_path.relative_to(skills_dir)
+    except ValueError as exc:
+        raise ValueError(f"Report skill path escapes archive root: {relative_path}") from exc
+    if skill_path.name != "SKILL.md" or skill_path.parent == skills_dir:
+        raise ValueError(f"Report path is not an archived SKILL.md: {relative_path}")
+    if not skill_path.is_file() or skill_path.is_symlink():
+        raise ValueError(f"Archived SKILL.md is missing or unsafe: {relative_path}")
+    if skill_path.parent.is_symlink():
+        raise ValueError(f"Archived skill directory cannot be a symlink: {relative_path}")
+    return skill_path
+
+
+def build_plan(skills_dir: Path, report: dict[str, Any]) -> list[Remediation]:
+    skills_dir = skills_dir.resolve()
+    scanner = report.get("scanner")
+    policy = report.get("scan_policy")
+    results = report.get("skills")
+    if not isinstance(scanner, dict) or scanner.get("name") != SECURITY_SCANNER_NAME:
+        raise ValueError("Security report has an invalid scanner identity")
+    if scanner.get("version") != SECURITY_SCANNER_VERSION:
+        raise ValueError("Security report scanner version does not match this core checkout")
+    if scanner.get("ruleset_sha256") != security_ruleset_hash():
+        raise ValueError("Security report ruleset does not match this core checkout")
+    if not isinstance(policy, dict) or policy.get("require_metadata") is not True:
+        raise ValueError("Security report must require archive metadata")
+    if not isinstance(results, list):
+        raise ValueError("Security report is missing skill decisions")
+
+    counted_failed = sum(1 for result in results if result.get("safe") is False)
+    aggregate = (report.get("total"), report.get("passed"), report.get("failed"))
+    expected = (len(results), len(results) - counted_failed, counted_failed)
+    if aggregate != expected:
+        raise ValueError("Security report aggregate counts do not match its decisions")
+
+    plan: list[Remediation] = []
+    seen_paths: set[str] = set()
+    for result in results:
+        if result.get("safe") is not False:
+            continue
+        relative_path = result.get("path")
+        if not isinstance(relative_path, str) or relative_path in seen_paths:
+            raise ValueError(f"Security report has an invalid or duplicate path: {relative_path!r}")
+        seen_paths.add(relative_path)
+        skill_path = _safe_skill_path(skills_dir, relative_path)
+
+        issues = result.get("issues")
+        decision = result.get("security_decision")
+        if not isinstance(issues, list) or not isinstance(decision, dict):
+            raise ValueError(f"Security report decision is incomplete: {relative_path}")
+        if decision.get("status") != "failed":
+            raise ValueError(f"Failed skill has a non-failed decision: {relative_path}")
+        provenance = decision.get("provenance")
+        if not isinstance(provenance, dict):
+            raise ValueError(f"Security decision lacks provenance: {relative_path}")
+
+        error_types = tuple(
+            sorted(
+                {
+                    issue.get("type")
+                    for issue in issues
+                    if isinstance(issue, dict)
+                    and issue.get("severity") == "error"
+                    and isinstance(issue.get("type"), str)
+                }
+            )
+        )
+        if not error_types:
+            raise ValueError(f"Failed skill has no typed error: {relative_path}")
+        expected_hash = provenance.get("content_sha256")
+        actual_hash = source_content_hash(skill_path.parent)
+        if not isinstance(expected_hash, str) or expected_hash != actual_hash:
+            raise ValueError(f"Archived content changed after scan: {relative_path}")
+
+        metadata = _load_json_object(skill_path.parent / "metadata.json", "archive metadata")
+        action = "normalize_frontmatter" if set(error_types) <= FORMAT_ONLY_ERRORS else "quarantine"
+        plan.append(
+            Remediation(
+                path=relative_path,
+                action=action,
+                error_types=error_types,
+                content_sha256=actual_hash,
+                source_repo=str(metadata.get("repo") or ""),
+                source_path=str(metadata.get("github_path") or metadata.get("path") or ""),
+                source_ref=str(metadata.get("github_branch") or metadata.get("branch") or ""),
+            )
+        )
+    return sorted(plan, key=lambda item: item.path)
+
+
+def apply_plan(skills_dir: Path, plan: list[Remediation]) -> None:
+    skills_dir = skills_dir.resolve()
+    scanner = SecurityScanner(require_metadata=True)
+
+    # Validate every target before the first mutation so a stale report cannot
+    # leave a partially remediated archive.
+    resolved: list[tuple[Remediation, Path, str | None]] = []
+    for item in plan:
+        skill_path = _safe_skill_path(skills_dir, item.path)
+        if source_content_hash(skill_path.parent) != item.content_sha256:
+            raise ValueError(f"Archived content changed after planning: {item.path}")
+        metadata = _load_json_object(skill_path.parent / "metadata.json", "archive metadata")
+        normalized: str | None = None
+        if item.action == "normalize_frontmatter":
+            content = skill_path.read_text(encoding="utf-8")
+            normalized = normalize_skill_frontmatter(
+                content,
+                metadata,
+                fallback_name=skill_path.parent.name,
+            )
+            if normalized == content:
+                raise ValueError(f"Frontmatter remediation made no change: {item.path}")
+            is_safe, issues = scanner.scan_content(normalized, skill_path)
+            if not is_safe:
+                error_types = sorted(
+                    {
+                        issue.get("type")
+                        for issue in issues
+                        if issue.get("severity") == "error"
+                    }
+                )
+                raise ValueError(
+                    f"Planned normalized skill remains unsafe: {item.path}: {error_types}"
+                )
+        elif item.action != "quarantine":
+            raise ValueError(f"Unknown remediation action: {item.action}")
+        resolved.append((item, skill_path, normalized))
+
+    for item, skill_path, normalized in resolved:
+        if item.action == "quarantine":
+            shutil.rmtree(skill_path.parent)
+            continue
+        if normalized is None:
+            raise ValueError(f"Normalized content is missing: {item.path}")
+        skill_path.write_text(normalized, encoding="utf-8")
+
+
+def write_audit(path: Path, report: dict[str, Any], plan: list[Remediation], applied: bool) -> None:
+    payload = {
+        "schema_version": 1,
+        "source_report": {
+            "scanner": report["scanner"],
+            "generated_at": report.get("generated_at"),
+            "total": report["total"],
+            "passed": report["passed"],
+            "failed": report["failed"],
+        },
+        "applied": applied,
+        "counts": {
+            "total": len(plan),
+            "normalize_frontmatter": sum(item.action == "normalize_frontmatter" for item in plan),
+            "quarantine": sum(item.action == "quarantine" for item in plan),
+        },
+        "remediations": [asdict(item) for item in plan],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--skills-dir", type=Path, required=True)
+    parser.add_argument("--security-report", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True, help="Audit plan/result JSON")
+    parser.add_argument("--apply", action="store_true", help="Apply the plan (default is dry-run)")
+    args = parser.parse_args()
+
+    skills_dir = args.skills_dir.resolve()
+    output = args.output.resolve()
+    if not skills_dir.is_dir():
+        raise ValueError(f"Skills directory does not exist: {skills_dir}")
+    try:
+        output.relative_to(skills_dir)
+    except ValueError:
+        pass
+    else:
+        raise ValueError("Audit output must be outside the archive root")
+
+    report = _load_json_object(args.security_report.resolve(), "security report")
+    plan = build_plan(skills_dir, report)
+    if args.apply:
+        apply_plan(skills_dir, plan)
+    write_audit(output, report, plan, args.apply)
+
+    normalized = sum(item.action == "normalize_frontmatter" for item in plan)
+    quarantined = sum(item.action == "quarantine" for item in plan)
+    mode = "Applied" if args.apply else "Planned"
+    print(f"{mode}: {len(plan)} total, {normalized} normalized, {quarantined} quarantined")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/security_scanner.py
+++ b/scripts/security_scanner.py
@@ -25,12 +25,12 @@ from security_rules import (
     OBFUSCATION_EXEC_PATTERNS,
     SENSITIVE_PATHS,
 )
-from utils import is_declared_bundled_skill_file
+from utils import is_declared_bundled_skill_file, split_frontmatter_content
 
 # Load schema
 SCHEMA_PATH = Path(__file__).parent.parent / "schema" / "skill.schema.json"
 SECURITY_SCANNER_NAME = "claude-skill-registry-security-scanner"
-SECURITY_SCANNER_VERSION = "1.1.2"
+SECURITY_SCANNER_VERSION = "1.1.3"
 
 
 def utc_now_isoformat() -> str:
@@ -134,6 +134,12 @@ class SecurityScanner:
                 {"severity": "error", "type": "read_error", "message": f"Cannot read file: {e}"}
             )
             return False, self.issues
+
+        return self.scan_content(content, skill_path)
+
+    def scan_content(self, content: str, skill_path: Path) -> Tuple[bool, List[Dict]]:
+        """Scan supplied SKILL.md text while resolving support files from its directory."""
+        self.issues = []
 
         # 1. Validate file size
         if len(content) > 1_000_000:  # 1MB limit
@@ -252,16 +258,13 @@ class SecurityScanner:
 
     def _extract_frontmatter(self, content: str) -> dict:
         """Extract YAML frontmatter from SKILL.md"""
-        if not content.startswith("---"):
-            return None
-
-        parts = content.split("---", 2)
-        if len(parts) < 3:
+        frontmatter, _body = split_frontmatter_content(content)
+        if frontmatter is None:
             return None
 
         try:
             # Use safe_load to prevent YAML deserialization attacks
-            return yaml.safe_load(parts[1])
+            return yaml.safe_load(frontmatter)
         except yaml.YAMLError as e:
             self.issues.append(
                 {

--- a/scripts/skill_frontmatter.py
+++ b/scripts/skill_frontmatter.py
@@ -1,0 +1,86 @@
+"""Canonical SKILL.md frontmatter normalization helpers."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import yaml
+from utils import extract_description, normalize_name, split_frontmatter_content
+
+TRAILING_HORIZONTAL_WHITESPACE_RE = re.compile(r"[ \t]+(?=\r?$)", re.MULTILINE)
+
+
+def _strip_trailing_whitespace(content: str) -> str:
+    return TRAILING_HORIZONTAL_WHITESPACE_RE.sub("", content)
+
+
+def _source_text(source: dict[str, Any], key: str) -> str:
+    value = source.get(key)
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _frontmatter_and_body(content: str) -> tuple[dict[str, Any] | None, str]:
+    raw_frontmatter, body = split_frontmatter_content(content)
+    if raw_frontmatter is None:
+        return None, content
+
+    try:
+        frontmatter = yaml.safe_load(raw_frontmatter)
+    except yaml.YAMLError:
+        return None, content
+    if not isinstance(frontmatter, dict):
+        return None, content
+    return frontmatter, body
+
+
+def _canonical_description(content: str, source: dict[str, Any], name: str) -> str:
+    source_description = _source_text(source, "description")
+    if 10 <= len(source_description) <= 500:
+        return source_description
+
+    derived = extract_description(content, max_length=500).strip()
+    if len(derived) >= 10:
+        return derived[:500]
+
+    return f"Archived skill guidance for {name}."[:500]
+
+
+def normalize_skill_frontmatter(
+    content: str,
+    source: dict[str, Any],
+    *,
+    fallback_name: str = "",
+) -> str:
+    """Repair absent/invalid frontmatter and bound an overlong description.
+
+    Valid upstream mappings are preserved except for the existing overlong
+    description repair. Invalid or absent mappings are replaced by the minimum
+    registry schema fields, using archive metadata before body-derived text.
+    """
+    frontmatter, body = _frontmatter_and_body(content)
+    if frontmatter is not None:
+        upstream_description = frontmatter.get("description")
+        if not isinstance(upstream_description, str) or len(upstream_description) <= 500:
+            return content
+
+        source_description = _source_text(source, "description")
+        if not 10 <= len(source_description) <= 500:
+            return content
+
+        frontmatter["description"] = source_description
+        rendered = yaml.safe_dump(frontmatter, sort_keys=False, allow_unicode=True).strip()
+        return _strip_trailing_whitespace(f"---\n{rendered}\n---{body}")
+
+    name = normalize_name(_source_text(source, "name") or fallback_name)
+    description = _canonical_description(body, source, name)
+    rendered = yaml.safe_dump(
+        {"name": name, "description": description},
+        sort_keys=False,
+        allow_unicode=True,
+    ).strip()
+    normalized_body = body.lstrip("\r\n")
+    separator = "\n\n" if normalized_body else "\n"
+    return _strip_trailing_whitespace(
+        f"---\n{rendered}\n---{separator}{normalized_body}"
+    )

--- a/scripts/sync_pipeline_support.py
+++ b/scripts/sync_pipeline_support.py
@@ -33,8 +33,6 @@ import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path, PurePosixPath
 
-import yaml
-
 # Add parent to path for imports
 SCRIPT_DIR = Path(__file__).resolve().parent
 ROOT_DIR = SCRIPT_DIR.parent
@@ -42,6 +40,7 @@ sys.path.insert(0, str(ROOT_DIR))
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from security_blocklist import blocked_metadata_source
+from skill_frontmatter import normalize_skill_frontmatter
 from utils import (
     build_skill_key,
     normalize_category,
@@ -294,31 +293,12 @@ def requires_complete_bundled_archive(skill_content: str) -> bool:
 
 
 def normalize_skill_frontmatter_description(content: str, skill: dict) -> str:
-    """Replace overlong upstream descriptions with the curated source description."""
-    source_description = str(skill.get("description") or "").strip()
-    if not source_description or len(source_description) > 500:
-        return content
-    if not content.startswith("---"):
-        return content
-
-    parts = content.split("---", 2)
-    if len(parts) < 3:
-        return content
-
-    try:
-        frontmatter = yaml.safe_load(parts[1])
-    except yaml.YAMLError:
-        return content
-    if not isinstance(frontmatter, dict):
-        return content
-
-    upstream_description = frontmatter.get("description")
-    if not isinstance(upstream_description, str) or len(upstream_description) <= 500:
-        return content
-
-    frontmatter["description"] = source_description
-    rendered = yaml.safe_dump(frontmatter, sort_keys=False, allow_unicode=True).strip()
-    return f"---\n{rendered}\n---{parts[2]}"
+    """Keep valid upstream data and repair invalid acquisition frontmatter."""
+    return normalize_skill_frontmatter(
+        content,
+        skill,
+        fallback_name=str(skill.get("dir_name") or ""),
+    )
 
 
 def build_manifest_key(repo: str, path: str, name: str, category: str) -> str:

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -432,15 +432,28 @@ def ensure_unique_dir(parent: Path, base_name: str, key: str = "", repo: str = "
 CATEGORY_KEYWORDS = category_keywords()
 
 
+def split_frontmatter_content(content: str) -> tuple[str | None, str]:
+    """Return an exact YAML frontmatter block and body.
+
+    Delimiters must occupy their own lines. Treating any three hyphens as a
+    delimiter corrupts Markdown tables and prose containing longer dash runs.
+    """
+    opening = re.match(r"\A---[ \t]*\r?\n", content)
+    if not opening:
+        return None, content
+    remainder = content[opening.end() :]
+    closing = re.search(r"(?m)^---[ \t]*(?:\r?\n|\Z)", remainder)
+    if not closing:
+        return None, content
+    return remainder[: closing.start()], remainder[closing.end() :]
+
+
 def extract_frontmatter(content: str) -> dict:
     """Extract YAML frontmatter from SKILL.md content using safe_load."""
-    if not content.startswith("---"):
+    frontmatter, _body = split_frontmatter_content(content)
+    if frontmatter is None:
         return {}
     try:
-        end_idx = content.find("---", 3)
-        if end_idx == -1:
-            return {}
-        frontmatter = content[3:end_idx].strip()
         data = yaml.safe_load(frontmatter)
         return data if isinstance(data, dict) else {}
     except yaml.YAMLError:

--- a/tests/test_remediate_archive_security.py
+++ b/tests/test_remediate_archive_security.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import remediate_archive_security as remediation  # noqa: E402
+import security_scanner  # noqa: E402
+from skill_frontmatter import normalize_skill_frontmatter  # noqa: E402
+
+
+def write_skill(root: Path, name: str, content: str) -> Path:
+    skill_dir = root / "development" / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+    (skill_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "name": name,
+                "description": f"Archive metadata description for {name}.",
+                "repo": f"owner/{name}",
+                "github_path": f"skills/{name}",
+                "github_branch": "main",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def scan(root: Path) -> dict:
+    return security_scanner.scan_directory(root, quiet=True, require_metadata=True)
+
+
+def test_normalize_skill_frontmatter_repairs_invalid_and_absent_mappings():
+    invalid = "---\nname: demo\ndescription: Invalid: unquoted colon\n---\n# Demo\n"
+    repaired = normalize_skill_frontmatter(
+        invalid,
+        {"name": "Demo Skill", "description": "A valid archive description."},
+    )
+    absent = normalize_skill_frontmatter(
+        "# Demo\n\nThis body paragraph supplies a sufficiently long description.\n",
+        {"name": "Demo Skill", "description": ""},
+    )
+
+    scanner = security_scanner.SecurityScanner()
+    assert scanner._extract_frontmatter(repaired) == {
+        "name": "demo-skill",
+        "description": "A valid archive description.",
+    }
+    assert "description: This body paragraph supplies" in absent
+
+    unterminated = (
+        "---\nname: demo\ndescription: Unterminated metadata\n"
+        "# Demo\n\n| Topic | Reference |\n| --------- | ---------------- |\n"
+    )
+    repaired_unterminated = normalize_skill_frontmatter(
+        unterminated,
+        {"name": "Demo Skill", "description": ""},
+    )
+    assert scanner._extract_frontmatter(repaired_unterminated) == {
+        "name": "demo-skill",
+        "description": "Archived skill guidance for demo-skill.",
+    }
+    assert unterminated in repaired_unterminated
+
+
+def test_plan_and_apply_repairs_format_only_and_quarantines_security_errors(tmp_path):
+    skills_dir = tmp_path / "skills"
+    invalid_dir = write_skill(
+        skills_dir,
+        "invalid-yaml",
+        "---\nname: invalid-yaml\ndescription: Invalid: unquoted colon\n---\n# Demo\n",
+    )
+    dangerous_dir = write_skill(
+        skills_dir,
+        "dangerous",
+        "---\nname: dangerous\ndescription: A valid dangerous fixture description.\n---\n"
+        "# Demo\n\neval(user_input)\n",
+    )
+    report = scan(skills_dir)
+
+    plan = remediation.build_plan(skills_dir, report)
+
+    assert [(item.path, item.action) for item in plan] == [
+        ("development/dangerous/SKILL.md", "quarantine"),
+        ("development/invalid-yaml/SKILL.md", "normalize_frontmatter"),
+    ]
+
+    remediation.apply_plan(skills_dir, plan)
+
+    assert not dangerous_dir.exists()
+    assert invalid_dir.exists()
+    final_report = scan(skills_dir)
+    assert (final_report["total"], final_report["passed"], final_report["failed"]) == (1, 1, 0)
+
+
+def test_apply_validates_every_target_before_mutating_archive(tmp_path):
+    skills_dir = tmp_path / "skills"
+    invalid_dir = write_skill(
+        skills_dir,
+        "a-invalid-yaml",
+        "---\nname: a-invalid-yaml\ndescription: Invalid: unquoted colon\n---\n# Demo\n",
+    )
+    dangerous_dir = write_skill(
+        skills_dir,
+        "z-dangerous",
+        "---\nname: z-dangerous\ndescription: A valid dangerous fixture description.\n---\n"
+        "# Demo\n\neval(user_input)\n",
+    )
+    original_invalid = (invalid_dir / "SKILL.md").read_text(encoding="utf-8")
+    plan = remediation.build_plan(skills_dir, scan(skills_dir))
+    with (dangerous_dir / "SKILL.md").open("a", encoding="utf-8") as handle:
+        handle.write("# changed after planning\n")
+
+    with pytest.raises(ValueError, match="changed after planning"):
+        remediation.apply_plan(skills_dir, plan)
+
+    assert (invalid_dir / "SKILL.md").read_text(encoding="utf-8") == original_invalid
+    assert dangerous_dir.exists()
+
+
+def test_apply_preflights_normalized_content_before_mutating_archive(tmp_path):
+    skills_dir = tmp_path / "skills"
+    first_dir = write_skill(skills_dir, "a-first", "# First\n")
+    second_dir = write_skill(skills_dir, "z-second", "# Second\n")
+    original_first = (first_dir / "SKILL.md").read_text(encoding="utf-8")
+    report = scan(skills_dir)
+    plan = remediation.build_plan(skills_dir, report)
+    second_metadata_path = second_dir / "metadata.json"
+    second_metadata = json.loads(second_metadata_path.read_text(encoding="utf-8"))
+    second_metadata["description"] = "Unsafe metadata description: eval(user_input)"
+    second_metadata_path.write_text(json.dumps(second_metadata), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Planned normalized skill remains unsafe"):
+        remediation.apply_plan(skills_dir, plan)
+
+    assert (first_dir / "SKILL.md").read_text(encoding="utf-8") == original_first
+    assert second_dir.exists()
+
+
+def test_apply_removes_trailing_whitespace_from_repaired_skill(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skill_dir = write_skill(
+        skills_dir,
+        "missing-frontmatter",
+        "# Demo  \n\nBody text.\t\n",
+    )
+    report = scan(skills_dir)
+
+    remediation.apply_plan(skills_dir, remediation.build_plan(skills_dir, report))
+
+    repaired = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    assert "# Demo\n" in repaired
+    assert "Body text.\n" in repaired
+    assert "  \n" not in repaired
+    assert "\t\n" not in repaired
+
+
+def test_build_plan_rejects_report_aggregate_drift(tmp_path):
+    skills_dir = tmp_path / "skills"
+    write_skill(skills_dir, "missing-frontmatter", "# Demo\n")
+    report = scan(skills_dir)
+    report["failed"] = 0
+
+    with pytest.raises(ValueError, match="aggregate counts"):
+        remediation.build_plan(skills_dir, report)
+
+
+def test_write_audit_contains_only_bounded_remediation_evidence(tmp_path):
+    skills_dir = tmp_path / "skills"
+    write_skill(skills_dir, "missing-frontmatter", "# Demo\n")
+    report = scan(skills_dir)
+    plan = remediation.build_plan(skills_dir, report)
+    output = tmp_path / "audit.json"
+
+    remediation.write_audit(output, report, plan, applied=False)
+    payload = json.loads(output.read_text(encoding="utf-8"))
+
+    assert payload["counts"] == {
+        "total": 1,
+        "normalize_frontmatter": 1,
+        "quarantine": 0,
+    }
+    assert (
+        payload["remediations"][0]["path"]
+        == "development/missing-frontmatter/SKILL.md"
+    )
+    assert "issues" not in payload["remediations"][0]
+
+
+def test_main_dry_run_writes_audit_without_changing_archive(
+    tmp_path, monkeypatch, capsys
+):
+    skills_dir = tmp_path / "skills"
+    skill_dir = write_skill(skills_dir, "missing-frontmatter", "# Demo\n")
+    original = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    report_path = tmp_path / "security-report.json"
+    output_path = tmp_path / "audit" / "remediation-plan.json"
+    report_path.write_text(json.dumps(scan(skills_dir)), encoding="utf-8")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "remediate_archive_security.py",
+            "--skills-dir",
+            str(skills_dir),
+            "--security-report",
+            str(report_path),
+            "--output",
+            str(output_path),
+        ],
+    )
+
+    assert remediation.main() == 0
+
+    audit = json.loads(output_path.read_text(encoding="utf-8"))
+    assert audit["applied"] is False
+    assert audit["counts"] == {
+        "total": 1,
+        "normalize_frontmatter": 1,
+        "quarantine": 0,
+    }
+    assert (skill_dir / "SKILL.md").read_text(encoding="utf-8") == original
+    assert "Planned: 1 total, 1 normalized, 0 quarantined" in capsys.readouterr().out

--- a/tests/test_security_scanner.py
+++ b/tests/test_security_scanner.py
@@ -265,6 +265,24 @@ description: Invalid YAML: unquoted colon
     assert not any(issue.get("type") == "no_frontmatter" for issue in issues)
 
 
+def test_scanner_does_not_treat_markdown_dash_runs_as_frontmatter_delimiters(tmp_path):
+    module = load_module()
+    skill_dir = tmp_path / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: Unterminated metadata\n"
+        "# Demo\n\n| Topic | Reference |\n| --------- | ---------------- |\n",
+        encoding="utf-8",
+    )
+
+    scanner = module.SecurityScanner()
+    is_safe, issues = scanner.scan_file(skill_dir / "SKILL.md")
+
+    assert is_safe is False
+    assert any(issue.get("type") == "no_frontmatter" for issue in issues)
+    assert not any(issue.get("type") == "yaml_parse_error" for issue in issues)
+
+
 def test_single_file_scan_exits_nonzero_for_unsafe_skill(tmp_path):
     skill_dir = tmp_path / "demo"
     skill_dir.mkdir(parents=True)

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -764,6 +764,15 @@ def test_bundled_file_allowlist_is_scoped_and_size_limited():
     assert "Curated short source description." in normalized
     assert "x" * 501 not in normalized
 
+    repaired = support.normalize_skill_frontmatter_description(
+        "# Demo\n\nA body paragraph that remains after frontmatter repair.\n",
+        {"name": "Demo Skill", "description": "Curated source description."},
+    )
+    assert repaired.startswith(
+        "---\nname: demo-skill\ndescription: Curated source description.\n---\n\n"
+    )
+    assert "A body paragraph that remains" in repaired
+
 
 def test_bundles_root_helpers_src_and_design_subskills(tmp_path, monkeypatch):
     module = load_module()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -467,6 +467,16 @@ def test_extract_frontmatter_returns_empty_for_unterminated(utils):
     assert utils.extract_frontmatter("---\nname: demo\n") == {}
 
 
+def test_extract_frontmatter_ignores_markdown_dash_runs(utils):
+    content = (
+        "---\nname: demo\ndescription: Unterminated metadata\n"
+        "# Demo\n\n| Topic | Reference |\n| --------- | ---------------- |\n"
+    )
+
+    assert utils.extract_frontmatter(content) == {}
+    assert utils.split_frontmatter_content(content) == (None, content)
+
+
 def test_extract_frontmatter_returns_empty_for_invalid_yaml(utils):
     bad = "---\n: : : not yaml\n  -broken\n---\nbody"
     assert utils.extract_frontmatter(bad) == {}


### PR DESCRIPTION
Part of #267.

This keeps the Build Index security gate fail-closed and fixes the underlying archive path:

- parse frontmatter delimiters only when `---` is on its own line
- normalize invalid/absent frontmatter during intake
- add a hash-bound, dry-run-first archive remediation tool
- preflight all repaired content before the first archive mutation
- remove security-failing entries from the data checkout while preserving bounded audit evidence

Fresh local verification:

- `pytest -q`: 721 passed
- ruff and `git diff --check`: passed
- source archive scan (scanner 1.1.3): 205,437 total / 9,111 failed
- remediated data scan with `--require-metadata`: 202,336 total / 202,336 passed / 0 failed

The 9,111 source count is 198 higher than the prior CI count because exact-line delimiter parsing now exposes unterminated/missing frontmatter that the old split logic accidentally hid. The security-error quarantine set remains 3,101 entries.