### PR TITLE
fix: preserve publish co-author attribution

### DIFF
--- a/docs/attribution-backfills.md
+++ b/docs/attribution-backfills.md
@@ -1,0 +1,20 @@
+# Attribution Backfills
+
+This ledger records contributor credit restored after a generated change had
+already been published without its source `Co-authored-by` trailer. The normal
+publish workflow now derives validated trailers from the pinned core and data
+commit ranges; entries here are only for pre-automation history and must link
+the original contribution, authoritative port, and published artifact.
+
+## Lee — DynamoDB on-demand pricing correction
+
+- Contributor: [Lee (`LeeroyHannigan`)](https://github.com/LeeroyHannigan)
+- Original report: [main issue #54](https://github.com/majiayu000/claude-skill-registry/issues/54)
+- Original patch: [main PR #53](https://github.com/majiayu000/claude-skill-registry/pull/53)
+- Authoritative port: [data PR #103](https://github.com/majiayu000/claude-skill-registry-data/pull/103)
+- Attributed data commit: `1884f5ff62faefcbbcd656105660254edf23fa61`
+- First published main commit: `2d82af0b54ec083b2c593042a33b4255aaf1601e`
+
+The data commit preserved `Co-authored-by: Lee <leeroyhannigan@yahoo.ie>`, but
+the old subject-only main publisher dropped the trailer. The main commit that
+introduces this ledger is the non-history-rewriting attribution backfill.

--- a/scripts/build_publish_commit_message.py
+++ b/scripts/build_publish_commit_message.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Build a main publish commit message with validated source attribution."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+REPOSITORY_PATTERN = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+COAUTHOR_PATTERN = re.compile(
+    r"(?P<name>[^<>\x00-\x1f\x7f]{1,200}?)\s+"
+    r"<(?P<email>[^\s<>@]{1,64}@[^\s<>@]{1,253})>"
+)
+CONTROL_PATTERN = re.compile(r"[\x00-\x1f\x7f]")
+MAX_SOURCE_COMMITS = 10_000
+MAX_COAUTHORS = 200
+
+
+class AttributionError(ValueError):
+    """Raised when source history cannot safely produce publish attribution."""
+
+
+@dataclass(frozen=True)
+class Coauthor:
+    name: str
+    email: str
+
+    @property
+    def trailer(self) -> str:
+        return f"Co-authored-by: {self.name} <{self.email}>"
+
+
+@dataclass(frozen=True)
+class SourceRange:
+    label: str
+    repository: str
+    directory: Path
+    previous_sha: str
+    new_sha: str
+
+
+def _run_git(directory: Path, arguments: list[str]) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", "-C", str(directory), *arguments],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "git command failed"
+        raise AttributionError(f"{directory}: {detail}")
+    return result
+
+
+def _validate_repository(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or not REPOSITORY_PATTERN.fullmatch(value):
+        raise AttributionError(f"{field} must be an owner/name repository")
+    return value
+
+
+def _validate_sha(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or not SHA_PATTERN.fullmatch(value):
+        raise AttributionError(f"{field} must be a lowercase 40-character Git SHA")
+    return value
+
+
+def load_previous_provenance(path: Path) -> dict[str, str]:
+    if not path.is_file():
+        raise AttributionError(f"previous provenance is missing: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise AttributionError(f"previous provenance is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise AttributionError("previous provenance must be a JSON object")
+
+    return {
+        "core_repo": _validate_repository(payload.get("core_repo"), field="core_repo"),
+        "core_sha": _validate_sha(payload.get("core_sha"), field="core_sha"),
+        "data_repo": _validate_repository(payload.get("data_repo"), field="data_repo"),
+        "data_sha": _validate_sha(payload.get("data_sha"), field="data_sha"),
+    }
+
+
+def parse_coauthor_value(value: str) -> Coauthor:
+    if CONTROL_PATTERN.search(value):
+        raise AttributionError("Co-authored-by value contains a control character")
+    normalized = value.strip()
+    match = COAUTHOR_PATTERN.fullmatch(normalized)
+    if match is None:
+        raise AttributionError(f"invalid Co-authored-by value: {value!r}")
+    name = match.group("name").strip()
+    email = match.group("email")
+    if not name:
+        raise AttributionError("Co-authored-by name must not be blank")
+    return Coauthor(name=name, email=email)
+
+
+def _verify_source(source: SourceRange) -> None:
+    _validate_repository(source.repository, field=f"{source.label}_repo")
+    _validate_sha(source.previous_sha, field=f"previous_{source.label}_sha")
+    _validate_sha(source.new_sha, field=f"new_{source.label}_sha")
+    if not source.directory.is_dir():
+        raise AttributionError(f"{source.label} checkout is missing: {source.directory}")
+
+    head = _run_git(source.directory, ["rev-parse", "HEAD"]).stdout.strip()
+    if head != source.new_sha:
+        raise AttributionError(
+            f"{source.label} checkout HEAD is {head}, expected pinned SHA {source.new_sha}"
+        )
+    for sha in (source.previous_sha, source.new_sha):
+        _run_git(source.directory, ["cat-file", "-e", f"{sha}^{{commit}}"])
+
+
+def _is_ancestor(directory: Path, ancestor: str, descendant: str) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(directory), "merge-base", "--is-ancestor", ancestor, descendant],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    detail = result.stderr.strip() or result.stdout.strip() or "git merge-base failed"
+    raise AttributionError(f"{directory}: {detail}")
+
+
+def _forward_commits(source: SourceRange) -> list[str]:
+    _verify_source(source)
+    if source.previous_sha == source.new_sha:
+        return []
+    if _is_ancestor(source.directory, source.previous_sha, source.new_sha):
+        output = _run_git(
+            source.directory,
+            [
+                "rev-list",
+                "--reverse",
+                "--topo-order",
+                f"{source.previous_sha}..{source.new_sha}",
+            ],
+        ).stdout
+        commits = [line for line in output.splitlines() if line]
+        if len(commits) > MAX_SOURCE_COMMITS:
+            raise AttributionError(
+                f"{source.label} range contains {len(commits)} commits; "
+                f"maximum is {MAX_SOURCE_COMMITS}"
+            )
+        return commits
+    if _is_ancestor(source.directory, source.new_sha, source.previous_sha):
+        return []
+    raise AttributionError(
+        f"{source.label} history diverged: neither {source.previous_sha} nor "
+        f"{source.new_sha} is an ancestor of the other"
+    )
+
+
+def _commit_coauthors(directory: Path, commit_sha: str) -> list[Coauthor]:
+    trailer_format = "%(trailers:key=Co-authored-by,valueonly,separator=%x00,unfold=true)"
+    output = _run_git(directory, ["show", "-s", f"--format={trailer_format}", commit_sha]).stdout
+    if output.endswith("\n"):
+        output = output[:-1]
+    if not output:
+        return []
+    return [parse_coauthor_value(value) for value in output.split("\x00")]
+
+
+def collect_coauthors(sources: list[SourceRange]) -> list[Coauthor]:
+    collected: list[Coauthor] = []
+    seen_emails: set[str] = set()
+    for source in sources:
+        for commit_sha in _forward_commits(source):
+            for coauthor in _commit_coauthors(source.directory, commit_sha):
+                identity = coauthor.email.casefold()
+                if identity in seen_emails:
+                    continue
+                seen_emails.add(identity)
+                collected.append(coauthor)
+                if len(collected) > MAX_COAUTHORS:
+                    raise AttributionError(
+                        f"publish range contains more than {MAX_COAUTHORS} unique co-authors"
+                    )
+    return collected
+
+
+def build_commit_message(core_sha: str, data_sha: str, coauthors: list[Coauthor]) -> str:
+    _validate_sha(core_sha, field="core_sha")
+    _validate_sha(data_sha, field="data_sha")
+    subject = f"chore: publish merged artifact core@{core_sha[:12]} data@{data_sha[:12]}"
+    if not coauthors:
+        return f"{subject}\n"
+    trailers = "\n".join(coauthor.trailer for coauthor in coauthors)
+    return f"{subject}\n\n{trailers}\n"
+
+
+def build_from_provenance(
+    *,
+    previous_provenance: Path,
+    core_repo: str,
+    core_dir: Path,
+    core_sha: str,
+    data_repo: str,
+    data_dir: Path,
+    data_sha: str,
+) -> tuple[str, list[Coauthor]]:
+    previous = load_previous_provenance(previous_provenance)
+    core_repo = _validate_repository(core_repo, field="core_repo")
+    data_repo = _validate_repository(data_repo, field="data_repo")
+    core_sha = _validate_sha(core_sha, field="core_sha")
+    data_sha = _validate_sha(data_sha, field="data_sha")
+    if previous["core_repo"].casefold() != core_repo.casefold():
+        raise AttributionError("core repository changed from previous provenance")
+    if previous["data_repo"].casefold() != data_repo.casefold():
+        raise AttributionError("data repository changed from previous provenance")
+
+    sources = [
+        SourceRange("core", core_repo, core_dir, previous["core_sha"], core_sha),
+        SourceRange("data", data_repo, data_dir, previous["data_sha"], data_sha),
+    ]
+    coauthors = collect_coauthors(sources)
+    return build_commit_message(core_sha, data_sha, coauthors), coauthors
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build a publish commit message from pinned source commit ranges."
+    )
+    parser.add_argument("--previous-provenance", type=Path, required=True)
+    parser.add_argument("--core-repo", required=True)
+    parser.add_argument("--core-dir", type=Path, required=True)
+    parser.add_argument("--core-sha", required=True)
+    parser.add_argument("--data-repo", required=True)
+    parser.add_argument("--data-dir", type=Path, required=True)
+    parser.add_argument("--data-sha", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        message, coauthors = build_from_provenance(
+            previous_provenance=args.previous_provenance,
+            core_repo=args.core_repo,
+            core_dir=args.core_dir,
+            core_sha=args.core_sha,
+            data_repo=args.data_repo,
+            data_dir=args.data_dir,
+            data_sha=args.data_sha,
+        )
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(message, encoding="utf-8")
+    except AttributionError as exc:
+        print(f"Publish attribution validation failed: {exc}")
+        return 1
+
+    print(f"Built publish commit message with {len(coauthors)} unique co-author(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_publish_commit_message.py
+++ b/tests/test_build_publish_commit_message.py
@@ -1,0 +1,368 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import build_publish_commit_message as attribution  # noqa: E402
+from build_publish_commit_message import (  # noqa: E402
+    AttributionError,
+    SourceRange,
+    build_commit_message,
+    build_from_provenance,
+    collect_coauthors,
+    load_previous_provenance,
+    parse_coauthor_value,
+)
+
+
+def git(repo: Path, *arguments: str, input_text: str | None = None) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *arguments],
+        input=input_text,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def init_repo(path: Path) -> str:
+    path.mkdir()
+    git(path, "init", "--quiet")
+    git(path, "config", "user.name", "Test Maintainer")
+    git(path, "config", "user.email", "maintainer@example.com")
+    return commit(path, "initial")
+
+
+def commit(repo: Path, message: str) -> str:
+    git(repo, "commit", "--allow-empty", "--file=-", input_text=f"{message}\n")
+    return git(repo, "rev-parse", "HEAD")
+
+
+def source_range(label: str, repo: Path, previous_sha: str, new_sha: str) -> SourceRange:
+    return SourceRange(
+        label=label,
+        repository=f"owner/{label}",
+        directory=repo,
+        previous_sha=previous_sha,
+        new_sha=new_sha,
+    )
+
+
+def write_provenance(path: Path, core_sha: str, data_sha: str) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-08-02T00:00:00Z",
+                "core_repo": "owner/core",
+                "core_sha": core_sha,
+                "data_repo": "owner/data",
+                "data_sha": data_sha,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_collects_source_trailers_in_deterministic_order_and_deduplicates_email(tmp_path):
+    core = tmp_path / "core"
+    data = tmp_path / "data"
+    old_core = init_repo(core)
+    old_data = init_repo(data)
+    new_core = commit(
+        core,
+        "core change\n\nCo-authored-by: Lee <leeroyhannigan@yahoo.ie>",
+    )
+    new_data = commit(
+        data,
+        "data change\n\n"
+        "Co-authored-by: Duplicate Lee <LEEROYHANNIGAN@yahoo.ie>\n"
+        "Co-authored-by: Ada Lovelace <ada@example.com>",
+    )
+
+    coauthors = collect_coauthors(
+        [
+            source_range("core", core, old_core, new_core),
+            source_range("data", data, old_data, new_data),
+        ]
+    )
+
+    assert [item.trailer for item in coauthors] == [
+        "Co-authored-by: Lee <leeroyhannigan@yahoo.ie>",
+        "Co-authored-by: Ada Lovelace <ada@example.com>",
+    ]
+
+
+def test_rejects_malformed_source_trailer(tmp_path):
+    repo = tmp_path / "core"
+    previous_sha = init_repo(repo)
+    new_sha = commit(repo, "change\n\nCo-authored-by: missing-email")
+
+    with pytest.raises(AttributionError, match="invalid Co-authored-by value"):
+        collect_coauthors([source_range("core", repo, previous_sha, new_sha)])
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "Lee <lee@example.com>\nInjected: value",
+        "Lee <lee@example.com>\x7f",
+        "<lee@example.com>",
+        "Lee lee@example.com",
+    ],
+)
+def test_rejects_invalid_or_injectable_values(value):
+    with pytest.raises(AttributionError):
+        parse_coauthor_value(value)
+
+
+def test_ignores_unchanged_and_explicit_rollback_ranges(tmp_path):
+    repo = tmp_path / "data"
+    old_sha = init_repo(repo)
+    new_sha = commit(repo, "change\n\nCo-authored-by: Lee <lee@example.com>")
+
+    unchanged = collect_coauthors([source_range("data", repo, new_sha, new_sha)])
+    git(repo, "checkout", "--quiet", "--detach", old_sha)
+    rollback = collect_coauthors([source_range("data", repo, new_sha, old_sha)])
+
+    assert unchanged == []
+    assert rollback == []
+
+
+def test_rejects_divergent_source_history(tmp_path):
+    repo = tmp_path / "data"
+    base_sha = init_repo(repo)
+    first_sha = commit(repo, "first branch")
+    git(repo, "checkout", "--quiet", "--detach", base_sha)
+    second_sha = commit(repo, "second branch")
+
+    with pytest.raises(AttributionError, match="history diverged"):
+        collect_coauthors([source_range("data", repo, first_sha, second_sha)])
+
+
+def test_rejects_checkout_that_does_not_match_pinned_new_sha(tmp_path):
+    repo = tmp_path / "core"
+    old_sha = init_repo(repo)
+    expected_sha = commit(repo, "expected")
+    commit(repo, "unexpected head")
+
+    with pytest.raises(AttributionError, match="expected pinned SHA"):
+        collect_coauthors([source_range("core", repo, old_sha, expected_sha)])
+
+
+def test_rejects_missing_checkout_and_invalid_source_identity(tmp_path):
+    with pytest.raises(AttributionError, match="owner/name"):
+        collect_coauthors(
+            [SourceRange("core", "invalid", tmp_path / "missing", "a" * 40, "b" * 40)]
+        )
+
+    with pytest.raises(AttributionError, match="40-character Git SHA"):
+        collect_coauthors(
+            [SourceRange("core", "owner/core", tmp_path / "missing", "bad", "b" * 40)]
+        )
+
+    with pytest.raises(AttributionError, match="checkout is missing"):
+        collect_coauthors(
+            [
+                SourceRange(
+                    "core",
+                    "owner/core",
+                    tmp_path / "missing",
+                    "a" * 40,
+                    "b" * 40,
+                )
+            ]
+        )
+
+
+def test_rejects_missing_source_commit(tmp_path):
+    repo = tmp_path / "core"
+    head_sha = init_repo(repo)
+
+    with pytest.raises(AttributionError, match="Not a valid object name"):
+        collect_coauthors([source_range("core", repo, "a" * 40, head_sha)])
+
+
+def test_enforces_source_commit_and_coauthor_limits(tmp_path, monkeypatch):
+    repo = tmp_path / "data"
+    old_sha = init_repo(repo)
+    commit(repo, "first")
+    new_sha = commit(repo, "second")
+    monkeypatch.setattr(attribution, "MAX_SOURCE_COMMITS", 1)
+
+    with pytest.raises(AttributionError, match="range contains 2 commits"):
+        collect_coauthors([source_range("data", repo, old_sha, new_sha)])
+
+    repo = tmp_path / "core"
+    old_sha = init_repo(repo)
+    new_sha = commit(
+        repo,
+        "change\n\nCo-authored-by: One <one@example.com>\nCo-authored-by: Two <two@example.com>",
+    )
+    monkeypatch.setattr(attribution, "MAX_SOURCE_COMMITS", 10_000)
+    monkeypatch.setattr(attribution, "MAX_COAUTHORS", 1)
+
+    with pytest.raises(AttributionError, match="more than 1 unique co-authors"):
+        collect_coauthors([source_range("core", repo, old_sha, new_sha)])
+
+
+def test_builds_exact_subject_and_trailer_block():
+    coauthor = parse_coauthor_value("Lee <leeroyhannigan@yahoo.ie>")
+
+    message = build_commit_message("a" * 40, "b" * 40, [coauthor])
+
+    assert message == (
+        "chore: publish merged artifact core@aaaaaaaaaaaa data@bbbbbbbbbbbb\n\n"
+        "Co-authored-by: Lee <leeroyhannigan@yahoo.ie>\n"
+    )
+
+
+def test_builds_subject_only_message_without_source_trailers():
+    assert build_commit_message("a" * 40, "b" * 40, []) == (
+        "chore: publish merged artifact core@aaaaaaaaaaaa data@bbbbbbbbbbbb\n"
+    )
+
+
+@pytest.mark.parametrize(
+    ("contents", "error"),
+    [
+        (None, "previous provenance is missing"),
+        ("not-json", "not valid JSON"),
+        ("[]", "must be a JSON object"),
+        ("{}", "core_repo must be an owner/name repository"),
+    ],
+)
+def test_rejects_missing_or_invalid_previous_provenance(tmp_path, contents, error):
+    path = tmp_path / "previous.json"
+    if contents is not None:
+        path.write_text(contents, encoding="utf-8")
+
+    with pytest.raises(AttributionError, match=error):
+        load_previous_provenance(path)
+
+
+def test_build_from_provenance_rejects_repository_change(tmp_path):
+    core = tmp_path / "core"
+    data = tmp_path / "data"
+    core_sha = init_repo(core)
+    data_sha = init_repo(data)
+    provenance = tmp_path / "previous.json"
+    write_provenance(provenance, core_sha, data_sha)
+
+    with pytest.raises(AttributionError, match="core repository changed"):
+        build_from_provenance(
+            previous_provenance=provenance,
+            core_repo="other/core",
+            core_dir=core,
+            core_sha=core_sha,
+            data_repo="owner/data",
+            data_dir=data,
+            data_sha=data_sha,
+        )
+
+
+def test_build_from_provenance_accepts_repository_name_case_changes(tmp_path):
+    core = tmp_path / "core"
+    data = tmp_path / "data"
+    core_sha = init_repo(core)
+    data_sha = init_repo(data)
+    provenance = tmp_path / "previous.json"
+    write_provenance(provenance, core_sha, data_sha)
+
+    message, coauthors = build_from_provenance(
+        previous_provenance=provenance,
+        core_repo="Owner/Core",
+        core_dir=core,
+        core_sha=core_sha,
+        data_repo="Owner/Data",
+        data_dir=data,
+        data_sha=data_sha,
+    )
+
+    assert coauthors == []
+    assert message.endswith(f"data@{data_sha[:12]}\n")
+
+
+def test_cli_writes_message_from_previous_provenance(tmp_path):
+    core = tmp_path / "core"
+    data = tmp_path / "data"
+    old_core = init_repo(core)
+    old_data = init_repo(data)
+    new_core = commit(core, "core change")
+    new_data = commit(
+        data,
+        "pricing fix\n\nCo-authored-by: Lee <leeroyhannigan@yahoo.ie>",
+    )
+    provenance = tmp_path / "previous.json"
+    output = tmp_path / "commit-message.txt"
+    write_provenance(provenance, old_core, old_data)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPTS_DIR / "build_publish_commit_message.py"),
+            "--previous-provenance",
+            str(provenance),
+            "--core-repo",
+            "owner/core",
+            "--core-dir",
+            str(core),
+            "--core-sha",
+            new_core,
+            "--data-repo",
+            "owner/data",
+            "--data-dir",
+            str(data),
+            "--data-sha",
+            new_data,
+            "--output",
+            str(output),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "1 unique co-author(s)" in result.stdout
+    assert output.read_text(encoding="utf-8").endswith(
+        "\n\nCo-authored-by: Lee <leeroyhannigan@yahoo.ie>\n"
+    )
+
+
+def test_main_returns_failure_without_writing_for_invalid_provenance(tmp_path, monkeypatch, capsys):
+    output = tmp_path / "message.txt"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "build_publish_commit_message.py",
+            "--previous-provenance",
+            str(tmp_path / "missing.json"),
+            "--core-repo",
+            "owner/core",
+            "--core-dir",
+            str(tmp_path / "core"),
+            "--core-sha",
+            "a" * 40,
+            "--data-repo",
+            "owner/data",
+            "--data-dir",
+            str(tmp_path / "data"),
+            "--data-sha",
+            "b" * 40,
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert attribution.main() == 1
+    assert not output.exists()
+    assert "Publish attribution validation failed" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- derive `Co-authored-by` trailers from the immutable core/data ranges between the previous and next main provenance tuples
- validate pinned checkout identity, repository identity, ancestry, trailer shape, control characters, range size, and deterministic email deduplication
- preserve explicit rollback behavior while failing closed for truly divergent histories
- add an auditable pre-automation attribution ledger for Lee's DynamoDB pricing correction

Closes #269

## Safety

- dispatch continues to contain only repository names and immutable SHAs
- no free-form contributor identity crosses the workflow dispatch boundary
- malformed trailers, mismatched checkouts, and divergent histories block publication
- published history is not amended or force-pushed

## Verification

- `python -m pytest -q --cov-report=xml:coverage.xml --cov-report=json:coverage.json` — 743 passed
- `python scripts/check_coverage_ratchet.py --coverage coverage.json --baseline coverage-baseline.json --compare-ref origin/main` — passed
- `diff-cover coverage.xml --compare-branch=origin/main --fail-under=80` — 94% changed-line coverage
- `ruff check scripts/build_publish_commit_message.py tests/test_build_publish_commit_message.py`
- `ruff format --check scripts/build_publish_commit_message.py tests/test_build_publish_commit_message.py`
- real data history integration: `4d5ef602d1b1..1884f5ff62fa` extracts exactly `Co-authored-by: Lee <leeroyhannigan@yahoo.ie>`
