### PR TITLE
feat: audit archived asset backfill state

### DIFF
--- a/scripts/asset_claims.py
+++ b/scripts/asset_claims.py
@@ -1,0 +1,57 @@
+"""Side-effect-free detection of skill dependencies on bundled assets."""
+
+from __future__ import annotations
+
+import re
+
+BUNDLED_DIR_ALLOWLIST = {
+    "bin",
+    "connectors",
+    "references",
+    "reference",
+    "scripts",
+    "assets",
+    "knowledge",
+    "templates",
+    "examples",
+    "prompts",
+    "rules",
+    "src",
+}
+
+BUNDLED_ROOT_FILE_ALLOWLIST = {
+    "audit.md",
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "requirements.txt",
+    "pyproject.toml",
+    "setup.md",
+    "uv.lock",
+    "README.md",
+    "LICENSE",
+    "LICENSE.md",
+}
+
+BUNDLED_REQUIRED_ROOT_FILE_HINTS = BUNDLED_ROOT_FILE_ALLOWLIST - {
+    "README.md",
+    "LICENSE",
+    "LICENSE.md",
+}
+
+
+def requires_complete_bundled_archive(skill_content: str) -> bool:
+    """Return True when SKILL.md explicitly depends on bundled support files."""
+    normalized = (skill_content or "").lower().replace("\\", "/")
+    for dirname in BUNDLED_DIR_ALLOWLIST:
+        if re.search(rf"(?<![a-z0-9_.-]){re.escape(dirname)}/", normalized):
+            return True
+    if re.search(r"(?<![a-z0-9_.-])design-[a-z0-9-]+/", normalized):
+        return True
+    if re.search(
+        r"(?<![a-z0-9_/.-])[a-z0-9][a-z0-9_.-]*\.(?:py|swift)(?![a-z0-9_.-])",
+        normalized,
+    ):
+        return True
+    return any(filename.lower() in normalized for filename in BUNDLED_REQUIRED_ROOT_FILE_HINTS)

--- a/scripts/asset_claims.py
+++ b/scripts/asset_claims.py
@@ -39,11 +39,13 @@ BUNDLED_REQUIRED_ROOT_FILE_HINTS = BUNDLED_ROOT_FILE_ALLOWLIST - {
     "LICENSE",
     "LICENSE.md",
 }
+_URL_RE = re.compile(r"https?://\S+")
 
 
 def requires_complete_bundled_archive(skill_content: str) -> bool:
     """Return True when SKILL.md explicitly depends on bundled support files."""
-    normalized = (skill_content or "").lower().replace("\\", "/")
+    without_urls = _URL_RE.sub("", skill_content or "")
+    normalized = without_urls.lower().replace("\\", "/")
     for dirname in BUNDLED_DIR_ALLOWLIST:
         if re.search(rf"(?<![a-z0-9_.-]){re.escape(dirname)}/", normalized):
             return True

--- a/scripts/audit_skill_assets.py
+++ b/scripts/audit_skill_assets.py
@@ -4,20 +4,36 @@
 Usage:
   python scripts/audit_skill_assets.py census <data_repo_root>
   python scripts/audit_skill_assets.py targets <data_repo_root> [min_stars]
+  python scripts/audit_skill_assets.py current-state <data_repo_root> [min_stars]
+  python scripts/audit_skill_assets.py backfill-targets <data_repo_root> [min_stars]
 
 `census` prints bucket statistics (EXEC / REF / BARE) as JSON.
 `targets` prints JSONL of deduped EXEC candidates at or above min_stars
 (default 100) for upstream verification by verify_upstream_assets.py.
+`current-state` reports what is actually archived and how it compares with
+metadata. `backfill-targets` emits only deterministic, exact-path candidates
+that claim support files but currently archive none.
 """
 from __future__ import annotations
 
 import collections
 import json
 import os
+import re
+import stat
 import sys
+from pathlib import Path, PurePosixPath
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from skill_asset_audit import classify_skill_text, iter_archived_skills
+from skill_asset_audit import (
+    classify_files,
+    classify_skill_text,
+    iter_archived_skills,
+    verdict_from_counts,
+)
+from utils import build_skill_key, is_declared_bundled_skill_file
+
+REPO_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
 
 def _read_skill(dirpath: str) -> str:
@@ -73,14 +89,203 @@ def run_targets(root: str, min_stars: int) -> None:
         }))
 
 
+def _canonical_source(repo_value: object, path_value: object) -> tuple[str, str, str]:
+    repo = repo_value.strip() if isinstance(repo_value, str) else ""
+    if not REPO_PATTERN.fullmatch(repo):
+        return repo, "", "invalid_repo"
+    if not isinstance(path_value, str) or not path_value.strip():
+        return repo, "", "missing_source_path"
+
+    source_path = path_value.strip().replace("\\", "/")
+    if source_path.startswith("/") or re.match(r"^[A-Za-z]:/", source_path):
+        return repo, source_path, "absolute_source_path"
+    parts = source_path.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        return repo, source_path, "invalid_source_path"
+    if parts[-1] != "SKILL.md":
+        return repo, source_path, "source_path_not_skill_md"
+    return repo, "/".join(parts), ""
+
+
+def _source_dir(source_path: str) -> str:
+    parent = PurePosixPath(source_path).parent.as_posix()
+    return "" if parent == "." else parent
+
+
+def _actual_bundled_files(dirpath: str) -> list[str]:
+    root = Path(dirpath)
+    files = []
+    for path in root.rglob("*"):
+        relative = path.relative_to(root).as_posix()
+        if path.is_symlink():
+            raise ValueError(f"symbolic link is not allowed in archive skill: {relative}")
+        try:
+            mode = path.lstat().st_mode
+        except OSError as exc:
+            raise ValueError(f"unable to inspect archive support path {relative}: {exc}") from exc
+        if not stat.S_ISREG(mode):
+            continue
+        if relative in {"SKILL.md", "metadata.json"}:
+            continue
+        files.append(relative)
+    return sorted(files)
+
+
+def _local_verdict(paths: list[str]) -> str:
+    counts = classify_files(paths)
+    counts["doc"] += sum(1 for path in paths if path.lower().endswith("/skill.md"))
+    return verdict_from_counts(counts)
+
+
+def _parse_stars(value: object, metadata_path: Path) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"invalid stars in {metadata_path}: {value!r}")
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"invalid stars in {metadata_path}: {value!r}") from exc
+
+
+def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
+    archive_root = Path(root).resolve()
+    claim_counts: collections.Counter = collections.Counter()
+    local_verdict_counts: collections.Counter = collections.Counter()
+    asset_state_counts: collections.Counter = collections.Counter()
+    archive_mode_counts: collections.Counter = collections.Counter()
+    key_counts: collections.Counter = collections.Counter()
+    candidates = []
+    total_skills = 0
+    actual_bundled_file_count = 0
+    metadata_mismatch_count = 0
+
+    for dirpath, raw_meta in iter_archived_skills(root):
+        skill_dir = Path(dirpath).resolve()
+        skill_md = skill_dir / "SKILL.md"
+        if is_declared_bundled_skill_file(skill_md, archive_root):
+            continue
+
+        metadata_path = skill_dir / "metadata.json"
+        if metadata_path.exists() and not isinstance(raw_meta, dict):
+            raise ValueError(f"invalid metadata object: {metadata_path}")
+        metadata = raw_meta if isinstance(raw_meta, dict) else {}
+        relative_dir = skill_dir.relative_to(archive_root).as_posix()
+        path_parts = PurePosixPath(relative_dir).parts
+        category = str(metadata.get("category") or (path_parts[0] if path_parts else "other"))
+        name = str(metadata.get("name") or (path_parts[-1] if path_parts else skill_dir.name))
+        raw_source_path = metadata.get("path") or metadata.get("github_path") or ""
+        repo, source_path, source_error = _canonical_source(
+            metadata.get("repo"), raw_source_path
+        )
+        stable_key = (
+            f"{repo}:{source_path}"
+            if not source_error
+            else build_skill_key(
+                repo,
+                str(raw_source_path),
+                name=name,
+                category=category,
+            )
+        )
+        if stable_key:
+            key_counts[stable_key] += 1
+
+        actual_files = _actual_bundled_files(dirpath)
+        declared_raw = metadata.get("bundled_files")
+        declared_files = (
+            sorted(
+                str(path).strip().replace("\\", "/").strip("/")
+                for path in declared_raw
+                if isinstance(path, str) and path.strip()
+            )
+            if isinstance(declared_raw, list)
+            else []
+        )
+        actual_archive_mode = "directory" if actual_files else "skill-md"
+        declared_archive_mode = str(metadata.get("archive_mode") or "")
+        claim = classify_skill_text(_read_skill(dirpath))
+        local_verdict = _local_verdict(actual_files)
+        if actual_files:
+            asset_state = "archived"
+        elif claim != "BARE":
+            asset_state = "missing_claimed_assets"
+        else:
+            asset_state = "no_assets_claimed"
+
+        total_skills += 1
+        actual_bundled_file_count += len(actual_files)
+        claim_counts[claim] += 1
+        local_verdict_counts[local_verdict] += 1
+        asset_state_counts[asset_state] += 1
+        archive_mode_counts[actual_archive_mode] += 1
+        if declared_archive_mode != actual_archive_mode or declared_files != actual_files:
+            metadata_mismatch_count += 1
+
+        stars = _parse_stars(metadata.get("stars"), metadata_path)
+        if (
+            asset_state == "missing_claimed_assets"
+            and stars >= min_stars
+            and not source_error
+        ):
+            candidates.append({
+                "stable_key": stable_key,
+                "archive_path": relative_dir,
+                "repo": repo,
+                "source_path": source_path,
+                "dir": _source_dir(source_path),
+                "name": name,
+                "category": category,
+                "stars": stars,
+                "claim": claim,
+            })
+
+    if not total_skills:
+        raise SystemExit(f"no SKILL.md found under {root}")
+
+    ambiguous_keys = {key for key, count in key_counts.items() if count > 1}
+    targets = sorted(
+        (row for row in candidates if row["stable_key"] not in ambiguous_keys),
+        key=lambda row: (row["stable_key"], row["archive_path"]),
+    )
+    report = {
+        "schema_version": 1,
+        "total_skills": total_skills,
+        "claim_counts": dict(claim_counts),
+        "local_verdict_counts": dict(local_verdict_counts),
+        "asset_state_counts": dict(asset_state_counts),
+        "archive_mode_counts": dict(archive_mode_counts),
+        "actual_bundled_file_count": actual_bundled_file_count,
+        "metadata_mismatch_count": metadata_mismatch_count,
+        "ambiguous_stable_key_count": len(ambiguous_keys),
+        "backfill_candidate_count": len(targets),
+    }
+    return report, targets
+
+
+def build_backfill_targets(root: str, min_stars: int = 100) -> list[dict]:
+    _report, targets = _scan_inventory(root, min_stars)
+    return targets
+
+
+def run_current_state(root: str, min_stars: int = 100) -> dict:
+    report, _targets = _scan_inventory(root, min_stars)
+    return report
+
+
 def main() -> None:
-    if len(sys.argv) < 3 or sys.argv[1] not in ("census", "targets"):
+    modes = {"census", "targets", "current-state", "backfill-targets"}
+    if len(sys.argv) < 3 or sys.argv[1] not in modes:
         raise SystemExit(__doc__)
     mode, root = sys.argv[1], sys.argv[2]
+    min_stars = int(sys.argv[3]) if len(sys.argv) > 3 else 100
     if mode == "census":
         print(json.dumps(run_census(root), indent=2))
+    elif mode == "targets":
+        run_targets(root, min_stars)
+    elif mode == "current-state":
+        sys.stdout.write(json.dumps(run_current_state(root, min_stars), indent=2) + "\n")
     else:
-        run_targets(root, int(sys.argv[3]) if len(sys.argv) > 3 else 100)
+        for target in build_backfill_targets(root, min_stars):
+            sys.stdout.write(json.dumps(target) + "\n")
 
 
 if __name__ == "__main__":

--- a/scripts/audit_skill_assets.py
+++ b/scripts/audit_skill_assets.py
@@ -31,7 +31,7 @@ from skill_asset_audit import (
     iter_archived_skills,
     verdict_from_counts,
 )
-from utils import build_skill_key, is_declared_bundled_skill_file
+from utils import build_skill_key
 
 REPO_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
@@ -45,6 +45,8 @@ def run_census(root: str) -> dict:
     buckets: collections.Counter = collections.Counter()
     sizes: dict[str, list[int]] = collections.defaultdict(list)
     for dirpath, _meta in iter_archived_skills(root):
+        if not _is_canonical_archive_skill(dirpath, root):
+            continue
         text = _read_skill(dirpath)
         bucket = classify_skill_text(text)
         buckets[bucket] += 1
@@ -68,6 +70,8 @@ def run_census(root: str) -> dict:
 def run_targets(root: str, min_stars: int) -> None:
     seen: set[tuple[str, str]] = set()
     for dirpath, meta in iter_archived_skills(root):
+        if not _is_canonical_archive_skill(dirpath, root):
+            continue
         if not meta:
             continue
         stars = meta.get("stars") or 0
@@ -89,7 +93,18 @@ def run_targets(root: str, min_stars: int) -> None:
         }))
 
 
-def _canonical_source(repo_value: object, path_value: object) -> tuple[str, str, str]:
+def _is_canonical_archive_skill(dirpath: str, root: str | Path) -> bool:
+    try:
+        relative = Path(dirpath).resolve().relative_to(Path(root).resolve())
+    except ValueError:
+        return False
+    return len(relative.parts) == 2
+
+
+def canonical_source_identity(
+    repo_value: object,
+    path_value: object,
+) -> tuple[str, str, str]:
     repo = repo_value.strip() if isinstance(repo_value, str) else ""
     if not REPO_PATTERN.fullmatch(repo):
         return repo, "", "invalid_repo"
@@ -102,9 +117,33 @@ def _canonical_source(repo_value: object, path_value: object) -> tuple[str, str,
     parts = source_path.split("/")
     if any(part in {"", ".", ".."} for part in parts):
         return repo, source_path, "invalid_source_path"
-    if parts[-1] != "SKILL.md":
+    if parts[-1].casefold() != "skill.md":
         return repo, source_path, "source_path_not_skill_md"
     return repo, "/".join(parts), ""
+
+
+def canonical_source_identity_from_metadata(metadata: dict) -> tuple[str, str, str]:
+    """Return one exact source identity, rejecting conflicting path aliases."""
+    aliases = []
+    for field in ("path", "github_path"):
+        if field not in metadata:
+            continue
+        repo, source_path, error = canonical_source_identity(
+            metadata.get("repo"), metadata[field]
+        )
+        if error:
+            return repo, source_path, error
+        aliases.append((repo, source_path))
+    if not aliases:
+        return canonical_source_identity(metadata.get("repo"), None)
+    if any(identity != aliases[0] for identity in aliases[1:]):
+        return aliases[0][0], aliases[0][1], "conflicting_source_path_aliases"
+    return aliases[0][0], aliases[0][1], ""
+
+
+# Preserve the private helper used by existing callers while the strict public
+# parser is shared by later pipeline phases.
+_canonical_source = canonical_source_identity
 
 
 def _source_dir(source_path: str) -> str:
@@ -138,12 +177,31 @@ def _local_verdict(paths: list[str]) -> str:
 
 
 def _parse_stars(value: object, metadata_path: Path) -> int:
-    if isinstance(value, bool):
+    if value is None:
+        return 0
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
         raise ValueError(f"invalid stars in {metadata_path}: {value!r}")
-    try:
-        return int(value or 0)
-    except (TypeError, ValueError) as exc:
-        raise ValueError(f"invalid stars in {metadata_path}: {value!r}") from exc
+    return value
+
+
+def _declared_bundled_files(metadata: dict) -> tuple[list[str], bool]:
+    if "bundled_files" not in metadata:
+        return [], True
+    declared = metadata["bundled_files"]
+    if not isinstance(declared, list):
+        return [], False
+    normalized = []
+    for value in declared:
+        if not isinstance(value, str) or not value or value != value.strip() or "\\" in value:
+            return [], False
+        path = PurePosixPath(value)
+        if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+            return [], False
+        normalized_path = path.as_posix()
+        if normalized_path in {"SKILL.md", "metadata.json"} or normalized_path in normalized:
+            return [], False
+        normalized.append(normalized_path)
+    return sorted(normalized), True
 
 
 def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
@@ -160,8 +218,7 @@ def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
 
     for dirpath, raw_meta in iter_archived_skills(root):
         skill_dir = Path(dirpath).resolve()
-        skill_md = skill_dir / "SKILL.md"
-        if is_declared_bundled_skill_file(skill_md, archive_root):
+        if not _is_canonical_archive_skill(dirpath, archive_root):
             continue
 
         metadata_path = skill_dir / "metadata.json"
@@ -172,12 +229,12 @@ def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
         path_parts = PurePosixPath(relative_dir).parts
         category = str(metadata.get("category") or (path_parts[0] if path_parts else "other"))
         name = str(metadata.get("name") or (path_parts[-1] if path_parts else skill_dir.name))
-        raw_source_path = metadata.get("path") or metadata.get("github_path") or ""
-        repo, source_path, source_error = _canonical_source(
-            metadata.get("repo"), raw_source_path
+        raw_source_path = (
+            metadata.get("path") if "path" in metadata else metadata.get("github_path", "")
         )
+        repo, source_path, source_error = canonical_source_identity_from_metadata(metadata)
         stable_key = (
-            f"{repo}:{source_path}"
+            f"{repo.casefold()}:{source_path}"
             if not source_error
             else build_skill_key(
                 repo,
@@ -190,16 +247,7 @@ def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
             key_counts[stable_key] += 1
 
         actual_files = _actual_bundled_files(dirpath)
-        declared_raw = metadata.get("bundled_files")
-        declared_files = (
-            sorted(
-                str(path).strip().replace("\\", "/").strip("/")
-                for path in declared_raw
-                if isinstance(path, str) and path.strip()
-            )
-            if isinstance(declared_raw, list)
-            else []
-        )
+        declared_files, declared_files_valid = _declared_bundled_files(metadata)
         actual_archive_mode = "directory" if actual_files else "skill-md"
         declared_archive_mode = str(metadata.get("archive_mode") or "")
         claim = classify_skill_text(_read_skill(dirpath))
@@ -217,7 +265,11 @@ def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
         local_verdict_counts[local_verdict] += 1
         asset_state_counts[asset_state] += 1
         archive_mode_counts[actual_archive_mode] += 1
-        if declared_archive_mode != actual_archive_mode or declared_files != actual_files:
+        if (
+            declared_archive_mode != actual_archive_mode
+            or not declared_files_valid
+            or declared_files != actual_files
+        ):
             metadata_mismatch_count += 1
 
         stars = _parse_stars(metadata.get("stars"), metadata_path)
@@ -225,6 +277,7 @@ def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
             asset_state == "missing_claimed_assets"
             and stars >= min_stars
             and not source_error
+            and declared_files_valid
         ):
             candidates.append({
                 "stable_key": stable_key,

--- a/scripts/audit_skill_assets.py
+++ b/scripts/audit_skill_assets.py
@@ -34,7 +34,6 @@ from skill_asset_audit import (
 from utils import build_skill_key
 
 REPO_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
-COMMIT_SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
 
 
 def _read_skill(dirpath: str) -> str:
@@ -158,7 +157,6 @@ def canonical_source_branch_from_metadata(metadata: dict) -> tuple[str, str]:
             not branch
             or len(branch) > 255
             or any(ord(character) < 33 or ord(character) == 127 for character in branch)
-            or COMMIT_SHA_PATTERN.fullmatch(branch)
         ):
             return "", "invalid_source_branch"
         branches.append(branch)
@@ -267,7 +265,9 @@ def _declared_bundled_files(metadata: dict) -> tuple[list[str], bool]:
     for value in declared:
         if not isinstance(value, str) or not value or value != value.strip() or "\\" in value:
             return [], False
-        if any(part in {"", ".", ".."} for part in value.split("/")):
+        if re.match(r"^[A-Za-z]:/", value) or any(
+            part in {"", ".", ".."} for part in value.split("/")
+        ):
             return [], False
         path = PurePosixPath(value)
         if path.is_absolute():

--- a/scripts/audit_skill_assets.py
+++ b/scripts/audit_skill_assets.py
@@ -182,7 +182,7 @@ def is_valid_git_source_ref(ref: str) -> bool:
     """Validate a Git branch-like ref while explicitly allowing commit SHAs."""
     if COMMIT_SHA_PATTERN.fullmatch(ref):
         return True
-    if not ref or len(ref) > 255 or ref == "@" or ref.startswith(("/", "-")):
+    if not ref or len(ref) > 255 or ref.startswith(("/", "-")):
         return False
     if ref.endswith(("/", ".")) or "//" in ref or ".." in ref or "@{" in ref:
         return False

--- a/scripts/audit_skill_assets.py
+++ b/scripts/audit_skill_assets.py
@@ -215,6 +215,7 @@ def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
     total_skills = 0
     actual_bundled_file_count = 0
     metadata_mismatch_count = 0
+    source_identity_errors = []
 
     for dirpath, raw_meta in iter_archived_skills(root):
         skill_dir = Path(dirpath).resolve()
@@ -273,6 +274,16 @@ def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
             metadata_mismatch_count += 1
 
         stars = _parse_stars(metadata.get("stars"), metadata_path)
+        if source_error:
+            source_identity_errors.append({
+                "archive_path": relative_dir,
+                "error": source_error,
+                "eligible_for_backfill": (
+                    asset_state == "missing_claimed_assets"
+                    and stars >= min_stars
+                    and declared_files_valid
+                ),
+            })
         if (
             asset_state == "missing_claimed_assets"
             and stars >= min_stars
@@ -308,6 +319,11 @@ def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
         "archive_mode_counts": dict(archive_mode_counts),
         "actual_bundled_file_count": actual_bundled_file_count,
         "metadata_mismatch_count": metadata_mismatch_count,
+        "source_identity_error_count": len(source_identity_errors),
+        "source_identity_errors": sorted(
+            source_identity_errors,
+            key=lambda row: (row["archive_path"], row["error"]),
+        ),
         "ambiguous_stable_key_count": len(ambiguous_keys),
         "backfill_candidate_count": len(targets),
     }
@@ -315,7 +331,17 @@ def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
 
 
 def build_backfill_targets(root: str, min_stars: int = 100) -> list[dict]:
-    _report, targets = _scan_inventory(root, min_stars)
+    report, targets = _scan_inventory(root, min_stars)
+    blocking_errors = [
+        row
+        for row in report["source_identity_errors"]
+        if row["eligible_for_backfill"]
+    ]
+    if blocking_errors:
+        details = ", ".join(
+            f"{row['archive_path']} ({row['error']})" for row in blocking_errors
+        )
+        raise ValueError(f"invalid source identity for backfill candidates: {details}")
     return targets
 
 

--- a/scripts/audit_skill_assets.py
+++ b/scripts/audit_skill_assets.py
@@ -186,12 +186,12 @@ def canonical_source_identity_from_metadata(metadata: dict) -> tuple[str, str, s
 
 
 def _metadata_source_path(field: str, value: object) -> object:
-    """Expand the legacy directory-form github_path into an exact SKILL.md path."""
-    if field != "github_path" or not isinstance(value, str):
+    """Expand repository-written directory aliases into exact SKILL.md paths."""
+    if field not in {"path", "github_path"} or not isinstance(value, str):
         return value
     source_path = value.strip()
     if not source_path:
-        return "SKILL.md"
+        return "SKILL.md" if field == "github_path" else value
     normalized = source_path.replace("\\", "/")
     if normalized.rsplit("/", 1)[-1].casefold() == "skill.md":
         return source_path

--- a/scripts/audit_skill_assets.py
+++ b/scripts/audit_skill_assets.py
@@ -26,6 +26,7 @@ import sys
 from pathlib import Path, PurePosixPath
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from asset_claims import requires_complete_bundled_archive
 from portable_paths import is_safe_portable_relative_path
 from skill_asset_audit import (
     classify_files,
@@ -123,14 +124,23 @@ def _iter_canonical_archive_paths(root: str | Path):
                 raise ValueError(f"symbolic link is not allowed in archive tree: {relative}")
         if ".git" in dirnames:
             dirnames.remove(".git")
-        if "SKILL.md" not in filenames:
-            continue
         try:
             relative = Path(dirpath).resolve().relative_to(archive_root)
         except ValueError:
             continue
-        if len(relative.parts) == 2:
-            yield relative.as_posix()
+        if len(relative.parts) != 2:
+            continue
+        skill_variants = [name for name in filenames if name.casefold() == "skill.md"]
+        if skill_variants and "SKILL.md" not in skill_variants:
+            raise ValueError(
+                f"canonical SKILL.md has invalid casing: {relative / skill_variants[0]}"
+            )
+        if "SKILL.md" not in filenames:
+            continue
+        relative_path = relative.as_posix()
+        if not is_safe_portable_relative_path(relative_path):
+            raise ValueError(f"non-portable canonical archive path: {relative_path}")
+        yield relative_path
 
 
 def _assert_unique_canonical_archive_paths(root: str | Path) -> None:
@@ -205,6 +215,8 @@ def _metadata_source_path(field: str, value: object) -> object:
         return "SKILL.md" if field == "github_path" else value
     normalized = source_path.replace("\\", "/")
     if normalized.rsplit("/", 1)[-1].casefold() == "skill.md":
+        return source_path
+    if PurePosixPath(normalized).suffix:
         return source_path
     return f"{source_path}/SKILL.md"
 
@@ -305,22 +317,28 @@ def _actual_bundled_files(dirpath: str) -> list[str]:
     root = Path(dirpath)
     files = []
     archive_paths = []
-    for path in root.rglob("*"):
-        relative = path.relative_to(root).as_posix()
-        archive_paths.append(relative)
-        if path.is_symlink():
-            raise ValueError(f"symbolic link is not allowed in archive skill: {relative}")
-        if not is_safe_portable_relative_path(relative):
-            raise ValueError(f"non-portable path is not allowed in archive skill: {relative}")
-        try:
-            mode = path.lstat().st_mode
-        except OSError as exc:
-            raise ValueError(f"unable to inspect archive support path {relative}: {exc}") from exc
-        if not stat.S_ISREG(mode):
-            continue
-        if relative in {"SKILL.md", "metadata.json"}:
-            continue
-        files.append(relative)
+
+    def raise_walk_error(error: OSError) -> None:
+        raise ValueError(f"unable to inspect archive skill {dirpath}: {error}") from error
+
+    for current_dir, dirnames, filenames in os.walk(root, onerror=raise_walk_error):
+        for name in [*dirnames, *filenames]:
+            path = Path(current_dir, name)
+            relative = path.relative_to(root).as_posix()
+            archive_paths.append(relative)
+            try:
+                mode = path.lstat().st_mode
+            except OSError as exc:
+                raise ValueError(
+                    f"unable to inspect archive support path {relative}: {exc}"
+                ) from exc
+            if stat.S_ISLNK(mode):
+                raise ValueError(f"symbolic link is not allowed in archive skill: {relative}")
+            if not is_safe_portable_relative_path(relative):
+                raise ValueError(f"non-portable path is not allowed in archive skill: {relative}")
+            if not stat.S_ISREG(mode) or relative in {"SKILL.md", "metadata.json"}:
+                continue
+            files.append(relative)
     if _has_case_conflict(archive_paths):
         raise ValueError(f"case-conflicting paths are not allowed in archive skill: {dirpath}")
     return sorted(files)
@@ -355,7 +373,10 @@ def _declared_bundled_files(metadata: dict) -> tuple[list[str], bool]:
         if path.is_absolute():
             return [], False
         normalized_path = path.as_posix()
-        if normalized_path in {"SKILL.md", "metadata.json"} or normalized_path in normalized:
+        if (
+            normalized_path.casefold() in {"skill.md", "metadata.json"}
+            or normalized_path in normalized
+        ):
             return [], False
         normalized.append(normalized_path)
     if _has_case_conflict(normalized):
@@ -398,11 +419,17 @@ def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
         declared_files, declared_files_valid = _declared_bundled_files(metadata)
         actual_archive_mode = "directory" if actual_files else "skill-md"
         declared_archive_mode = str(metadata.get("archive_mode") or "")
-        claim = classify_skill_text(_read_skill(dirpath))
+        skill_text = _read_skill(dirpath)
+        claim = classify_skill_text(skill_text)
+        pipeline_claim = requires_complete_bundled_archive(skill_text)
         local_verdict = _local_verdict(actual_files)
         if actual_files:
             asset_state = "archived"
-        elif claim != "BARE":
+        elif (
+            claim != "BARE"
+            or pipeline_claim
+            or (declared_files_valid and bool(declared_files))
+        ):
             asset_state = "missing_claimed_assets"
         else:
             asset_state = "no_assets_claimed"

--- a/scripts/audit_skill_assets.py
+++ b/scripts/audit_skill_assets.py
@@ -122,12 +122,47 @@ def _iter_canonical_archive_paths(root: str | Path):
         if len(relative.parts) != 2:
             continue
         skill_variants = [name for name in filenames if name.casefold() == "skill.md"]
-        if skill_variants and "SKILL.md" not in skill_variants:
+        if len(skill_variants) > 1:
+            raise ValueError(
+                f"canonical archive contains case-conflicting SKILL.md files: {relative}"
+            )
+        if skill_variants and skill_variants[0] != "SKILL.md":
             raise ValueError(
                 f"canonical SKILL.md has invalid casing: {relative / skill_variants[0]}"
             )
         if "SKILL.md" not in filenames:
             continue
+        skill_path = Path(dirpath, "SKILL.md")
+        try:
+            skill_mode = skill_path.lstat().st_mode
+        except OSError as exc:
+            raise ValueError(f"unable to inspect canonical SKILL.md: {skill_path}") from exc
+        if not stat.S_ISREG(skill_mode):
+            raise ValueError(f"canonical SKILL.md must be a regular file: {relative}")
+        metadata_variants = [
+            name for name in filenames if name.casefold() == "metadata.json"
+        ]
+        if len(metadata_variants) > 1:
+            raise ValueError(
+                f"canonical archive contains case-conflicting metadata.json files: {relative}"
+            )
+        if metadata_variants and metadata_variants[0] != "metadata.json":
+            raise ValueError(
+                f"canonical metadata.json has invalid casing: "
+                f"{relative / metadata_variants[0]}"
+            )
+        if "metadata.json" in filenames:
+            metadata_path = Path(dirpath, "metadata.json")
+            try:
+                metadata_mode = metadata_path.lstat().st_mode
+            except OSError as exc:
+                raise ValueError(
+                    f"unable to inspect canonical metadata.json: {metadata_path}"
+                ) from exc
+            if not stat.S_ISREG(metadata_mode):
+                raise ValueError(
+                    f"canonical metadata.json must be a regular file: {relative}"
+                )
         relative_path = relative.as_posix()
         if not is_safe_portable_relative_path(relative_path):
             raise ValueError(f"non-portable canonical archive path: {relative_path}")

--- a/scripts/audit_skill_assets.py
+++ b/scripts/audit_skill_assets.py
@@ -31,6 +31,7 @@ from skill_asset_audit import (
     iter_archived_skills,
     verdict_from_counts,
 )
+from sync_pipeline_support import is_safe_portable_relative_path
 from utils import build_skill_key
 
 REPO_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
@@ -102,7 +103,11 @@ def _is_canonical_archive_skill(dirpath: str, root: str | Path) -> bool:
 def _iter_canonical_archive_paths(root: str | Path):
     """Yield canonical archive paths without parsing their metadata."""
     archive_root = Path(root).resolve()
-    for dirpath, dirnames, filenames in os.walk(root):
+
+    def raise_walk_error(error: OSError) -> None:
+        raise ValueError(f"unable to inspect archive tree {root}: {error}") from error
+
+    for dirpath, dirnames, filenames in os.walk(root, onerror=raise_walk_error):
         if ".git" in dirnames:
             dirnames.remove(".git")
         if "SKILL.md" not in filenames:
@@ -152,9 +157,9 @@ def canonical_source_identity(
     source_path = path_value.strip().replace("\\", "/")
     if source_path.startswith("/") or re.match(r"^[A-Za-z]:", source_path):
         return repo, source_path, "absolute_source_path"
-    parts = source_path.split("/")
-    if any(part in {"", ".", ".."} for part in parts):
+    if not is_safe_portable_relative_path(source_path):
         return repo, source_path, "invalid_source_path"
+    parts = source_path.split("/")
     if parts[-1].casefold() != "skill.md":
         return repo, source_path, "source_path_not_skill_md"
     return repo, "/".join(parts), ""
@@ -331,11 +336,7 @@ def _declared_bundled_files(metadata: dict) -> tuple[list[str], bool]:
         return [], False
     normalized = []
     for value in declared:
-        if not isinstance(value, str) or not value or value != value.strip() or "\\" in value:
-            return [], False
-        if re.match(r"^[A-Za-z]:", value) or any(
-            part in {"", ".", ".."} for part in value.split("/")
-        ):
+        if not is_safe_portable_relative_path(value):
             return [], False
         path = PurePosixPath(value)
         if path.is_absolute():

--- a/scripts/audit_skill_assets.py
+++ b/scripts/audit_skill_assets.py
@@ -34,6 +34,7 @@ from skill_asset_audit import (
 from utils import build_skill_key
 
 REPO_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+COMMIT_SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
 
 
 def _read_skill(dirpath: str) -> str:
@@ -108,6 +109,8 @@ def canonical_source_identity(
     repo = repo_value.strip() if isinstance(repo_value, str) else ""
     if not REPO_PATTERN.fullmatch(repo):
         return repo, "", "invalid_repo"
+    if any(component in {".", ".."} for component in repo.split("/")):
+        return repo, "", "invalid_repo"
     if not isinstance(path_value, str) or not path_value.strip():
         return repo, "", "missing_source_path"
 
@@ -141,6 +144,31 @@ def canonical_source_identity_from_metadata(metadata: dict) -> tuple[str, str, s
     return aliases[0][0], aliases[0][1], ""
 
 
+def canonical_source_branch_from_metadata(metadata: dict) -> tuple[str, str]:
+    """Return one exact source branch, rejecting missing or conflicting aliases."""
+    branches = []
+    for field in ("github_branch", "branch"):
+        if field not in metadata:
+            continue
+        raw_branch = metadata[field]
+        if not isinstance(raw_branch, str):
+            return "", "invalid_source_branch"
+        branch = raw_branch.strip()
+        if (
+            not branch
+            or len(branch) > 255
+            or any(ord(character) < 33 or ord(character) == 127 for character in branch)
+            or COMMIT_SHA_PATTERN.fullmatch(branch)
+        ):
+            return "", "invalid_source_branch"
+        branches.append(branch)
+    if not branches:
+        return "", "missing_source_branch"
+    if any(branch != branches[0] for branch in branches[1:]):
+        return "", "conflicting_source_branch_aliases"
+    return branches[0], ""
+
+
 # Preserve the private helper used by existing callers while the strict public
 # parser is shared by later pipeline phases.
 _canonical_source = canonical_source_identity
@@ -151,11 +179,53 @@ def _source_dir(source_path: str) -> str:
     return "" if parent == "." else parent
 
 
+def _identity_keys(metadata: dict, *, name: str, category: str) -> set[str]:
+    """Return every plausible key so malformed aliases still make duplicates ambiguous."""
+    repo_value = metadata.get("repo")
+    repo = repo_value.strip() if isinstance(repo_value, str) else ""
+    values = [metadata[field] for field in ("path", "github_path") if field in metadata]
+    if not values:
+        values = [None]
+
+    keys = set()
+    for value in values:
+        exact_repo, source_path, error = canonical_source_identity(repo_value, value)
+        if not error:
+            keys.add(f"{exact_repo.casefold()}:{source_path}")
+            continue
+        fallback = build_skill_key(
+            repo.casefold(),
+            str(value or ""),
+            name=name,
+            category=category,
+        )
+        if fallback:
+            keys.add(fallback)
+    return keys
+
+
+def _has_case_conflict(paths: list[str]) -> bool:
+    """Detect case-only conflicts in complete paths or any directory prefix."""
+    seen: dict[str, str] = {}
+    for relative in paths:
+        parts = relative.split("/")
+        for length in range(1, len(parts) + 1):
+            prefix = "/".join(parts[:length])
+            folded = prefix.casefold()
+            previous = seen.get(folded)
+            if previous is not None and previous != prefix:
+                return True
+            seen[folded] = prefix
+    return False
+
+
 def _actual_bundled_files(dirpath: str) -> list[str]:
     root = Path(dirpath)
     files = []
+    archive_paths = []
     for path in root.rglob("*"):
         relative = path.relative_to(root).as_posix()
+        archive_paths.append(relative)
         if path.is_symlink():
             raise ValueError(f"symbolic link is not allowed in archive skill: {relative}")
         try:
@@ -167,12 +237,15 @@ def _actual_bundled_files(dirpath: str) -> list[str]:
         if relative in {"SKILL.md", "metadata.json"}:
             continue
         files.append(relative)
+    if _has_case_conflict(archive_paths):
+        raise ValueError(f"case-conflicting paths are not allowed in archive skill: {dirpath}")
     return sorted(files)
 
 
 def _local_verdict(paths: list[str]) -> str:
     counts = classify_files(paths)
     counts["doc"] += sum(1 for path in paths if path.lower().endswith("/skill.md"))
+    counts["asset"] += sum(1 for path in paths if path.endswith("/metadata.json"))
     return verdict_from_counts(counts)
 
 
@@ -194,13 +267,17 @@ def _declared_bundled_files(metadata: dict) -> tuple[list[str], bool]:
     for value in declared:
         if not isinstance(value, str) or not value or value != value.strip() or "\\" in value:
             return [], False
+        if any(part in {"", ".", ".."} for part in value.split("/")):
+            return [], False
         path = PurePosixPath(value)
-        if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        if path.is_absolute():
             return [], False
         normalized_path = path.as_posix()
         if normalized_path in {"SKILL.md", "metadata.json"} or normalized_path in normalized:
             return [], False
         normalized.append(normalized_path)
+    if _has_case_conflict(normalized):
+        return [], False
     return sorted(normalized), True
 
 
@@ -230,22 +307,12 @@ def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
         path_parts = PurePosixPath(relative_dir).parts
         category = str(metadata.get("category") or (path_parts[0] if path_parts else "other"))
         name = str(metadata.get("name") or (path_parts[-1] if path_parts else skill_dir.name))
-        raw_source_path = (
-            metadata.get("path") if "path" in metadata else metadata.get("github_path", "")
-        )
         repo, source_path, source_error = canonical_source_identity_from_metadata(metadata)
-        stable_key = (
-            f"{repo.casefold()}:{source_path}"
-            if not source_error
-            else build_skill_key(
-                repo,
-                str(raw_source_path),
-                name=name,
-                category=category,
-            )
-        )
-        if stable_key:
-            key_counts[stable_key] += 1
+        source_branch, branch_error = canonical_source_branch_from_metadata(metadata)
+        identity_keys = _identity_keys(metadata, name=name, category=category)
+        stable_key = f"{repo.casefold()}:{source_path}" if not source_error else ""
+        for identity_key in identity_keys:
+            key_counts[identity_key] += 1
 
         actual_files = _actual_bundled_files(dirpath)
         declared_files, declared_files_valid = _declared_bundled_files(metadata)
@@ -274,10 +341,11 @@ def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
             metadata_mismatch_count += 1
 
         stars = _parse_stars(metadata.get("stars"), metadata_path)
-        if source_error:
+        provenance_error = source_error or branch_error
+        if provenance_error:
             source_identity_errors.append({
                 "archive_path": relative_dir,
-                "error": source_error,
+                "error": provenance_error,
                 "eligible_for_backfill": (
                     asset_state == "missing_claimed_assets"
                     and stars >= min_stars
@@ -287,7 +355,7 @@ def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
         if (
             asset_state == "missing_claimed_assets"
             and stars >= min_stars
-            and not source_error
+            and not provenance_error
             and declared_files_valid
         ):
             candidates.append({
@@ -295,6 +363,7 @@ def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
                 "archive_path": relative_dir,
                 "repo": repo,
                 "source_path": source_path,
+                "github_branch": source_branch,
                 "dir": _source_dir(source_path),
                 "name": name,
                 "category": category,

--- a/scripts/audit_skill_assets.py
+++ b/scripts/audit_skill_assets.py
@@ -34,6 +34,8 @@ from skill_asset_audit import (
 from utils import build_skill_key
 
 REPO_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+COMMIT_SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
+INVALID_GIT_REF_CHARACTERS = frozenset("~^:?*[\\")
 
 
 def _read_skill(dirpath: str) -> str:
@@ -44,9 +46,7 @@ def _read_skill(dirpath: str) -> str:
 def run_census(root: str) -> dict:
     buckets: collections.Counter = collections.Counter()
     sizes: dict[str, list[int]] = collections.defaultdict(list)
-    for dirpath, _meta in iter_archived_skills(root):
-        if not _is_canonical_archive_skill(dirpath, root):
-            continue
+    for dirpath, _meta in _canonical_archive_rows(root):
         text = _read_skill(dirpath)
         bucket = classify_skill_text(text)
         buckets[bucket] += 1
@@ -69,9 +69,7 @@ def run_census(root: str) -> dict:
 
 def run_targets(root: str, min_stars: int) -> None:
     seen: set[tuple[str, str]] = set()
-    for dirpath, meta in iter_archived_skills(root):
-        if not _is_canonical_archive_skill(dirpath, root):
-            continue
+    for dirpath, meta in _canonical_archive_rows(root):
         if not meta:
             continue
         stars = meta.get("stars") or 0
@@ -99,6 +97,23 @@ def _is_canonical_archive_skill(dirpath: str, root: str | Path) -> bool:
     except ValueError:
         return False
     return len(relative.parts) == 2
+
+
+def _canonical_archive_rows(root: str | Path) -> list[tuple[str, dict | None]]:
+    """Return canonical archive roots after rejecting global case collisions."""
+    archive_root = Path(root).resolve()
+    rows = [
+        (dirpath, metadata)
+        for dirpath, metadata in iter_archived_skills(str(root))
+        if _is_canonical_archive_skill(dirpath, archive_root)
+    ]
+    relative_dirs = [
+        Path(dirpath).resolve().relative_to(archive_root).as_posix()
+        for dirpath, _metadata in rows
+    ]
+    if _has_case_conflict(relative_dirs):
+        raise ValueError(f"archive contains case-conflicting skill roots: {root}")
+    return rows
 
 
 def canonical_source_identity(
@@ -153,11 +168,7 @@ def canonical_source_branch_from_metadata(metadata: dict) -> tuple[str, str]:
         if not isinstance(raw_branch, str):
             return "", "invalid_source_branch"
         branch = raw_branch.strip()
-        if (
-            not branch
-            or len(branch) > 255
-            or any(ord(character) < 33 or ord(character) == 127 for character in branch)
-        ):
+        if not is_valid_git_source_ref(branch):
             return "", "invalid_source_branch"
         branches.append(branch)
     if not branches:
@@ -165,6 +176,24 @@ def canonical_source_branch_from_metadata(metadata: dict) -> tuple[str, str]:
     if any(branch != branches[0] for branch in branches[1:]):
         return "", "conflicting_source_branch_aliases"
     return branches[0], ""
+
+
+def is_valid_git_source_ref(ref: str) -> bool:
+    """Validate a Git branch-like ref while explicitly allowing commit SHAs."""
+    if COMMIT_SHA_PATTERN.fullmatch(ref):
+        return True
+    if not ref or len(ref) > 255 or ref == "@" or ref.startswith(("/", "-")):
+        return False
+    if ref.endswith(("/", ".")) or "//" in ref or ".." in ref or "@{" in ref:
+        return False
+    if any(ord(character) < 33 or ord(character) == 127 for character in ref):
+        return False
+    if any(character in INVALID_GIT_REF_CHARACTERS for character in ref):
+        return False
+    return all(
+        component and not component.startswith(".") and not component.endswith(".lock")
+        for component in ref.split("/")
+    )
 
 
 # Preserve the private helper used by existing callers while the strict public
@@ -294,11 +323,8 @@ def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
     metadata_mismatch_count = 0
     source_identity_errors = []
 
-    for dirpath, raw_meta in iter_archived_skills(root):
+    for dirpath, raw_meta in _canonical_archive_rows(root):
         skill_dir = Path(dirpath).resolve()
-        if not _is_canonical_archive_skill(dirpath, archive_root):
-            continue
-
         metadata_path = skill_dir / "metadata.json"
         if metadata_path.exists() and not isinstance(raw_meta, dict):
             raise ValueError(f"invalid metadata object: {metadata_path}")

--- a/scripts/audit_skill_assets.py
+++ b/scripts/audit_skill_assets.py
@@ -425,7 +425,6 @@ def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
         if (
             asset_state == "missing_claimed_assets"
             and stars >= min_stars
-            and not provenance_error
             and not declared_files_valid
         ):
             metadata_errors.append(
@@ -441,9 +440,7 @@ def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
                     "archive_path": relative_dir,
                     "error": provenance_error,
                     "eligible_for_backfill": (
-                        asset_state == "missing_claimed_assets"
-                        and stars >= min_stars
-                        and declared_files_valid
+                        asset_state == "missing_claimed_assets" and stars >= min_stars
                     ),
                 }
             )

--- a/scripts/audit_skill_assets.py
+++ b/scripts/audit_skill_assets.py
@@ -107,12 +107,20 @@ def _is_canonical_archive_skill(dirpath: str, root: str | Path) -> bool:
 
 def _iter_canonical_archive_paths(root: str | Path):
     """Yield canonical archive paths without parsing their metadata."""
-    archive_root = Path(root).resolve()
+    root_path = Path(root)
+    if root_path.is_symlink():
+        raise ValueError(f"archive root must not be a symbolic link: {root}")
+    archive_root = root_path.resolve()
 
     def raise_walk_error(error: OSError) -> None:
         raise ValueError(f"unable to inspect archive tree {root}: {error}") from error
 
     for dirpath, dirnames, filenames in os.walk(root, onerror=raise_walk_error):
+        for dirname in dirnames:
+            candidate = Path(dirpath, dirname)
+            if candidate.is_symlink():
+                relative = candidate.relative_to(root_path).as_posix()
+                raise ValueError(f"symbolic link is not allowed in archive tree: {relative}")
         if ".git" in dirnames:
             dirnames.remove(".git")
         if "SKILL.md" not in filenames:
@@ -302,6 +310,8 @@ def _actual_bundled_files(dirpath: str) -> list[str]:
         archive_paths.append(relative)
         if path.is_symlink():
             raise ValueError(f"symbolic link is not allowed in archive skill: {relative}")
+        if not is_safe_portable_relative_path(relative):
+            raise ValueError(f"non-portable path is not allowed in archive skill: {relative}")
         try:
             mode = path.lstat().st_mode
         except OSError as exc:

--- a/scripts/audit_skill_assets.py
+++ b/scripts/audit_skill_assets.py
@@ -14,6 +14,7 @@ Usage:
 metadata. `backfill-targets` emits only deterministic, exact-path candidates
 that claim support files but currently archive none.
 """
+
 from __future__ import annotations
 
 import collections
@@ -25,13 +26,13 @@ import sys
 from pathlib import Path, PurePosixPath
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from portable_paths import is_safe_portable_relative_path
 from skill_asset_audit import (
     classify_files,
     classify_skill_text,
     iter_archived_skills,
     verdict_from_counts,
 )
-from sync_pipeline_support import is_safe_portable_relative_path
 from utils import build_skill_key
 
 REPO_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
@@ -84,12 +85,16 @@ def run_targets(root: str, min_stars: int) -> None:
         if key in seen:
             continue
         seen.add(key)
-        print(json.dumps({
-            "repo": repo,
-            "dir": skill_dir,
-            "stars": stars,
-            "name": meta.get("name", ""),
-        }))
+        print(
+            json.dumps(
+                {
+                    "repo": repo,
+                    "dir": skill_dir,
+                    "stars": stars,
+                    "name": meta.get("name", ""),
+                }
+            )
+        )
 
 
 def _is_canonical_archive_skill(dirpath: str, root: str | Path) -> bool:
@@ -172,9 +177,7 @@ def canonical_source_identity_from_metadata(metadata: dict) -> tuple[str, str, s
         if field not in metadata:
             continue
         path_value = _metadata_source_path(field, metadata[field])
-        repo, source_path, error = canonical_source_identity(
-            metadata.get("repo"), path_value
-        )
+        repo, source_path, error = canonical_source_identity(metadata.get("repo"), path_value)
         if error:
             return repo, source_path, error
         aliases.append((repo, source_path))
@@ -409,33 +412,37 @@ def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
         stars = _parse_stars(metadata.get("stars"), metadata_path)
         provenance_error = source_error or branch_error
         if provenance_error:
-            source_identity_errors.append({
-                "archive_path": relative_dir,
-                "error": provenance_error,
-                "eligible_for_backfill": (
-                    asset_state == "missing_claimed_assets"
-                    and stars >= min_stars
-                    and declared_files_valid
-                ),
-            })
+            source_identity_errors.append(
+                {
+                    "archive_path": relative_dir,
+                    "error": provenance_error,
+                    "eligible_for_backfill": (
+                        asset_state == "missing_claimed_assets"
+                        and stars >= min_stars
+                        and declared_files_valid
+                    ),
+                }
+            )
         if (
             asset_state == "missing_claimed_assets"
             and stars >= min_stars
             and not provenance_error
             and declared_files_valid
         ):
-            candidates.append({
-                "stable_key": stable_key,
-                "archive_path": relative_dir,
-                "repo": repo,
-                "source_path": source_path,
-                "github_branch": source_branch,
-                "dir": _source_dir(source_path),
-                "name": name,
-                "category": category,
-                "stars": stars,
-                "claim": claim,
-            })
+            candidates.append(
+                {
+                    "stable_key": stable_key,
+                    "archive_path": relative_dir,
+                    "repo": repo,
+                    "source_path": source_path,
+                    "github_branch": source_branch,
+                    "dir": _source_dir(source_path),
+                    "name": name,
+                    "category": category,
+                    "stars": stars,
+                    "claim": claim,
+                }
+            )
 
     if not total_skills:
         raise SystemExit(f"no SKILL.md found under {root}")
@@ -468,14 +475,10 @@ def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
 def build_backfill_targets(root: str, min_stars: int = 100) -> list[dict]:
     report, targets = _scan_inventory(root, min_stars)
     blocking_errors = [
-        row
-        for row in report["source_identity_errors"]
-        if row["eligible_for_backfill"]
+        row for row in report["source_identity_errors"] if row["eligible_for_backfill"]
     ]
     if blocking_errors:
-        details = ", ".join(
-            f"{row['archive_path']} ({row['error']})" for row in blocking_errors
-        )
+        details = ", ".join(f"{row['archive_path']} ({row['error']})" for row in blocking_errors)
         raise ValueError(f"invalid source identity for backfill candidates: {details}")
     return targets
 

--- a/scripts/audit_skill_assets.py
+++ b/scripts/audit_skill_assets.py
@@ -31,7 +31,6 @@ from portable_paths import is_safe_portable_relative_path
 from skill_asset_audit import (
     classify_files,
     classify_skill_text,
-    iter_archived_skills,
     verdict_from_counts,
 )
 from utils import build_skill_key
@@ -98,14 +97,6 @@ def run_targets(root: str, min_stars: int) -> None:
         )
 
 
-def _is_canonical_archive_skill(dirpath: str, root: str | Path) -> bool:
-    try:
-        relative = Path(dirpath).resolve().relative_to(Path(root).resolve())
-    except ValueError:
-        return False
-    return len(relative.parts) == 2
-
-
 def _iter_canonical_archive_paths(root: str | Path):
     """Yield canonical archive paths without parsing their metadata."""
     root_path = Path(root)
@@ -143,9 +134,9 @@ def _iter_canonical_archive_paths(root: str | Path):
         yield relative_path
 
 
-def _assert_unique_canonical_archive_paths(root: str | Path) -> None:
+def _assert_unique_canonical_archive_paths(paths: list[str], root: str | Path) -> None:
     seen: dict[str, str] = {}
-    for relative in _iter_canonical_archive_paths(root):
+    for relative in paths:
         parts = relative.split("/")
         for length in range(1, len(parts) + 1):
             prefix = "/".join(parts[:length])
@@ -157,12 +148,20 @@ def _assert_unique_canonical_archive_paths(root: str | Path) -> None:
 
 
 def _canonical_archive_rows(root: str | Path):
-    """Stream canonical archive rows after a lightweight path-only preflight."""
+    """Stream canonical rows from the single fail-closed archive preflight."""
     archive_root = Path(root).resolve()
-    _assert_unique_canonical_archive_paths(root)
-    for dirpath, metadata in iter_archived_skills(str(root)):
-        if _is_canonical_archive_skill(dirpath, archive_root):
-            yield dirpath, metadata
+    paths = list(_iter_canonical_archive_paths(root))
+    _assert_unique_canonical_archive_paths(paths, root)
+    for relative in paths:
+        dirpath = archive_root / relative
+        metadata_path = dirpath / "metadata.json"
+        metadata = None
+        if metadata_path.exists():
+            try:
+                metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                raise ValueError(f"invalid metadata object: {metadata_path}: {exc}") from exc
+        yield str(dirpath), metadata
 
 
 def canonical_source_identity(
@@ -216,7 +215,7 @@ def _metadata_source_path(field: str, value: object) -> object:
     normalized = source_path.replace("\\", "/")
     if normalized.rsplit("/", 1)[-1].casefold() == "skill.md":
         return source_path
-    if PurePosixPath(normalized).suffix:
+    if normalized.rsplit("/", 1)[-1].casefold() in {"metadata.json", "readme.md"}:
         return source_path
     return f"{source_path}/SKILL.md"
 

--- a/scripts/audit_skill_assets.py
+++ b/scripts/audit_skill_assets.py
@@ -99,21 +99,42 @@ def _is_canonical_archive_skill(dirpath: str, root: str | Path) -> bool:
     return len(relative.parts) == 2
 
 
-def _canonical_archive_rows(root: str | Path) -> list[tuple[str, dict | None]]:
-    """Return canonical archive roots after rejecting global case collisions."""
+def _iter_canonical_archive_paths(root: str | Path):
+    """Yield canonical archive paths without parsing their metadata."""
     archive_root = Path(root).resolve()
-    rows = [
-        (dirpath, metadata)
-        for dirpath, metadata in iter_archived_skills(str(root))
-        if _is_canonical_archive_skill(dirpath, archive_root)
-    ]
-    relative_dirs = [
-        Path(dirpath).resolve().relative_to(archive_root).as_posix()
-        for dirpath, _metadata in rows
-    ]
-    if _has_case_conflict(relative_dirs):
-        raise ValueError(f"archive contains case-conflicting skill roots: {root}")
-    return rows
+    for dirpath, dirnames, filenames in os.walk(root):
+        if ".git" in dirnames:
+            dirnames.remove(".git")
+        if "SKILL.md" not in filenames:
+            continue
+        try:
+            relative = Path(dirpath).resolve().relative_to(archive_root)
+        except ValueError:
+            continue
+        if len(relative.parts) == 2:
+            yield relative.as_posix()
+
+
+def _assert_unique_canonical_archive_paths(root: str | Path) -> None:
+    seen: dict[str, str] = {}
+    for relative in _iter_canonical_archive_paths(root):
+        parts = relative.split("/")
+        for length in range(1, len(parts) + 1):
+            prefix = "/".join(parts[:length])
+            folded = prefix.casefold()
+            previous = seen.get(folded)
+            if previous is not None and previous != prefix:
+                raise ValueError(f"archive contains case-conflicting skill roots: {root}")
+            seen[folded] = prefix
+
+
+def _canonical_archive_rows(root: str | Path):
+    """Stream canonical archive rows after a lightweight path-only preflight."""
+    archive_root = Path(root).resolve()
+    _assert_unique_canonical_archive_paths(root)
+    for dirpath, metadata in iter_archived_skills(str(root)):
+        if _is_canonical_archive_skill(dirpath, archive_root):
+            yield dirpath, metadata
 
 
 def canonical_source_identity(
@@ -129,7 +150,7 @@ def canonical_source_identity(
         return repo, "", "missing_source_path"
 
     source_path = path_value.strip().replace("\\", "/")
-    if source_path.startswith("/") or re.match(r"^[A-Za-z]:/", source_path):
+    if source_path.startswith("/") or re.match(r"^[A-Za-z]:", source_path):
         return repo, source_path, "absolute_source_path"
     parts = source_path.split("/")
     if any(part in {"", ".", ".."} for part in parts):
@@ -145,8 +166,9 @@ def canonical_source_identity_from_metadata(metadata: dict) -> tuple[str, str, s
     for field in ("path", "github_path"):
         if field not in metadata:
             continue
+        path_value = _metadata_source_path(field, metadata[field])
         repo, source_path, error = canonical_source_identity(
-            metadata.get("repo"), metadata[field]
+            metadata.get("repo"), path_value
         )
         if error:
             return repo, source_path, error
@@ -156,6 +178,19 @@ def canonical_source_identity_from_metadata(metadata: dict) -> tuple[str, str, s
     if any(identity != aliases[0] for identity in aliases[1:]):
         return aliases[0][0], aliases[0][1], "conflicting_source_path_aliases"
     return aliases[0][0], aliases[0][1], ""
+
+
+def _metadata_source_path(field: str, value: object) -> object:
+    """Expand the legacy directory-form github_path into an exact SKILL.md path."""
+    if field != "github_path" or not isinstance(value, str):
+        return value
+    source_path = value.strip()
+    if not source_path:
+        return "SKILL.md"
+    normalized = source_path.replace("\\", "/")
+    if normalized.rsplit("/", 1)[-1].casefold() == "skill.md":
+        return source_path
+    return f"{source_path}/SKILL.md"
 
 
 def canonical_source_branch_from_metadata(metadata: dict) -> tuple[str, str]:
@@ -210,12 +245,16 @@ def _identity_keys(metadata: dict, *, name: str, category: str) -> set[str]:
     """Return every plausible key so malformed aliases still make duplicates ambiguous."""
     repo_value = metadata.get("repo")
     repo = repo_value.strip() if isinstance(repo_value, str) else ""
-    values = [metadata[field] for field in ("path", "github_path") if field in metadata]
+    values = [
+        (field, _metadata_source_path(field, metadata[field]))
+        for field in ("path", "github_path")
+        if field in metadata
+    ]
     if not values:
-        values = [None]
+        values = [("path", None)]
 
     keys = set()
-    for value in values:
+    for _field, value in values:
         exact_repo, source_path, error = canonical_source_identity(repo_value, value)
         if not error:
             keys.add(f"{exact_repo.casefold()}:{source_path}")
@@ -294,7 +333,7 @@ def _declared_bundled_files(metadata: dict) -> tuple[list[str], bool]:
     for value in declared:
         if not isinstance(value, str) or not value or value != value.strip() or "\\" in value:
             return [], False
-        if re.match(r"^[A-Za-z]:/", value) or any(
+        if re.match(r"^[A-Za-z]:", value) or any(
             part in {"", ".", ".."} for part in value.split("/")
         ):
             return [], False

--- a/scripts/audit_skill_assets.py
+++ b/scripts/audit_skill_assets.py
@@ -375,6 +375,7 @@ def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
     actual_bundled_file_count = 0
     metadata_mismatch_count = 0
     source_identity_errors = []
+    metadata_errors = []
 
     for dirpath, raw_meta in _canonical_archive_rows(root):
         skill_dir = Path(dirpath).resolve()
@@ -421,6 +422,19 @@ def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
 
         stars = _parse_stars(metadata.get("stars"), metadata_path)
         provenance_error = source_error or branch_error
+        if (
+            asset_state == "missing_claimed_assets"
+            and stars >= min_stars
+            and not provenance_error
+            and not declared_files_valid
+        ):
+            metadata_errors.append(
+                {
+                    "archive_path": relative_dir,
+                    "error": "invalid_bundled_files",
+                    "eligible_for_backfill": True,
+                }
+            )
         if provenance_error:
             source_identity_errors.append(
                 {
@@ -476,6 +490,11 @@ def _scan_inventory(root: str, min_stars: int) -> tuple[dict, list[dict]]:
             source_identity_errors,
             key=lambda row: (row["archive_path"], row["error"]),
         ),
+        "metadata_error_count": len(metadata_errors),
+        "metadata_errors": sorted(
+            metadata_errors,
+            key=lambda row: (row["archive_path"], row["error"]),
+        ),
         "ambiguous_stable_key_count": len(ambiguous_keys),
         "backfill_candidate_count": len(targets),
     }
@@ -490,6 +509,10 @@ def build_backfill_targets(root: str, min_stars: int = 100) -> list[dict]:
     if blocking_errors:
         details = ", ".join(f"{row['archive_path']} ({row['error']})" for row in blocking_errors)
         raise ValueError(f"invalid source identity for backfill candidates: {details}")
+    blocking_metadata = [row for row in report["metadata_errors"] if row["eligible_for_backfill"]]
+    if blocking_metadata:
+        details = ", ".join(f"{row['archive_path']} ({row['error']})" for row in blocking_metadata)
+        raise ValueError(f"invalid metadata for backfill candidates: {details}")
     return targets
 
 

--- a/scripts/portable_paths.py
+++ b/scripts/portable_paths.py
@@ -1,0 +1,38 @@
+"""Side-effect-free validation for archive-relative portable paths."""
+
+from __future__ import annotations
+
+import re
+from pathlib import PurePosixPath
+
+_WINDOWS_INVALID_CHARACTERS = frozenset('<>:"\\|?*')
+_WINDOWS_RESERVED_NAMES = frozenset(
+    {"CON", "PRN", "AUX", "NUL"}
+    | {f"COM{index}" for index in range(1, 10)}
+    | {f"LPT{index}" for index in range(1, 10)}
+)
+
+
+def _is_windows_portable_component(component: str) -> bool:
+    if component[-1] in {" ", "."}:
+        return False
+    if any(ord(character) < 32 for character in component):
+        return False
+    if any(character in _WINDOWS_INVALID_CHARACTERS for character in component):
+        return False
+    stem = component.split(".", 1)[0].upper()
+    return stem not in _WINDOWS_RESERVED_NAMES
+
+
+def is_safe_portable_relative_path(value: object) -> bool:
+    """Return whether value is a strict relative path portable across platforms."""
+    if not isinstance(value, str) or not value or value != value.strip():
+        return False
+    if "\\" in value or re.match(r"^[A-Za-z]:", value):
+        return False
+    parts = value.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        return False
+    if PurePosixPath(value).is_absolute():
+        return False
+    return all(_is_windows_portable_component(part) for part in parts)

--- a/scripts/portable_paths.py
+++ b/scripts/portable_paths.py
@@ -10,6 +10,7 @@ _WINDOWS_RESERVED_NAMES = frozenset(
     {"CON", "PRN", "AUX", "NUL"}
     | {f"COM{index}" for index in range(1, 10)}
     | {f"LPT{index}" for index in range(1, 10)}
+    | {f"{prefix}{index}" for prefix in ("COM", "LPT") for index in "¹²³"}
 )
 
 

--- a/scripts/portable_paths.py
+++ b/scripts/portable_paths.py
@@ -7,7 +7,7 @@ from pathlib import PurePosixPath
 
 _WINDOWS_INVALID_CHARACTERS = frozenset('<>:"\\|?*')
 _WINDOWS_RESERVED_NAMES = frozenset(
-    {"CON", "PRN", "AUX", "NUL"}
+    {"CON", "PRN", "AUX", "NUL", "CONIN$", "CONOUT$"}
     | {f"COM{index}" for index in range(1, 10)}
     | {f"LPT{index}" for index in range(1, 10)}
     | {f"{prefix}{index}" for prefix in ("COM", "LPT") for index in "¹²³"}

--- a/scripts/sync_download.py
+++ b/scripts/sync_download.py
@@ -407,7 +407,7 @@ async def download_skills(
                     size = int(entry.get("size") or 0)
                 except (TypeError, ValueError):
                     size = -1
-                if is_safe_bundled_file(rel_path, size):
+                if is_safe_bundled_file(rel_path, size, reject_nonportable=True):
                     candidates.append(
                         {
                             "repo_path": repo_path,

--- a/scripts/sync_download.py
+++ b/scripts/sync_download.py
@@ -39,6 +39,7 @@ from sync_pipeline_support import (
     normalize_skill_frontmatter_description,
     not_found_cooldown_hours,
     prune_negative_cache,
+    reject_case_conflicting_paths,
     remove_ci_untracked_archive_files,
     requires_complete_bundled_archive,
     sanitize_category,
@@ -378,7 +379,6 @@ async def download_skills(
         queue = [source_dir]
         seen_dirs = set()
         candidates: list[dict] = []
-
         while queue:
             current_dir = queue.pop(0)
             if current_dir in seen_dirs:
@@ -417,7 +417,7 @@ async def download_skills(
                         }
                     )
 
-        selected: list[dict] = []
+        selected: list[dict] = reject_case_conflicting_paths((entry["relative_path"] for entry in candidates), source_dir) or []
         total_size = 0
         for entry in sorted(candidates, key=lambda item: item["relative_path"]):
             if len(selected) >= MAX_BUNDLED_FILES_PER_SKILL:

--- a/scripts/sync_pipeline_support.py
+++ b/scripts/sync_pipeline_support.py
@@ -235,9 +235,16 @@ def should_recurse_bundled_dir(relative_path: str) -> bool:
     )
 
 
-def is_safe_bundled_file(relative_path: str, size: int) -> bool:
+def is_safe_bundled_file(
+    relative_path: str,
+    size: int,
+    *,
+    reject_nonportable: bool = False,
+) -> bool:
     """Return True when a bundled support file should be archived."""
     if not is_safe_portable_relative_path(relative_path):
+        if reject_nonportable:
+            raise BundledListingError(relative_path, "non-portable bundled path")
         return False
     normalized = relative_path
     if not normalized or normalized == "SKILL.md":

--- a/scripts/sync_pipeline_support.py
+++ b/scripts/sync_pipeline_support.py
@@ -217,6 +217,18 @@ def bundled_relative_path(source_dir: str, repo_path: str) -> str:
     return repo_path[len(prefix):]
 
 
+def is_safe_portable_relative_path(value: object) -> bool:
+    """Return whether value is a strict POSIX relative path on every platform."""
+    if not isinstance(value, str) or not value or value != value.strip() or "\\" in value:
+        return False
+    if re.match(r"^[A-Za-z]:", value):
+        return False
+    parts = value.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        return False
+    return not PurePosixPath(value).is_absolute()
+
+
 def should_recurse_bundled_dir(relative_path: str) -> bool:
     """Return True when a support subdirectory is safe to inspect."""
     parts = [part for part in relative_path.strip("/").split("/") if part]

--- a/scripts/sync_pipeline_support.py
+++ b/scripts/sync_pipeline_support.py
@@ -39,6 +39,7 @@ ROOT_DIR = SCRIPT_DIR.parent
 sys.path.insert(0, str(ROOT_DIR))
 sys.path.insert(0, str(SCRIPT_DIR))
 
+from portable_paths import is_safe_portable_relative_path as _is_safe_portable_relative_path
 from security_blocklist import blocked_metadata_source
 from skill_frontmatter import normalize_skill_frontmatter
 from utils import (
@@ -63,13 +64,11 @@ def skill_key(skill: dict) -> str:
     category = sanitize_category(skill.get("category") or "other")
     return f"{category}:{name}"
 
+
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.FileHandler('sync_and_download.log'),
-        logging.StreamHandler()
-    ]
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    handlers=[logging.FileHandler("sync_and_download.log"), logging.StreamHandler()],
 )
 logger = logging.getLogger(__name__)
 ACQUISITION_MANIFEST_VERSION = 1
@@ -214,19 +213,12 @@ def bundled_relative_path(source_dir: str, repo_path: str) -> str:
         return ""
     if not repo_path.startswith(prefix):
         return ""
-    return repo_path[len(prefix):]
+    return repo_path[len(prefix) :]
 
 
 def is_safe_portable_relative_path(value: object) -> bool:
-    """Return whether value is a strict POSIX relative path on every platform."""
-    if not isinstance(value, str) or not value or value != value.strip() or "\\" in value:
-        return False
-    if re.match(r"^[A-Za-z]:", value):
-        return False
-    parts = value.split("/")
-    if any(part in {"", ".", ".."} for part in parts):
-        return False
-    return not PurePosixPath(value).is_absolute()
+    """Expose the side-effect-free portable path validator to pipeline callers."""
+    return _is_safe_portable_relative_path(value)
 
 
 def should_recurse_bundled_dir(relative_path: str) -> bool:
@@ -532,8 +524,7 @@ def validate_existing_archive_sources(
     if metadata_errors:
         sample = "\n".join(metadata_errors[:20])
         raise RuntimeError(
-            "Cannot validate existing archive metadata for security blocklist:\n"
-            f"{sample}"
+            f"Cannot validate existing archive metadata for security blocklist:\n{sample}"
         )
 
     if blocked_archives:
@@ -548,8 +539,7 @@ def validate_existing_archive_sources(
                     resolved_archive_dir.relative_to(output_root)
                 except ValueError as exc:
                     raise RuntimeError(
-                        "Refusing to remove blocked archive outside output dir: "
-                        f"{archive_dir}"
+                        f"Refusing to remove blocked archive outside output dir: {archive_dir}"
                     ) from exc
                 if resolved_archive_dir in removed_dirs:
                     continue
@@ -564,10 +554,7 @@ def validate_existing_archive_sources(
             )
             return removed_archives
 
-        raise RuntimeError(
-            "Existing archive contains blocked source repos:\n"
-            f"{sample}"
-        )
+        raise RuntimeError(f"Existing archive contains blocked source repos:\n{sample}")
 
     return []
 
@@ -607,7 +594,9 @@ def remove_ci_untracked_archive_files(output_dir: Path) -> int:
         try:
             target.relative_to(output_root)
         except ValueError as exc:
-            raise RuntimeError(f"Refusing untracked archive path outside output dir: {target}") from exc
+            raise RuntimeError(
+                f"Refusing untracked archive path outside output dir: {target}"
+            ) from exc
         if target.is_dir():
             shutil.rmtree(target)
         elif target.exists() or target.is_symlink():
@@ -648,7 +637,9 @@ def build_branch_probe_order(
     return _ordered_unique(candidates)
 
 
-def build_relative_probe_order(relative_candidates: list[str], manifest_entry: dict | None) -> list[str]:
+def build_relative_probe_order(
+    relative_candidates: list[str], manifest_entry: dict | None
+) -> list[str]:
     """Build relative-path probe order with manifest hint first."""
     candidates = []
     if manifest_entry and manifest_entry.get("relative_path"):

--- a/scripts/sync_pipeline_support.py
+++ b/scripts/sync_pipeline_support.py
@@ -30,6 +30,7 @@ import re
 import shutil
 import subprocess
 import sys
+from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path, PurePosixPath
 
@@ -214,6 +215,27 @@ def bundled_relative_path(source_dir: str, repo_path: str) -> str:
     if not repo_path.startswith(prefix):
         return ""
     return repo_path[len(prefix) :]
+
+
+def has_case_conflicting_paths(paths: Iterable[str]) -> bool:
+    """Detect case-only conflicts in complete paths or any directory prefix."""
+    seen: dict[str, str] = {}
+    for relative in paths:
+        parts = relative.split("/")
+        for length in range(1, len(parts) + 1):
+            prefix = "/".join(parts[:length])
+            folded = prefix.casefold()
+            previous = seen.get(folded)
+            if previous is not None and previous != prefix:
+                return True
+            seen[folded] = prefix
+    return False
+
+
+def reject_case_conflicting_paths(paths: Iterable[str], directory_path: str) -> None:
+    """Reject a bundled listing that cannot be represented cross-platform."""
+    if has_case_conflicting_paths(paths):
+        raise BundledListingError(directory_path, "case-conflicting bundled paths")
 
 
 def is_safe_portable_relative_path(value: object) -> bool:

--- a/scripts/sync_pipeline_support.py
+++ b/scripts/sync_pipeline_support.py
@@ -242,11 +242,8 @@ def is_safe_bundled_file(
     reject_nonportable: bool = False,
 ) -> bool:
     """Return True when a bundled support file should be archived."""
-    if not is_safe_portable_relative_path(relative_path):
-        if reject_nonportable:
-            raise BundledListingError(relative_path, "non-portable bundled path")
-        return False
-    normalized = relative_path
+    portable = is_safe_portable_relative_path(relative_path)
+    normalized = relative_path if isinstance(relative_path, str) else ""
     if not normalized or normalized == "SKILL.md":
         return False
     if size < 0:
@@ -262,29 +259,32 @@ def is_safe_bundled_file(
     if len(parts) == 1:
         if size > MAX_BUNDLED_FILE_BYTES:
             return False
-        return (
+        eligible = (
             filename in BUNDLED_ROOT_FILE_ALLOWLIST
             or BUNDLED_ROOT_CODE_FILE_PATTERN.fullmatch(filename) is not None
         )
-
-    if filename.lower() == "skill.md":
-        return DESIGN_BUNDLED_DIR_PATTERN.fullmatch(parts[0]) is not None
-
-    if parts[0] not in BUNDLED_DIR_ALLOWLIST and (
+    elif filename.lower() == "skill.md":
+        eligible = DESIGN_BUNDLED_DIR_PATTERN.fullmatch(parts[0]) is not None
+    elif parts[0] not in BUNDLED_DIR_ALLOWLIST and (
         DESIGN_BUNDLED_DIR_PATTERN.fullmatch(parts[0]) is None
     ):
         return False
-    if parts[0] == "bin":
-        return (
+    elif parts[0] == "bin":
+        eligible = (
             len(parts) == 2
             and size <= MAX_BUNDLED_BIN_FILE_BYTES
             and SAFE_BUNDLED_BIN_FILENAMES.fullmatch(filename) is not None
         )
-    if size > MAX_BUNDLED_FILE_BYTES:
+    elif size > MAX_BUNDLED_FILE_BYTES:
         return False
-    if filename in BUNDLED_ROOT_FILE_ALLOWLIST:
-        return True
-    return PurePosixPath(filename).suffix.lower() in BUNDLED_FILE_EXTENSIONS
+    else:
+        eligible = (
+            filename in BUNDLED_ROOT_FILE_ALLOWLIST
+            or PurePosixPath(filename).suffix.lower() in BUNDLED_FILE_EXTENSIONS
+        )
+    if eligible and not portable and reject_nonportable:
+        raise BundledListingError(relative_path, "non-portable bundled path")
+    return eligible and portable
 
 
 def is_submodule_contents_entry(entry: dict) -> bool:

--- a/scripts/sync_pipeline_support.py
+++ b/scripts/sync_pipeline_support.py
@@ -40,6 +40,13 @@ ROOT_DIR = SCRIPT_DIR.parent
 sys.path.insert(0, str(ROOT_DIR))
 sys.path.insert(0, str(SCRIPT_DIR))
 
+from asset_claims import (
+    BUNDLED_DIR_ALLOWLIST,
+    BUNDLED_ROOT_FILE_ALLOWLIST,
+)
+from asset_claims import (
+    requires_complete_bundled_archive as requires_complete_bundled_archive,
+)
 from portable_paths import is_safe_portable_relative_path as _is_safe_portable_relative_path
 from security_blocklist import blocked_metadata_source
 from skill_frontmatter import normalize_skill_frontmatter
@@ -77,42 +84,9 @@ DEFAULT_MANIFEST_PATH = ROOT_DIR / "sources" / "acquisition_manifest.json"
 DEFAULT_LEARNING_PRIORS_PATH = ROOT_DIR / "sources" / "learning" / "discovery_priors.json"
 GITHUB_API_BASE = "https://api.github.com"
 
-BUNDLED_DIR_ALLOWLIST = {
-    "bin",
-    "connectors",
-    "references",
-    "reference",
-    "scripts",
-    "assets",
-    "knowledge",
-    "templates",
-    "examples",
-    "prompts",
-    "rules",
-    "src",
-}
 DESIGN_BUNDLED_DIR_PATTERN = re.compile(r"^design-[a-z0-9-]+$")
 SAFE_BUNDLED_BIN_FILENAMES = re.compile(r"^jq(?:-[A-Za-z0-9_.-]+|\.LICENSE)$")
 BUNDLED_ROOT_CODE_FILE_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*\.(?:py|swift)$")
-BUNDLED_ROOT_FILE_ALLOWLIST = {
-    "audit.md",
-    "package.json",
-    "package-lock.json",
-    "pnpm-lock.yaml",
-    "yarn.lock",
-    "requirements.txt",
-    "pyproject.toml",
-    "setup.md",
-    "uv.lock",
-    "README.md",
-    "LICENSE",
-    "LICENSE.md",
-}
-BUNDLED_REQUIRED_ROOT_FILE_HINTS = BUNDLED_ROOT_FILE_ALLOWLIST - {
-    "README.md",
-    "LICENSE",
-    "LICENSE.md",
-}
 BUNDLED_FILE_EXTENSIONS = {
     ".bash",
     ".css",
@@ -312,19 +286,6 @@ def is_safe_bundled_file(
 def is_submodule_contents_entry(entry: dict) -> bool:
     """Return True for GitHub Contents API submodules exposed as file entries."""
     return entry.get("type") == "submodule" or "submodule_git_url" in entry
-
-
-def requires_complete_bundled_archive(skill_content: str) -> bool:
-    """Return True when SKILL.md explicitly depends on bundled support files."""
-    normalized = (skill_content or "").lower().replace("\\", "/")
-    for dirname in BUNDLED_DIR_ALLOWLIST:
-        if re.search(rf"(?<![a-z0-9_.-]){re.escape(dirname)}/", normalized):
-            return True
-    if re.search(r"(?<![a-z0-9_.-])design-[a-z0-9-]+/", normalized):
-        return True
-    if re.search(r"(?<![a-z0-9_/.-])[a-z0-9][a-z0-9_.-]*\.(?:py|swift)(?![a-z0-9_.-])", normalized):
-        return True
-    return any(filename.lower() in normalized for filename in BUNDLED_REQUIRED_ROOT_FILE_HINTS)
 
 
 def normalize_skill_frontmatter_description(content: str, skill: dict) -> str:

--- a/scripts/sync_pipeline_support.py
+++ b/scripts/sync_pipeline_support.py
@@ -237,7 +237,9 @@ def should_recurse_bundled_dir(relative_path: str) -> bool:
 
 def is_safe_bundled_file(relative_path: str, size: int) -> bool:
     """Return True when a bundled support file should be archived."""
-    normalized = relative_path.strip("/")
+    if not is_safe_portable_relative_path(relative_path):
+        return False
+    normalized = relative_path
     if not normalized or normalized == "SKILL.md":
         return False
     if size < 0:

--- a/tests/test_skill_asset_audit.py
+++ b/tests/test_skill_asset_audit.py
@@ -276,6 +276,29 @@ class TestStrictBackfillInventory:
 
         assert target["github_branch"] == "release/v1"
 
+    def test_directory_form_path_emits_exact_backfill_identity(self, tmp_path):
+        skill = tmp_path / "data" / "dev" / "demo"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("Run scripts/setup.py.", encoding="utf-8")
+        (skill / "metadata.json").write_text(
+            json.dumps(
+                {
+                    "repo": "acme/tools",
+                    "path": "skills/demo",
+                    "github_branch": "main",
+                    "stars": 100,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        [target] = audit_skill_assets.build_backfill_targets(
+            str(tmp_path / "data"), min_stars=100
+        )
+
+        assert target["source_path"] == "skills/demo/SKILL.md"
+        assert target["stable_key"] == "acme/tools:skills/demo/SKILL.md"
+
 
 class TestResolveSkillDir:
     DIRS = ["skills/alpha", "skills/beta", ""]

--- a/tests/test_skill_asset_audit.py
+++ b/tests/test_skill_asset_audit.py
@@ -107,37 +107,30 @@ class TestStrictBackfillInventory:
         with pytest.raises(ValueError, match="unable to inspect archive tree.*denied"):
             list(audit_skill_assets._canonical_archive_rows(root))
 
-    def test_canonical_archive_rows_stream_metadata_after_lightweight_preflight(
-        self, tmp_path, monkeypatch
-    ):
+    def test_canonical_archive_rows_reuse_fail_closed_preflight_paths(self, tmp_path, monkeypatch):
         root = tmp_path / "data"
         first = root / "dev" / "one"
         second = root / "dev" / "two"
         first.mkdir(parents=True)
         second.mkdir(parents=True)
-        calls = []
+        (first / "metadata.json").write_text('{"name":"one"}', encoding="utf-8")
+        (second / "metadata.json").write_text('{"name":"two"}', encoding="utf-8")
+        calls = 0
 
-        monkeypatch.setattr(
-            audit_skill_assets,
-            "_iter_canonical_archive_paths",
-            lambda _root: iter(["dev/one", "dev/two"]),
-        )
+        def canonical_paths(_root):
+            nonlocal calls
+            calls += 1
+            yield "dev/one"
+            yield "dev/two"
 
-        def metadata_rows(_root):
-            calls.append("metadata")
-            yield str(first), {"name": "one"}
-            yield str(second), {"name": "two"}
+        monkeypatch.setattr(audit_skill_assets, "_iter_canonical_archive_paths", canonical_paths)
 
-        monkeypatch.setattr(audit_skill_assets, "iter_archived_skills", metadata_rows)
-
-        rows = audit_skill_assets._canonical_archive_rows(root)
-
-        assert calls == []
+        rows = iter(audit_skill_assets._canonical_archive_rows(root))
         assert next(rows) == (str(first), {"name": "one"})
-        assert calls == ["metadata"]
         assert next(rows) == (str(second), {"name": "two"})
         with pytest.raises(StopIteration):
             next(rows)
+        assert calls == 1
 
     @pytest.mark.parametrize(
         ("metadata", "expected_path"),
@@ -174,6 +167,11 @@ class TestStrictBackfillInventory:
         assert audit_skill_assets.canonical_source_identity_from_metadata(
             {"repo": "acme/tools", field: "README.md"}
         ) == ("acme/tools", "README.md", "source_path_not_skill_md")
+
+    def test_dotted_directory_metadata_path_is_preserved(self):
+        assert audit_skill_assets.canonical_source_identity_from_metadata(
+            {"repo": "acme/tools", "path": "skills/v1.0"}
+        ) == ("acme/tools", "skills/v1.0/SKILL.md", "")
 
     def test_conflicting_aliases_contribute_every_normalized_identity_key(self):
         keys = audit_skill_assets._identity_keys(

--- a/tests/test_skill_asset_audit.py
+++ b/tests/test_skill_asset_audit.py
@@ -169,6 +169,12 @@ class TestStrictBackfillInventory:
             "acme/tools", "skills/demo"
         ) == ("acme/tools", "skills/demo", "source_path_not_skill_md")
 
+    @pytest.mark.parametrize("field", ["path", "github_path"])
+    def test_metadata_file_path_is_not_reinterpreted_as_directory(self, field):
+        assert audit_skill_assets.canonical_source_identity_from_metadata(
+            {"repo": "acme/tools", field: "README.md"}
+        ) == ("acme/tools", "README.md", "source_path_not_skill_md")
+
     def test_conflicting_aliases_contribute_every_normalized_identity_key(self):
         keys = audit_skill_assets._identity_keys(
             {
@@ -200,6 +206,9 @@ class TestStrictBackfillInventory:
             ["references//guide.md"],
             ["C:/scripts/run.py"],
             ["C:scripts/run.py"],
+            ["skill.md"],
+            ["SKILL.MD"],
+            ["Metadata.json"],
             ["references/Guide.md", "references/guide.md"],
             ["References/one.md", "references/two.md"],
         ],
@@ -222,6 +231,44 @@ class TestStrictBackfillInventory:
 
         assert report["actual_bundled_file_count"] == 1
         assert report["local_verdict_counts"] == {"REF_ASSET": 1}
+
+    def test_support_file_scan_fails_closed_on_walk_error(self, tmp_path, monkeypatch):
+        skill = tmp_path / "dev" / "demo"
+        skill.mkdir(parents=True)
+
+        def failed_walk(_root, *, onerror):
+            onerror(PermissionError("denied"))
+            yield from ()
+
+        monkeypatch.setattr(audit_skill_assets.os, "walk", failed_walk)
+
+        with pytest.raises(ValueError, match="unable to inspect archive skill.*denied"):
+            audit_skill_assets._actual_bundled_files(str(skill))
+
+    @pytest.mark.parametrize(
+        ("category", "name"),
+        [("CON", "demo"), ("dev", "demo.")],
+    )
+    def test_rejects_nonportable_canonical_archive_root(self, tmp_path, category, name):
+        root = tmp_path / "data"
+        skill = root / category / name
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("body", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="non-portable canonical archive path"):
+            audit_skill_assets.run_current_state(str(root))
+
+    def test_rejects_miscased_canonical_skill_filename(self, tmp_path):
+        root = tmp_path / "data"
+        valid = root / "dev" / "valid"
+        invalid = root / "dev" / "invalid"
+        valid.mkdir(parents=True)
+        invalid.mkdir(parents=True)
+        (valid / "SKILL.md").write_text("body", encoding="utf-8")
+        (invalid / "skill.md").write_text("body", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="canonical SKILL.md has invalid casing"):
+            audit_skill_assets.run_current_state(str(root))
 
     def test_conflicting_alias_record_makes_valid_candidate_ambiguous(self, tmp_path):
         root = tmp_path / "data"
@@ -297,6 +344,37 @@ class TestStrictBackfillInventory:
         )
 
         assert target["source_path"] == "skills/demo/SKILL.md"
+        assert target["stable_key"] == "acme/tools:skills/demo/SKILL.md"
+
+    @pytest.mark.parametrize(
+        ("body", "bundled_files"),
+        [
+            ("No recognizable asset reference.", ["package.json"]),
+            ("Run src/widget.jsx before continuing.", None),
+        ],
+    )
+    def test_pipeline_asset_claims_are_backfill_eligible(
+        self, tmp_path, body, bundled_files
+    ):
+        skill = tmp_path / "data" / "dev" / "demo"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(body, encoding="utf-8")
+        metadata = {
+            "repo": "acme/tools",
+            "path": "skills/demo/SKILL.md",
+            "github_branch": "main",
+            "stars": 100,
+        }
+        if bundled_files is not None:
+            metadata.update(
+                {"archive_mode": "directory", "bundled_files": bundled_files}
+            )
+        (skill / "metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
+
+        [target] = audit_skill_assets.build_backfill_targets(
+            str(tmp_path / "data"), min_stars=100
+        )
+
         assert target["stable_key"] == "acme/tools:skills/demo/SKILL.md"
 
 

--- a/tests/test_skill_asset_audit.py
+++ b/tests/test_skill_asset_audit.py
@@ -142,6 +142,7 @@ class TestStrictBackfillInventory:
     @pytest.mark.parametrize(
         ("metadata", "expected_path"),
         [
+            ({"repo": "acme/tools", "path": "skills/demo"}, "skills/demo/SKILL.md"),
             ({"repo": "acme/tools", "github_path": "skills/demo"}, "skills/demo/SKILL.md"),
             ({"repo": "acme/tools", "github_path": ""}, "SKILL.md"),
             (
@@ -154,12 +155,19 @@ class TestStrictBackfillInventory:
             ),
         ],
     )
-    def test_normalizes_legacy_directory_form_github_path(self, metadata, expected_path):
+    def test_normalizes_repository_directory_form_metadata_paths(
+        self, metadata, expected_path
+    ):
         assert audit_skill_assets.canonical_source_identity_from_metadata(metadata) == (
             "acme/tools",
             expected_path,
             "",
         )
+
+    def test_direct_canonical_source_still_requires_exact_skill_path(self):
+        assert audit_skill_assets.canonical_source_identity(
+            "acme/tools", "skills/demo"
+        ) == ("acme/tools", "skills/demo", "source_path_not_skill_md")
 
     def test_conflicting_aliases_contribute_every_normalized_identity_key(self):
         keys = audit_skill_assets._identity_keys(

--- a/tests/test_skill_asset_audit.py
+++ b/tests/test_skill_asset_audit.py
@@ -72,6 +72,30 @@ class TestStrictBackfillInventory:
             "github_branch": pinned_ref,
         }) == (pinned_ref, "")
 
+    @pytest.mark.parametrize(
+        "source_ref",
+        ["main..evil", "main@{x}", "main.lock", ".hidden", "main/", "-main", "main?"],
+    )
+    def test_rejects_invalid_git_source_refs(self, source_ref):
+        assert audit_skill_assets.canonical_source_branch_from_metadata({
+            "github_branch": source_ref,
+        }) == ("", "invalid_source_branch")
+
+    def test_rejects_case_colliding_archive_roots(self, tmp_path, monkeypatch):
+        root = tmp_path / "data"
+        root.mkdir()
+        monkeypatch.setattr(
+            audit_skill_assets,
+            "iter_archived_skills",
+            lambda _root: iter([
+                (str(root / "dev" / "Demo"), {}),
+                (str(root / "dev" / "demo"), {}),
+            ]),
+        )
+
+        with pytest.raises(ValueError, match="case-conflicting skill roots"):
+            audit_skill_assets._canonical_archive_rows(root)
+
     def test_conflicting_aliases_contribute_every_normalized_identity_key(self):
         keys = audit_skill_assets._identity_keys(
             {

--- a/tests/test_skill_asset_audit.py
+++ b/tests/test_skill_asset_audit.py
@@ -67,6 +67,10 @@ class TestStrictBackfillInventory:
             "github_branch": " release/v1 ",
             "branch": "release/v1",
         }) == ("release/v1", "")
+        pinned_ref = "a" * 40
+        assert audit_skill_assets.canonical_source_branch_from_metadata({
+            "github_branch": pinned_ref,
+        }) == (pinned_ref, "")
 
     def test_conflicting_aliases_contribute_every_normalized_identity_key(self):
         keys = audit_skill_assets._identity_keys(
@@ -97,6 +101,7 @@ class TestStrictBackfillInventory:
         "declared",
         [
             ["references//guide.md"],
+            ["C:/scripts/run.py"],
             ["references/Guide.md", "references/guide.md"],
             ["References/one.md", "references/two.md"],
         ],

--- a/tests/test_skill_asset_audit.py
+++ b/tests/test_skill_asset_audit.py
@@ -2,8 +2,11 @@ import json
 import os
 import sys
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
+import audit_skill_assets
 from skill_asset_audit import (
     classify_files,
     classify_skill_text,
@@ -42,6 +45,133 @@ class TestClassifyFiles:
         assert verdict_from_counts({"exec": 1, "doc": 0, "asset": 0}) == "EXEC"
         assert verdict_from_counts({"exec": 0, "doc": 2, "asset": 0}) == "REF_ASSET"
         assert verdict_from_counts({"exec": 0, "doc": 0, "asset": 0}) == "BARE"
+
+
+class TestStrictBackfillInventory:
+    @pytest.mark.parametrize("repo", ["../tools", "owner/..", "./repo", "owner/."])
+    def test_rejects_dot_segment_repository_components(self, repo):
+        assert audit_skill_assets.canonical_source_identity(
+            repo, "skills/demo/SKILL.md"
+        )[2] == "invalid_repo"
+
+    def test_requires_one_exact_source_branch(self):
+        assert audit_skill_assets.canonical_source_branch_from_metadata({}) == (
+            "",
+            "missing_source_branch",
+        )
+        assert audit_skill_assets.canonical_source_branch_from_metadata({
+            "github_branch": "main",
+            "branch": "release",
+        }) == ("", "conflicting_source_branch_aliases")
+        assert audit_skill_assets.canonical_source_branch_from_metadata({
+            "github_branch": " release/v1 ",
+            "branch": "release/v1",
+        }) == ("release/v1", "")
+
+    def test_conflicting_aliases_contribute_every_normalized_identity_key(self):
+        keys = audit_skill_assets._identity_keys(
+            {
+                "repo": "Acme/Tools",
+                "path": "skills/one/SKILL.md",
+                "github_path": "skills/two/SKILL.md",
+            },
+            name="demo",
+            category="dev",
+        )
+        assert keys == {
+            "acme/tools:skills/one/SKILL.md",
+            "acme/tools:skills/two/SKILL.md",
+        }
+
+    @pytest.mark.parametrize(
+        "paths",
+        [
+            ["references/Guide.md", "references/guide.md"],
+            ["References/one.md", "references/two.md"],
+        ],
+    )
+    def test_detects_case_conflicts_in_files_and_directory_prefixes(self, paths):
+        assert audit_skill_assets._has_case_conflict(paths) is True
+
+    @pytest.mark.parametrize(
+        "declared",
+        [
+            ["references//guide.md"],
+            ["references/Guide.md", "references/guide.md"],
+            ["References/one.md", "references/two.md"],
+        ],
+    )
+    def test_rejects_non_portable_bundled_file_declarations(self, declared):
+        assert audit_skill_assets._declared_bundled_files({
+            "bundled_files": declared,
+        }) == ([], False)
+
+    def test_nested_metadata_is_a_bundled_asset(self):
+        assert audit_skill_assets._local_verdict(["references/metadata.json"]) == "REF_ASSET"
+
+    def test_nested_metadata_keeps_current_state_internally_consistent(self, tmp_path):
+        skill = tmp_path / "data" / "dev" / "demo"
+        (skill / "references").mkdir(parents=True)
+        (skill / "SKILL.md").write_text("See references/metadata.json.", encoding="utf-8")
+        (skill / "references" / "metadata.json").write_text("{}", encoding="utf-8")
+
+        report = audit_skill_assets.run_current_state(str(tmp_path / "data"), min_stars=0)
+
+        assert report["actual_bundled_file_count"] == 1
+        assert report["local_verdict_counts"] == {"REF_ASSET": 1}
+
+    def test_conflicting_alias_record_makes_valid_candidate_ambiguous(self, tmp_path):
+        root = tmp_path / "data"
+        for name, metadata in (
+            (
+                "valid",
+                {
+                    "repo": "acme/tools",
+                    "path": "skills/one/SKILL.md",
+                    "github_branch": "main",
+                    "stars": 100,
+                },
+            ),
+            (
+                "conflict",
+                {
+                    "repo": "Acme/Tools",
+                    "path": "skills/two/SKILL.md",
+                    "github_path": "skills/one/SKILL.md",
+                    "github_branch": "main",
+                    "stars": 100,
+                },
+            ),
+        ):
+            skill = root / "dev" / name
+            skill.mkdir(parents=True)
+            (skill / "SKILL.md").write_text("Run scripts/setup.py.", encoding="utf-8")
+            (skill / "metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
+
+        report = audit_skill_assets.run_current_state(str(root), min_stars=100)
+
+        assert report["ambiguous_stable_key_count"] == 1
+        assert report["backfill_candidate_count"] == 0
+
+    def test_backfill_target_preserves_source_branch(self, tmp_path):
+        skill = tmp_path / "data" / "dev" / "demo"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("Run scripts/setup.py.", encoding="utf-8")
+        (skill / "metadata.json").write_text(
+            json.dumps({
+                "repo": "acme/tools",
+                "path": "skills/demo/SKILL.md",
+                "github_branch": "release/v1",
+                "stars": 100,
+            }),
+            encoding="utf-8",
+        )
+
+        [target] = audit_skill_assets.build_backfill_targets(
+            str(tmp_path / "data"), min_stars=100
+        )
+
+        assert target["github_branch"] == "release/v1"
 
 
 class TestResolveSkillDir:

--- a/tests/test_skill_asset_audit.py
+++ b/tests/test_skill_asset_audit.py
@@ -71,6 +71,9 @@ class TestStrictBackfillInventory:
         assert audit_skill_assets.canonical_source_branch_from_metadata({
             "github_branch": pinned_ref,
         }) == (pinned_ref, "")
+        assert audit_skill_assets.canonical_source_branch_from_metadata({
+            "github_branch": "@",
+        }) == ("@", "")
 
     @pytest.mark.parametrize(
         "source_ref",

--- a/tests/test_skill_asset_audit.py
+++ b/tests/test_skill_asset_audit.py
@@ -86,18 +86,68 @@ class TestStrictBackfillInventory:
 
     def test_rejects_case_colliding_archive_roots(self, tmp_path, monkeypatch):
         root = tmp_path / "data"
-        root.mkdir()
         monkeypatch.setattr(
             audit_skill_assets,
-            "iter_archived_skills",
-            lambda _root: iter([
-                (str(root / "dev" / "Demo"), {}),
-                (str(root / "dev" / "demo"), {}),
-            ]),
+            "_iter_canonical_archive_paths",
+            lambda _root: iter(["dev/Demo", "dev/demo"]),
         )
 
         with pytest.raises(ValueError, match="case-conflicting skill roots"):
-            audit_skill_assets._canonical_archive_rows(root)
+            list(audit_skill_assets._canonical_archive_rows(root))
+
+    def test_canonical_archive_rows_stream_metadata_after_lightweight_preflight(
+        self, tmp_path, monkeypatch
+    ):
+        root = tmp_path / "data"
+        first = root / "dev" / "one"
+        second = root / "dev" / "two"
+        first.mkdir(parents=True)
+        second.mkdir(parents=True)
+        calls = []
+
+        monkeypatch.setattr(
+            audit_skill_assets,
+            "_iter_canonical_archive_paths",
+            lambda _root: iter(["dev/one", "dev/two"]),
+        )
+
+        def metadata_rows(_root):
+            calls.append("metadata")
+            yield str(first), {"name": "one"}
+            yield str(second), {"name": "two"}
+
+        monkeypatch.setattr(audit_skill_assets, "iter_archived_skills", metadata_rows)
+
+        rows = audit_skill_assets._canonical_archive_rows(root)
+
+        assert calls == []
+        assert next(rows) == (str(first), {"name": "one"})
+        assert calls == ["metadata"]
+        assert next(rows) == (str(second), {"name": "two"})
+        with pytest.raises(StopIteration):
+            next(rows)
+
+    @pytest.mark.parametrize(
+        ("metadata", "expected_path"),
+        [
+            ({"repo": "acme/tools", "github_path": "skills/demo"}, "skills/demo/SKILL.md"),
+            ({"repo": "acme/tools", "github_path": ""}, "SKILL.md"),
+            (
+                {
+                    "repo": "acme/tools",
+                    "path": "skills/demo/SKILL.md",
+                    "github_path": "skills/demo",
+                },
+                "skills/demo/SKILL.md",
+            ),
+        ],
+    )
+    def test_normalizes_legacy_directory_form_github_path(self, metadata, expected_path):
+        assert audit_skill_assets.canonical_source_identity_from_metadata(metadata) == (
+            "acme/tools",
+            expected_path,
+            "",
+        )
 
     def test_conflicting_aliases_contribute_every_normalized_identity_key(self):
         keys = audit_skill_assets._identity_keys(
@@ -129,6 +179,7 @@ class TestStrictBackfillInventory:
         [
             ["references//guide.md"],
             ["C:/scripts/run.py"],
+            ["C:scripts/run.py"],
             ["references/Guide.md", "references/guide.md"],
             ["References/one.md", "references/two.md"],
         ],

--- a/tests/test_skill_asset_audit.py
+++ b/tests/test_skill_asset_audit.py
@@ -95,6 +95,18 @@ class TestStrictBackfillInventory:
         with pytest.raises(ValueError, match="case-conflicting skill roots"):
             list(audit_skill_assets._canonical_archive_rows(root))
 
+    def test_archive_path_preflight_fails_closed_on_walk_error(self, tmp_path, monkeypatch):
+        root = tmp_path / "data"
+
+        def failed_walk(_root, *, onerror):
+            onerror(PermissionError("denied"))
+            yield from ()
+
+        monkeypatch.setattr(audit_skill_assets.os, "walk", failed_walk)
+
+        with pytest.raises(ValueError, match="unable to inspect archive tree.*denied"):
+            list(audit_skill_assets._canonical_archive_rows(root))
+
     def test_canonical_archive_rows_stream_metadata_after_lightweight_preflight(
         self, tmp_path, monkeypatch
     ):

--- a/tests/test_skill_asset_audit.py
+++ b/tests/test_skill_asset_audit.py
@@ -268,6 +268,64 @@ class TestStrictBackfillInventory:
         with pytest.raises(ValueError, match="canonical SKILL.md has invalid casing"):
             audit_skill_assets.run_current_state(str(root))
 
+    @pytest.mark.parametrize(
+        ("filename", "error"),
+        [
+            ("Metadata.json", "canonical metadata.json has invalid casing"),
+            ("METADATA.JSON", "canonical metadata.json has invalid casing"),
+        ],
+    )
+    def test_rejects_miscased_canonical_metadata_filename(
+        self, tmp_path, filename, error
+    ):
+        root = tmp_path / "data"
+        skill = root / "dev" / "demo"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("body", encoding="utf-8")
+        (skill / filename).write_text("{}", encoding="utf-8")
+
+        with pytest.raises(ValueError, match=error):
+            audit_skill_assets.run_current_state(str(root))
+
+    def test_rejects_coexisting_canonical_skill_case_variants(
+        self, tmp_path, monkeypatch
+    ):
+        root = tmp_path / "data"
+        skill = root / "dev" / "demo"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("body", encoding="utf-8")
+        monkeypatch.setattr(
+            audit_skill_assets.os,
+            "walk",
+            lambda _root, *, onerror: iter(
+                [(str(skill), [], ["SKILL.md", "skill.md"])]
+            ),
+        )
+
+        with pytest.raises(ValueError, match="case-conflicting SKILL.md files"):
+            audit_skill_assets.run_current_state(str(root))
+
+    @pytest.mark.parametrize(
+        ("filename", "error"),
+        [
+            ("SKILL.md", "canonical SKILL.md must be a regular file"),
+            ("metadata.json", "canonical metadata.json must be a regular file"),
+        ],
+    )
+    def test_rejects_symlinked_canonical_files(self, tmp_path, filename, error):
+        root = tmp_path / "data"
+        skill = root / "dev" / "demo"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("body", encoding="utf-8")
+        target = tmp_path / f"outside-{filename}"
+        target.write_text("{}" if filename == "metadata.json" else "body", encoding="utf-8")
+        canonical = skill / filename
+        canonical.unlink(missing_ok=True)
+        canonical.symlink_to(target)
+
+        with pytest.raises(ValueError, match=error):
+            audit_skill_assets.run_current_state(str(root))
+
     def test_conflicting_alias_record_makes_valid_candidate_ambiguous(self, tmp_path):
         root = tmp_path / "data"
         for name, metadata in (
@@ -374,6 +432,33 @@ class TestStrictBackfillInventory:
         )
 
         assert target["stable_key"] == "acme/tools:skills/demo/SKILL.md"
+
+    def test_remote_asset_url_is_not_a_backfill_claim(self, tmp_path):
+        skill = tmp_path / "data" / "dev" / "demo"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(
+            "Read https://example.com/references/guide.md.", encoding="utf-8"
+        )
+        (skill / "metadata.json").write_text(
+            json.dumps(
+                {
+                    "repo": "acme/tools",
+                    "path": "skills/demo/SKILL.md",
+                    "github_branch": "main",
+                    "stars": 100,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        assert audit_skill_assets.build_backfill_targets(
+            str(tmp_path / "data"), min_stars=100
+        ) == []
+
+
+@pytest.mark.parametrize("path", ["references/CONIN$.md", "references/CONOUT$.txt"])
+def test_windows_console_device_names_are_not_portable(path):
+    assert audit_skill_assets.is_safe_portable_relative_path(path) is False
 
 
 class TestResolveSkillDir:

--- a/tests/test_skill_asset_pipeline.py
+++ b/tests/test_skill_asset_pipeline.py
@@ -122,6 +122,220 @@ class TestTargets:
         assert capsys.readouterr().out == ""
 
 
+class TestCurrentStateInventory:
+    def test_reports_real_archive_state_and_metadata_drift(self, tmp_path):
+        root = tmp_path / "data"
+        archived = make_skill(
+            root,
+            "dev",
+            "archived",
+            "Run scripts/setup.py first.",
+            {
+                "stars": 500,
+                "repo": "acme/tools",
+                "path": "skills/archived/SKILL.md",
+                "name": "archived",
+                "category": "dev",
+                "archive_mode": "directory",
+                "bundled_files": ["scripts/setup.py"],
+            },
+        )
+        (archived / "scripts").mkdir()
+        (archived / "scripts" / "setup.py").write_text("print('ok')")
+        make_skill(
+            root,
+            "dev",
+            "missing",
+            "See references/guide.md.",
+            {
+                "stars": 300,
+                "repo": "acme/docs",
+                "path": "skills/missing/SKILL.md",
+                "name": "missing",
+                "category": "dev",
+                "archive_mode": "directory",
+                "bundled_files": ["references/guide.md"],
+            },
+        )
+        make_skill(
+            root,
+            "dev",
+            "plain",
+            "No local files are required.",
+            {
+                "stars": 1,
+                "repo": "acme/plain",
+                "path": "SKILL.md",
+                "name": "plain",
+                "category": "dev",
+                "archive_mode": "skill-md",
+                "bundled_files": [],
+            },
+        )
+
+        report = audit_skill_assets.run_current_state(str(root))
+
+        assert report == {
+            "schema_version": 1,
+            "total_skills": 3,
+            "claim_counts": {"EXEC": 1, "REF": 1, "BARE": 1},
+            "local_verdict_counts": {"EXEC": 1, "BARE": 2},
+            "asset_state_counts": {
+                "archived": 1,
+                "missing_claimed_assets": 1,
+                "no_assets_claimed": 1,
+            },
+            "archive_mode_counts": {"directory": 1, "skill-md": 2},
+            "actual_bundled_file_count": 1,
+            "metadata_mismatch_count": 1,
+            "ambiguous_stable_key_count": 0,
+            "backfill_candidate_count": 1,
+        }
+
+    def test_backfill_targets_are_exact_deterministic_and_fail_closed(self, tmp_path):
+        root = tmp_path / "data"
+        base_meta = {
+            "stars": 200,
+            "repo": "acme/tools",
+            "path": "skills/duplicate/SKILL.md",
+            "name": "duplicate",
+            "category": "dev",
+        }
+        make_skill(root, "a", "duplicate", "Run scripts/setup.py.", base_meta)
+        make_skill(root, "b", "duplicate", "Run scripts/setup.py.", base_meta)
+        make_skill(
+            root,
+            "dev",
+            "ready",
+            "Run scripts/build.py.",
+            {
+                "stars": 500,
+                "repo": "acme/ready",
+                "path": "skills/ready/SKILL.md",
+                "name": "ready",
+                "category": "dev",
+            },
+        )
+        make_skill(
+            root,
+            "dev",
+            "missing-path",
+            "Run scripts/build.py.",
+            {"stars": 900, "repo": "acme/no-path", "name": "missing-path"},
+        )
+
+        rows = audit_skill_assets.build_backfill_targets(str(root), min_stars=100)
+
+        assert rows == [
+            {
+                "stable_key": "acme/ready:skills/ready/SKILL.md",
+                "archive_path": "dev/ready",
+                "repo": "acme/ready",
+                "source_path": "skills/ready/SKILL.md",
+                "dir": "skills/ready",
+                "name": "ready",
+                "category": "dev",
+                "stars": 500,
+                "claim": "EXEC",
+            }
+        ]
+
+        report = audit_skill_assets.run_current_state(str(root), min_stars=100)
+        assert report["ambiguous_stable_key_count"] == 1
+        assert report["backfill_candidate_count"] == 1
+
+    @pytest.mark.parametrize(
+        ("repo", "source_path", "error"),
+        [
+            ("not-a-repo", "skills/a/SKILL.md", "invalid_repo"),
+            ("acme/tools", "../outside/SKILL.md", "invalid_source_path"),
+            ("acme/tools", "/skills/a/SKILL.md", "absolute_source_path"),
+            ("acme/tools", "C:\\skills\\a\\SKILL.md", "absolute_source_path"),
+            ("acme/tools", "skills/a", "source_path_not_skill_md"),
+        ],
+    )
+    def test_rejects_non_exact_source_identity(self, repo, source_path, error):
+        assert audit_skill_assets._canonical_source(repo, source_path)[2] == error
+
+    def test_canonicalizes_backslashes_and_preserves_root_identity(self):
+        assert audit_skill_assets._canonical_source(
+            "acme/tools", "skills\\a\\SKILL.md"
+        ) == ("acme/tools", "skills/a/SKILL.md", "")
+        assert audit_skill_assets._canonical_source("acme/tools", "SKILL.md") == (
+            "acme/tools",
+            "SKILL.md",
+            "",
+        )
+
+    def test_nested_declared_skill_is_counted_only_as_support_file(self, tmp_path):
+        root = tmp_path / "data"
+        parent = make_skill(
+            root,
+            "dev",
+            "parent",
+            "See references/helper/SKILL.md.",
+            {
+                "repo": "acme/tools",
+                "path": "skills/parent/SKILL.md",
+                "name": "parent",
+                "category": "dev",
+                "archive_mode": "directory",
+                "bundled_files": ["references/helper/SKILL.md"],
+            },
+        )
+        helper = parent / "references" / "helper"
+        helper.mkdir(parents=True)
+        (helper / "SKILL.md").write_text("helper")
+
+        report = audit_skill_assets.run_current_state(str(root), min_stars=0)
+
+        assert report["total_skills"] == 1
+        assert report["actual_bundled_file_count"] == 1
+        assert report["local_verdict_counts"] == {"REF_ASSET": 1}
+
+    def test_rejects_symbolic_links(self, tmp_path):
+        root = tmp_path / "data"
+        skill = make_skill(
+            root,
+            "dev",
+            "linked",
+            "Run scripts/setup.py.",
+            {"repo": "acme/tools", "path": "skills/linked/SKILL.md"},
+        )
+        outside = tmp_path / "outside.py"
+        outside.write_text("print('outside')")
+        (skill / "linked.py").symlink_to(outside)
+
+        with pytest.raises(ValueError, match="symbolic link"):
+            audit_skill_assets.run_current_state(str(root))
+
+    @pytest.mark.parametrize("metadata_text", ["{broken", "[]"])
+    def test_rejects_invalid_metadata(self, tmp_path, metadata_text):
+        root = tmp_path / "data"
+        skill = make_skill(root, "dev", "broken", "body")
+        (skill / "metadata.json").write_text(metadata_text)
+
+        with pytest.raises(ValueError, match="invalid metadata object"):
+            audit_skill_assets.run_current_state(str(root))
+
+    def test_rejects_invalid_stars(self, tmp_path):
+        root = tmp_path / "data"
+        make_skill(
+            root,
+            "dev",
+            "broken",
+            "Run scripts/setup.py.",
+            {
+                "repo": "acme/tools",
+                "path": "skills/broken/SKILL.md",
+                "stars": "many",
+            },
+        )
+
+        with pytest.raises(ValueError, match="invalid stars"):
+            audit_skill_assets.run_current_state(str(root))
+
+
 class TestAuditMain:
     def test_census_mode(self, archive, monkeypatch, capsys):
         monkeypatch.setattr(sys, "argv", ["audit", "census", str(archive)])
@@ -132,6 +346,22 @@ class TestAuditMain:
         monkeypatch.setattr(sys, "argv", ["audit", "targets", str(archive), "1"])
         audit_skill_assets.main()
         assert len(capsys.readouterr().out.splitlines()) == 2
+
+    def test_current_state_mode(self, archive, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["audit", "current-state", str(archive), "100"])
+        audit_skill_assets.main()
+        report = json.loads(capsys.readouterr().out)
+        assert report["total_skills"] == 4
+        assert report["backfill_candidate_count"] == 2
+
+    def test_backfill_targets_mode(self, archive, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["audit", "backfill-targets", str(archive), "100"])
+        audit_skill_assets.main()
+        rows = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+        assert [row["stable_key"] for row in rows] == [
+            "acme/docs:skills/with-docs/SKILL.md",
+            "acme/tools:skills/with-script/SKILL.md",
+        ]
 
     def test_bad_mode_exits(self, monkeypatch):
         monkeypatch.setattr(sys, "argv", ["audit", "bogus", "/tmp"])

--- a/tests/test_skill_asset_pipeline.py
+++ b/tests/test_skill_asset_pipeline.py
@@ -267,6 +267,18 @@ class TestCurrentStateInventory:
             "",
         )
 
+    def test_accepts_case_insensitive_skill_filename(self):
+        assert audit_skill_assets.canonical_source_identity(
+            "acme/tools", "skills/a/skill.md"
+        ) == ("acme/tools", "skills/a/skill.md", "")
+
+    def test_rejects_conflicting_source_path_aliases(self):
+        assert audit_skill_assets.canonical_source_identity_from_metadata({
+            "repo": "acme/tools",
+            "path": "skills/old/SKILL.md",
+            "github_path": "skills/new/SKILL.md",
+        })[2] == "conflicting_source_path_aliases"
+
     def test_nested_declared_skill_is_counted_only_as_support_file(self, tmp_path):
         root = tmp_path / "data"
         parent = make_skill(
@@ -293,6 +305,73 @@ class TestCurrentStateInventory:
         assert report["actual_bundled_file_count"] == 1
         assert report["local_verdict_counts"] == {"REF_ASSET": 1}
 
+    def test_nested_skill_is_support_even_when_metadata_is_stale(self, tmp_path):
+        root = tmp_path / "data"
+        parent = make_skill(
+            root,
+            "dev",
+            "parent",
+            "See references/helper/SKILL.md.",
+            {
+                "repo": "acme/tools",
+                "path": "skills/parent/SKILL.md",
+                "archive_mode": "directory",
+                "bundled_files": [],
+            },
+        )
+        helper = parent / "references" / "helper"
+        helper.mkdir(parents=True)
+        (helper / "SKILL.md").write_text("helper")
+
+        report = audit_skill_assets.run_current_state(str(root), min_stars=0)
+
+        assert report["total_skills"] == 1
+        assert report["actual_bundled_file_count"] == 1
+        assert report["metadata_mismatch_count"] == 1
+
+    def test_repository_case_aliases_are_ambiguous(self, tmp_path):
+        root = tmp_path / "data"
+        for name, repo in (("one", "Acme/Tools"), ("two", "acme/tools")):
+            make_skill(
+                root,
+                "dev",
+                name,
+                "Run scripts/setup.py.",
+                {
+                    "repo": repo,
+                    "path": "skills/demo/SKILL.md",
+                    "stars": 100,
+                },
+            )
+
+        report = audit_skill_assets.run_current_state(str(root), min_stars=100)
+
+        assert report["ambiguous_stable_key_count"] == 1
+        assert report["backfill_candidate_count"] == 0
+
+    @pytest.mark.parametrize(
+        "declared",
+        [{}, ["scripts/run.py", 7], ["scripts/run.py", "scripts/run.py"]],
+    )
+    def test_malformed_bundled_files_is_visible_drift(self, tmp_path, declared):
+        root = tmp_path / "data"
+        make_skill(
+            root,
+            "dev",
+            "broken",
+            "body",
+            {
+                "repo": "acme/tools",
+                "path": "skills/broken/SKILL.md",
+                "archive_mode": "skill-md",
+                "bundled_files": declared,
+            },
+        )
+
+        report = audit_skill_assets.run_current_state(str(root), min_stars=0)
+
+        assert report["metadata_mismatch_count"] == 1
+
     def test_rejects_symbolic_links(self, tmp_path):
         root = tmp_path / "data"
         skill = make_skill(
@@ -318,7 +397,8 @@ class TestCurrentStateInventory:
         with pytest.raises(ValueError, match="invalid metadata object"):
             audit_skill_assets.run_current_state(str(root))
 
-    def test_rejects_invalid_stars(self, tmp_path):
+    @pytest.mark.parametrize("stars", ["many", "100", 100.9, {}, [], -1, True])
+    def test_rejects_invalid_stars(self, tmp_path, stars):
         root = tmp_path / "data"
         make_skill(
             root,
@@ -328,7 +408,7 @@ class TestCurrentStateInventory:
             {
                 "repo": "acme/tools",
                 "path": "skills/broken/SKILL.md",
-                "stars": "many",
+                "stars": stars,
             },
         )
 

--- a/tests/test_skill_asset_pipeline.py
+++ b/tests/test_skill_asset_pipeline.py
@@ -229,6 +229,8 @@ class TestCurrentStateInventory:
             "metadata_mismatch_count": 1,
             "source_identity_error_count": 0,
             "source_identity_errors": [],
+            "metadata_error_count": 0,
+            "metadata_errors": [],
             "ambiguous_stable_key_count": 0,
             "backfill_candidate_count": 1,
         }
@@ -301,6 +303,33 @@ class TestCurrentStateInventory:
             }
         ]
         with pytest.raises(ValueError, match="dev/missing-path.*missing_source_path"):
+            audit_skill_assets.build_backfill_targets(str(root), min_stars=100)
+
+    def test_invalid_candidate_bundle_declaration_blocks_targets(self, tmp_path):
+        root = tmp_path / "data"
+        make_skill(
+            root,
+            "dev",
+            "invalid-bundle",
+            "Run scripts/build.py.",
+            {
+                "stars": 900,
+                "repo": "acme/tools",
+                "path": "skills/invalid-bundle/SKILL.md",
+                "github_branch": "main",
+                "bundled_files": ["references/a:b.md"],
+            },
+        )
+
+        report = audit_skill_assets.run_current_state(str(root), min_stars=100)
+        assert report["metadata_errors"] == [
+            {
+                "archive_path": "dev/invalid-bundle",
+                "error": "invalid_bundled_files",
+                "eligible_for_backfill": True,
+            }
+        ]
+        with pytest.raises(ValueError, match="dev/invalid-bundle.*invalid_bundled_files"):
             audit_skill_assets.build_backfill_targets(str(root), min_stars=100)
 
     @pytest.mark.parametrize(

--- a/tests/test_skill_asset_pipeline.py
+++ b/tests/test_skill_asset_pipeline.py
@@ -188,6 +188,8 @@ class TestCurrentStateInventory:
             "archive_mode_counts": {"directory": 1, "skill-md": 2},
             "actual_bundled_file_count": 1,
             "metadata_mismatch_count": 1,
+            "source_identity_error_count": 0,
+            "source_identity_errors": [],
             "ambiguous_stable_key_count": 0,
             "backfill_candidate_count": 1,
         }
@@ -216,14 +218,6 @@ class TestCurrentStateInventory:
                 "category": "dev",
             },
         )
-        make_skill(
-            root,
-            "dev",
-            "missing-path",
-            "Run scripts/build.py.",
-            {"stars": 900, "repo": "acme/no-path", "name": "missing-path"},
-        )
-
         rows = audit_skill_assets.build_backfill_targets(str(root), min_stars=100)
 
         assert rows == [
@@ -243,6 +237,27 @@ class TestCurrentStateInventory:
         report = audit_skill_assets.run_current_state(str(root), min_stars=100)
         assert report["ambiguous_stable_key_count"] == 1
         assert report["backfill_candidate_count"] == 1
+
+    def test_invalid_candidate_identity_is_reported_and_blocks_targets(self, tmp_path):
+        root = tmp_path / "data"
+        make_skill(
+            root,
+            "dev",
+            "missing-path",
+            "Run scripts/build.py.",
+            {"stars": 900, "repo": "acme/no-path", "name": "missing-path"},
+        )
+
+        report = audit_skill_assets.run_current_state(str(root), min_stars=100)
+
+        assert report["source_identity_error_count"] == 1
+        assert report["source_identity_errors"] == [{
+            "archive_path": "dev/missing-path",
+            "error": "missing_source_path",
+            "eligible_for_backfill": True,
+        }]
+        with pytest.raises(ValueError, match="dev/missing-path.*missing_source_path"):
+            audit_skill_assets.build_backfill_targets(str(root), min_stars=100)
 
     @pytest.mark.parametrize(
         ("repo", "source_path", "error"),

--- a/tests/test_skill_asset_pipeline.py
+++ b/tests/test_skill_asset_pipeline.py
@@ -332,6 +332,27 @@ class TestCurrentStateInventory:
         with pytest.raises(ValueError, match="dev/invalid-bundle.*invalid_bundled_files"):
             audit_skill_assets.build_backfill_targets(str(root), min_stars=100)
 
+    def test_invalid_identity_and_bundle_declaration_both_block_targets(self, tmp_path):
+        root = tmp_path / "data"
+        make_skill(
+            root,
+            "dev",
+            "invalid-both",
+            "Run scripts/build.py.",
+            {
+                "stars": 900,
+                "repo": "acme/tools",
+                "bundled_files": ["references/a:b.md"],
+            },
+        )
+
+        report = audit_skill_assets.run_current_state(str(root), min_stars=100)
+
+        assert report["source_identity_errors"][0]["eligible_for_backfill"] is True
+        assert report["metadata_errors"][0]["eligible_for_backfill"] is True
+        with pytest.raises(ValueError, match="missing_source_path"):
+            audit_skill_assets.build_backfill_targets(str(root), min_stars=100)
+
     @pytest.mark.parametrize(
         ("repo", "source_path", "error"),
         [

--- a/tests/test_skill_asset_pipeline.py
+++ b/tests/test_skill_asset_pipeline.py
@@ -41,24 +41,25 @@ def archive(tmp_path):
         root, "dev", "with-script",
         "Run scripts/setup.py first.",
         {"stars": 500, "repo": "acme/tools", "path": "skills/with-script/SKILL.md",
-         "name": "with-script"},
+         "github_branch": "main", "name": "with-script"},
     )
     make_skill(
         root, "dev", "with-docs",
         "See references/guide.md for details.",
         {"stars": 300, "repo": "acme/docs", "path": "skills/with-docs/SKILL.md",
-         "name": "with-docs"},
+         "github_branch": "main", "name": "with-docs"},
     )
     make_skill(
         root, "dev", "plain",
         "Just prose, no local files.",
-        {"stars": 900, "repo": "acme/plain", "path": "skills/plain/SKILL.md", "name": "plain"},
+        {"stars": 900, "repo": "acme/plain", "path": "skills/plain/SKILL.md",
+         "github_branch": "main", "name": "plain"},
     )
     make_skill(
         root, "dev", "low-stars",
         "Run scripts/other.py first.",
         {"stars": 3, "repo": "acme/small", "path": "skills/low-stars/SKILL.md",
-         "name": "low-stars"},
+         "github_branch": "main", "name": "low-stars"},
     )
     return root
 
@@ -134,6 +135,7 @@ class TestCurrentStateInventory:
                 "stars": 500,
                 "repo": "acme/tools",
                 "path": "skills/archived/SKILL.md",
+                "github_branch": "main",
                 "name": "archived",
                 "category": "dev",
                 "archive_mode": "directory",
@@ -151,6 +153,7 @@ class TestCurrentStateInventory:
                 "stars": 300,
                 "repo": "acme/docs",
                 "path": "skills/missing/SKILL.md",
+                "github_branch": "release/v1",
                 "name": "missing",
                 "category": "dev",
                 "archive_mode": "directory",
@@ -166,6 +169,7 @@ class TestCurrentStateInventory:
                 "stars": 1,
                 "repo": "acme/plain",
                 "path": "SKILL.md",
+                "github_branch": "main",
                 "name": "plain",
                 "category": "dev",
                 "archive_mode": "skill-md",
@@ -200,6 +204,7 @@ class TestCurrentStateInventory:
             "stars": 200,
             "repo": "acme/tools",
             "path": "skills/duplicate/SKILL.md",
+            "github_branch": "main",
             "name": "duplicate",
             "category": "dev",
         }
@@ -214,6 +219,7 @@ class TestCurrentStateInventory:
                 "stars": 500,
                 "repo": "acme/ready",
                 "path": "skills/ready/SKILL.md",
+                "github_branch": "release/v2",
                 "name": "ready",
                 "category": "dev",
             },
@@ -226,6 +232,7 @@ class TestCurrentStateInventory:
                 "archive_path": "dev/ready",
                 "repo": "acme/ready",
                 "source_path": "skills/ready/SKILL.md",
+                "github_branch": "release/v2",
                 "dir": "skills/ready",
                 "name": "ready",
                 "category": "dev",

--- a/tests/test_skill_asset_pipeline.py
+++ b/tests/test_skill_asset_pipeline.py
@@ -3,6 +3,7 @@
 Network access is stubbed at the `gh` subprocess boundary so the census,
 verification, and fetch stages run against real files in tmp_path.
 """
+
 import json
 import os
 import subprocess
@@ -38,28 +39,56 @@ def make_skill(root, category, name, body, meta=None):
 def archive(tmp_path):
     root = tmp_path / "data"
     make_skill(
-        root, "dev", "with-script",
+        root,
+        "dev",
+        "with-script",
         "Run scripts/setup.py first.",
-        {"stars": 500, "repo": "acme/tools", "path": "skills/with-script/SKILL.md",
-         "github_branch": "main", "name": "with-script"},
+        {
+            "stars": 500,
+            "repo": "acme/tools",
+            "path": "skills/with-script/SKILL.md",
+            "github_branch": "main",
+            "name": "with-script",
+        },
     )
     make_skill(
-        root, "dev", "with-docs",
+        root,
+        "dev",
+        "with-docs",
         "See references/guide.md for details.",
-        {"stars": 300, "repo": "acme/docs", "path": "skills/with-docs/SKILL.md",
-         "github_branch": "main", "name": "with-docs"},
+        {
+            "stars": 300,
+            "repo": "acme/docs",
+            "path": "skills/with-docs/SKILL.md",
+            "github_branch": "main",
+            "name": "with-docs",
+        },
     )
     make_skill(
-        root, "dev", "plain",
+        root,
+        "dev",
+        "plain",
         "Just prose, no local files.",
-        {"stars": 900, "repo": "acme/plain", "path": "skills/plain/SKILL.md",
-         "github_branch": "main", "name": "plain"},
+        {
+            "stars": 900,
+            "repo": "acme/plain",
+            "path": "skills/plain/SKILL.md",
+            "github_branch": "main",
+            "name": "plain",
+        },
     )
     make_skill(
-        root, "dev", "low-stars",
+        root,
+        "dev",
+        "low-stars",
         "Run scripts/other.py first.",
-        {"stars": 3, "repo": "acme/small", "path": "skills/low-stars/SKILL.md",
-         "github_branch": "main", "name": "low-stars"},
+        {
+            "stars": 3,
+            "repo": "acme/small",
+            "path": "skills/low-stars/SKILL.md",
+            "github_branch": "main",
+            "name": "low-stars",
+        },
     )
     return root
 
@@ -67,14 +96,16 @@ def archive(tmp_path):
 class TestFetchRepoTree:
     def test_returns_blob_paths(self, monkeypatch):
         monkeypatch.setattr(
-            skill_asset_audit.subprocess, "run",
+            skill_asset_audit.subprocess,
+            "run",
             lambda *a, **k: FakeCompleted(stdout='["a/SKILL.md", "a/run.py"]'),
         )
         assert skill_asset_audit.fetch_repo_tree("acme/tools") == ["a/SKILL.md", "a/run.py"]
 
     def test_raises_on_gh_failure(self, monkeypatch):
         monkeypatch.setattr(
-            skill_asset_audit.subprocess, "run",
+            skill_asset_audit.subprocess,
+            "run",
             lambda *a, **k: FakeCompleted(returncode=1, stderr="Not Found"),
         )
         with pytest.raises(RuntimeError, match="Not Found"):
@@ -99,8 +130,12 @@ class TestTargets:
         audit_skill_assets.run_targets(str(archive), 100)
         rows = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
         assert [r["name"] for r in rows] == ["with-script"]
-        assert rows[0] == {"repo": "acme/tools", "dir": "skills/with-script",
-                           "stars": 500, "name": "with-script"}
+        assert rows[0] == {
+            "repo": "acme/tools",
+            "dir": "skills/with-script",
+            "stars": 500,
+            "name": "with-script",
+        }
 
     def test_lower_threshold_includes_small_repos(self, archive, capsys):
         audit_skill_assets.run_targets(str(archive), 1)
@@ -258,11 +293,13 @@ class TestCurrentStateInventory:
         report = audit_skill_assets.run_current_state(str(root), min_stars=100)
 
         assert report["source_identity_error_count"] == 1
-        assert report["source_identity_errors"] == [{
-            "archive_path": "dev/missing-path",
-            "error": "missing_source_path",
-            "eligible_for_backfill": True,
-        }]
+        assert report["source_identity_errors"] == [
+            {
+                "archive_path": "dev/missing-path",
+                "error": "missing_source_path",
+                "eligible_for_backfill": True,
+            }
+        ]
         with pytest.raises(ValueError, match="dev/missing-path.*missing_source_path"):
             audit_skill_assets.build_backfill_targets(str(root), min_stars=100)
 
@@ -280,9 +317,11 @@ class TestCurrentStateInventory:
         assert audit_skill_assets._canonical_source(repo, source_path)[2] == error
 
     def test_canonicalizes_backslashes_and_preserves_root_identity(self):
-        assert audit_skill_assets._canonical_source(
-            "acme/tools", "skills\\a\\SKILL.md"
-        ) == ("acme/tools", "skills/a/SKILL.md", "")
+        assert audit_skill_assets._canonical_source("acme/tools", "skills\\a\\SKILL.md") == (
+            "acme/tools",
+            "skills/a/SKILL.md",
+            "",
+        )
         assert audit_skill_assets._canonical_source("acme/tools", "SKILL.md") == (
             "acme/tools",
             "SKILL.md",
@@ -290,16 +329,23 @@ class TestCurrentStateInventory:
         )
 
     def test_accepts_case_insensitive_skill_filename(self):
-        assert audit_skill_assets.canonical_source_identity(
-            "acme/tools", "skills/a/skill.md"
-        ) == ("acme/tools", "skills/a/skill.md", "")
+        assert audit_skill_assets.canonical_source_identity("acme/tools", "skills/a/skill.md") == (
+            "acme/tools",
+            "skills/a/skill.md",
+            "",
+        )
 
     def test_rejects_conflicting_source_path_aliases(self):
-        assert audit_skill_assets.canonical_source_identity_from_metadata({
-            "repo": "acme/tools",
-            "path": "skills/old/SKILL.md",
-            "github_path": "skills/new/SKILL.md",
-        })[2] == "conflicting_source_path_aliases"
+        assert (
+            audit_skill_assets.canonical_source_identity_from_metadata(
+                {
+                    "repo": "acme/tools",
+                    "path": "skills/old/SKILL.md",
+                    "github_path": "skills/new/SKILL.md",
+                }
+            )[2]
+            == "conflicting_source_path_aliases"
+        )
 
     def test_nested_declared_skill_is_counted_only_as_support_file(self, tmp_path):
         root = tmp_path / "data"
@@ -410,6 +456,31 @@ class TestCurrentStateInventory:
         with pytest.raises(ValueError, match="symbolic link"):
             audit_skill_assets.run_current_state(str(root))
 
+    def test_rejects_non_portable_existing_asset_paths(self, tmp_path):
+        root = tmp_path / "data"
+        skill = make_skill(
+            root,
+            "dev",
+            "non-portable",
+            "Read references/a:b.md.",
+            {"repo": "acme/tools", "path": "skills/non-portable/SKILL.md"},
+        )
+        (skill / "references").mkdir()
+        (skill / "references" / "a:b.md").write_text("body")
+
+        with pytest.raises(ValueError, match="non-portable path"):
+            audit_skill_assets.run_current_state(str(root))
+
+    def test_rejects_symlinked_archive_directories(self, tmp_path):
+        root = tmp_path / "data"
+        make_skill(root, "dev", "valid", "body")
+        outside = tmp_path / "outside-category"
+        make_skill(outside, "external", "linked", "body")
+        (root / "linked-category").symlink_to(outside / "external", target_is_directory=True)
+
+        with pytest.raises(ValueError, match="symbolic link"):
+            audit_skill_assets.run_current_state(str(root))
+
     @pytest.mark.parametrize("metadata_text", ["{broken", "[]"])
     def test_rejects_invalid_metadata(self, tmp_path, metadata_text):
         root = tmp_path / "data"
@@ -488,11 +559,14 @@ class TestVerifyRepo:
 
     def test_classifies_each_verdict(self, monkeypatch):
         self._patch_tree(monkeypatch)
-        rows = verify_upstream_assets.verify_repo("acme/tools", [
-            {"repo": "acme/tools", "dir": "skills/alpha", "name": "alpha"},
-            {"repo": "acme/tools", "dir": "skills/beta", "name": "beta"},
-            {"repo": "acme/tools", "dir": "skills/gamma", "name": "gamma"},
-        ])
+        rows = verify_upstream_assets.verify_repo(
+            "acme/tools",
+            [
+                {"repo": "acme/tools", "dir": "skills/alpha", "name": "alpha"},
+                {"repo": "acme/tools", "dir": "skills/beta", "name": "beta"},
+                {"repo": "acme/tools", "dir": "skills/gamma", "name": "gamma"},
+            ],
+        )
         assert [r["status"] for r in rows] == ["EXEC", "REF_ASSET", "BARE"]
         assert rows[0]["exec"] == 1
 
@@ -524,10 +598,13 @@ class TestVerifyRepo:
             raise RuntimeError("gh api tree failed: 404")
 
         monkeypatch.setattr(verify_upstream_assets, "fetch_repo_tree", boom)
-        rows = verify_upstream_assets.verify_repo("acme/gone", [
-            {"repo": "acme/gone", "dir": "a", "name": "a"},
-            {"repo": "acme/gone", "dir": "b", "name": "b"},
-        ])
+        rows = verify_upstream_assets.verify_repo(
+            "acme/gone",
+            [
+                {"repo": "acme/gone", "dir": "a", "name": "a"},
+                {"repo": "acme/gone", "dir": "b", "name": "b"},
+            ],
+        )
         assert [r["status"] for r in rows] == ["repo_error", "repo_error"]
         assert "404" in rows[0]["error"]
 
@@ -536,8 +613,10 @@ class TestVerifyMain:
     def test_writes_rows_and_summary(self, tmp_path, monkeypatch, capsys):
         targets = tmp_path / "targets.jsonl"
         targets.write_text(
-            json.dumps({"repo": "acme/tools", "dir": "skills/alpha", "name": "alpha"}) + "\n"
-            + json.dumps({"repo": "acme/gone", "dir": "skills/x", "name": "x"}) + "\n",
+            json.dumps({"repo": "acme/tools", "dir": "skills/alpha", "name": "alpha"})
+            + "\n"
+            + json.dumps({"repo": "acme/gone", "dir": "skills/x", "name": "x"})
+            + "\n",
             encoding="utf-8",
         )
         out = tmp_path / "verified.jsonl"
@@ -565,7 +644,8 @@ class TestVerifyMain:
 class TestFetchFile:
     def test_writes_bytes(self, tmp_path, monkeypatch):
         monkeypatch.setattr(
-            fetch_curated_skills.subprocess, "run",
+            fetch_curated_skills.subprocess,
+            "run",
             lambda *a, **k: FakeCompleted(stdout=b"print('hi')"),
         )
         local = tmp_path / "nested" / "run.py"
@@ -574,7 +654,8 @@ class TestFetchFile:
 
     def test_raises_on_gh_failure(self, tmp_path, monkeypatch):
         monkeypatch.setattr(
-            fetch_curated_skills.subprocess, "run",
+            fetch_curated_skills.subprocess,
+            "run",
             lambda *a, **k: FakeCompleted(returncode=1, stderr=b"Not Found"),
         )
         with pytest.raises(RuntimeError, match="Not Found"):
@@ -582,14 +663,22 @@ class TestFetchFile:
 
 
 class TestFetchSkill:
-    TARGET = {"repo": "acme/tools", "resolved_dir": "skills/alpha", "stars": 500,
-              "status": "EXEC", "_tree": ["skills/alpha/SKILL.md", "skills/alpha/run.py"]}
+    TARGET = {
+        "repo": "acme/tools",
+        "resolved_dir": "skills/alpha",
+        "stars": 500,
+        "status": "EXEC",
+        "_tree": ["skills/alpha/SKILL.md", "skills/alpha/run.py"],
+    }
 
     def test_fetches_files_and_writes_provenance(self, tmp_path, monkeypatch):
         monkeypatch.setattr(
-            fetch_curated_skills, "fetch_file",
-            lambda repo, path, local: (os.makedirs(os.path.dirname(local), exist_ok=True),
-                                       open(local, "wb").write(b"x")),
+            fetch_curated_skills,
+            "fetch_file",
+            lambda repo, path, local: (
+                os.makedirs(os.path.dirname(local), exist_ok=True),
+                open(local, "wb").write(b"x"),
+            ),
         )
         row = fetch_curated_skills.fetch_skill("acme/tools", dict(self.TARGET), str(tmp_path))
         assert row["fetch"] == "ok"
@@ -622,11 +711,18 @@ class TestFetchSkill:
 class TestFetchMain:
     def test_skips_unverified_rows_and_writes_report(self, tmp_path, monkeypatch):
         verified = tmp_path / "verified.jsonl"
-        verified.write_text("\n".join(json.dumps(r) for r in [
-            {"repo": "acme/tools", "resolved_dir": "skills/alpha", "status": "EXEC"},
-            {"repo": "acme/tools", "resolved_dir": "skills/beta", "status": "BARE"},
-            {"repo": "acme/gone", "resolved_dir": "skills/x", "status": "REF_ASSET"},
-        ]) + "\n", encoding="utf-8")
+        verified.write_text(
+            "\n".join(
+                json.dumps(r)
+                for r in [
+                    {"repo": "acme/tools", "resolved_dir": "skills/alpha", "status": "EXEC"},
+                    {"repo": "acme/tools", "resolved_dir": "skills/beta", "status": "BARE"},
+                    {"repo": "acme/gone", "resolved_dir": "skills/x", "status": "REF_ASSET"},
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
         report_path = tmp_path / "report.json"
 
         def fake_tree(repo):
@@ -636,9 +732,12 @@ class TestFetchMain:
 
         monkeypatch.setattr(fetch_curated_skills, "fetch_repo_tree", fake_tree)
         monkeypatch.setattr(
-            fetch_curated_skills, "fetch_file",
-            lambda repo, path, local: (os.makedirs(os.path.dirname(local), exist_ok=True),
-                                       open(local, "wb").write(b"x")),
+            fetch_curated_skills,
+            "fetch_file",
+            lambda repo, path, local: (
+                os.makedirs(os.path.dirname(local), exist_ok=True),
+                open(local, "wb").write(b"x"),
+            ),
         )
         monkeypatch.setattr(
             sys, "argv", ["fetch", str(verified), str(tmp_path / "out"), str(report_path)]

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -698,6 +698,20 @@ def test_bundled_file_allowlist_is_scoped_and_size_limited():
     support = load_support_module()
 
     assert module.bundled_relative_path("", "package.json") == "package.json"
+    assert support.is_safe_portable_relative_path("references/guide.md") is True
+    for invalid_path in (
+        "CON",
+        "references/aux.txt",
+        "references/name.",
+        "references/name ",
+        "references/a:b.md",
+        "references/a?b.md",
+        "references/a*b.md",
+        "references/a|b.md",
+        "references/a<b.md",
+        "references/a>b.md",
+    ):
+        assert support.is_safe_portable_relative_path(invalid_path) is False
     assert (
         module.bundled_relative_path("skills/demo", "skills/demo/scripts/run.sh")
         == "scripts/run.sh"
@@ -868,7 +882,7 @@ def test_bundles_root_helpers_src_and_design_subskills(tmp_path, monkeypatch):
                 )
             ),
             "https://download.example/webmedia.py": FakeResponse(200, text="print('media')\n"),
-            "https://download.example/sck-record.swift": FakeResponse(200, text="print(\"rec\")\n"),
+            "https://download.example/sck-record.swift": FakeResponse(200, text='print("rec")\n'),
             "https://download.example/polish.py": FakeResponse(200, text="print('polish')\n"),
             "https://download.example/design-spatial-skill": FakeResponse(
                 200,
@@ -877,7 +891,9 @@ def test_bundles_root_helpers_src_and_design_subskills(tmp_path, monkeypatch):
                     "description: Demo nested design subskill.\n---\n# Design Spatial\n"
                 ),
             ),
-            "https://download.example/layout-audit.js": FakeResponse(200, text="console.log('ok')\n"),
+            "https://download.example/layout-audit.js": FakeResponse(
+                200, text="console.log('ok')\n"
+            ),
         },
     )
 
@@ -1284,9 +1300,7 @@ def test_bundled_references_rules_and_knowledge_are_archived_with_directory_mode
         "references/guide.md",
         "rules/rule.md",
     ]
-    assert (skill_dir / "knowledge" / "framework.md").read_text(
-        encoding="utf-8"
-    ) == "# Framework\n"
+    assert (skill_dir / "knowledge" / "framework.md").read_text(encoding="utf-8") == "# Framework\n"
     assert (skill_dir / "references" / "guide.md").read_text(encoding="utf-8") == "# Guide\n"
     assert (skill_dir / "rules" / "rule.md").read_text(encoding="utf-8") == "# Rule\n"
 
@@ -1318,8 +1332,7 @@ def test_bundled_collection_skips_github_submodule_entries(tmp_path, monkeypatch
             "https://raw.githubusercontent.com/acme/demo/main/SKILL.md": FakeResponse(
                 200,
                 text=(
-                    "---\nname: demo\n"
-                    "description: Demo skill with a submodule path.\n---\n# Demo\n"
+                    "---\nname: demo\ndescription: Demo skill with a submodule path.\n---\n# Demo\n"
                 ),
             ),
             "https://api.github.com/repos/acme/demo/contents?ref=main": FakeResponse(

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -752,6 +752,13 @@ def test_bundled_file_allowlist_is_scoped_and_size_limited():
     assert module.is_safe_bundled_file("examples/SKILL.md", 1024) is False
     assert module.is_safe_bundled_file("docs/helper.py", 1024) is False
     assert module.is_safe_bundled_file("references/.env", 10) is False
+    for non_portable in (
+        "references/a:b.md",
+        "references/CON.txt",
+        "/references/guide.md",
+        "references/guide.md/",
+    ):
+        assert module.is_safe_bundled_file(non_portable, 10) is False
     assert (
         module.is_safe_bundled_file(
             "references/huge.py",

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -760,6 +760,12 @@ def test_bundled_file_allowlist_is_scoped_and_size_limited():
     ):
         assert module.is_safe_bundled_file(non_portable, 10) is False
     assert (
+        support.is_safe_bundled_file("scripts/unrelated:name.bin", 10, reject_nonportable=True)
+        is False
+    )
+    with pytest.raises(support.BundledListingError, match="non-portable bundled path"):
+        support.is_safe_bundled_file("scripts/bad:name.py", 10, reject_nonportable=True)
+    assert (
         module.is_safe_bundled_file(
             "references/huge.py",
             module.MAX_BUNDLED_FILE_BYTES + 1,

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -710,6 +710,8 @@ def test_bundled_file_allowlist_is_scoped_and_size_limited():
         "references/a|b.md",
         "references/a<b.md",
         "references/a>b.md",
+        "references/COM¹.txt",
+        "references/lpt³.log",
     ):
         assert support.is_safe_portable_relative_path(invalid_path) is False
     assert (
@@ -728,6 +730,7 @@ def test_bundled_file_allowlist_is_scoped_and_size_limited():
     assert module.should_recurse_bundled_dir("src") is True
     assert module.should_recurse_bundled_dir("design-spatial") is True
     assert module.should_recurse_bundled_dir("docs") is False
+    assert support.has_case_conflicting_paths(["references/Guide.md", "references/guide.md"])
     assert module.is_safe_bundled_file("references/helper.py", 1024) is True
     assert module.is_safe_bundled_file("reference/environment.md", 1024) is True
     assert module.is_safe_bundled_file("connectors/slack.md", 1024) is True
@@ -1135,6 +1138,77 @@ def test_non_portable_required_bundle_path_fails_instead_of_degrading(tmp_path, 
     failure_report = json.loads(failure_report_path.read_text())
     assert failure_report["failure_reasons"]["bundled_listing_failed"] == 1
     assert "non-portable bundled path" in failure_report["failures"]["bundled_listing_failed"][0]
+
+
+def test_case_conflicting_required_bundle_paths_fail_before_download(tmp_path, monkeypatch):
+    module = load_module()
+    registry_path = tmp_path / "registry.json"
+    output_dir = tmp_path / "skills"
+    failure_report_path = tmp_path / "failure_report.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "skills": [
+                    {
+                        "name": "demo",
+                        "repo": "acme/demo",
+                        "path": "skills/demo",
+                        "category": "development",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    install_fake_aiohttp(
+        monkeypatch,
+        {
+            "https://raw.githubusercontent.com/acme/demo/main/skills/demo/SKILL.md": FakeResponse(
+                200,
+                text=(
+                    "---\nname: demo\ndescription: Demo with required assets.\n---\n"
+                    "# Demo\nRead references/Guide.md before use.\n"
+                ),
+            ),
+            "https://api.github.com/repos/acme/demo/contents/skills/demo?ref=main": FakeResponse(
+                200,
+                json_payload=[{"type": "dir", "path": "skills/demo/references", "size": 0}],
+            ),
+            "https://api.github.com/repos/acme/demo/contents/skills/demo/references?ref=main": (
+                FakeResponse(
+                    200,
+                    json_payload=[
+                        {
+                            "type": "file",
+                            "path": "skills/demo/references/Guide.md",
+                            "size": 10,
+                        },
+                        {
+                            "type": "file",
+                            "path": "skills/demo/references/guide.md",
+                            "size": 10,
+                        },
+                    ],
+                )
+            ),
+        },
+    )
+
+    stats = asyncio.run(
+        module.download_skills(
+            registry_path,
+            output_dir,
+            failure_report_path=failure_report_path,
+        )
+    )
+
+    assert stats["downloaded"] == 0
+    failure_report = json.loads(failure_report_path.read_text())
+    assert failure_report["failure_reasons"]["bundled_listing_failed"] == 1
+    assert (
+        "case-conflicting bundled paths" in failure_report["failures"]["bundled_listing_failed"][0]
+    )
+    assert not list(output_dir.rglob("SKILL.md"))
 
 
 def test_bundled_listing_failure_degrades_when_skill_has_no_support_refs(

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -1066,6 +1066,71 @@ def test_bundled_listing_failure_does_not_publish_skill_md_only(tmp_path, monkey
     assert "status 403" in failure_report["failures"]["bundled_listing_failed"][0]
 
 
+def test_non_portable_required_bundle_path_fails_instead_of_degrading(tmp_path, monkeypatch):
+    module = load_module()
+    registry_path = tmp_path / "registry.json"
+    output_dir = tmp_path / "skills"
+    failure_report_path = tmp_path / "failure_report.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "skills": [
+                    {
+                        "name": "demo",
+                        "repo": "acme/demo",
+                        "path": "skills/demo",
+                        "category": "development",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    install_fake_aiohttp(
+        monkeypatch,
+        {
+            "https://raw.githubusercontent.com/acme/demo/main/skills/demo/SKILL.md": FakeResponse(
+                200,
+                text=(
+                    "---\nname: demo\ndescription: Demo with required assets.\n---\n"
+                    "# Demo\nRead references/a:b.md before use.\n"
+                ),
+            ),
+            "https://api.github.com/repos/acme/demo/contents/skills/demo?ref=main": FakeResponse(
+                200,
+                json_payload=[{"type": "dir", "path": "skills/demo/references", "size": 0}],
+            ),
+            "https://api.github.com/repos/acme/demo/contents/skills/demo/references?ref=main": (
+                FakeResponse(
+                    200,
+                    json_payload=[
+                        {
+                            "type": "file",
+                            "path": "skills/demo/references/a:b.md",
+                            "size": 10,
+                        }
+                    ],
+                )
+            ),
+        },
+    )
+
+    stats = asyncio.run(
+        module.download_skills(
+            registry_path,
+            output_dir,
+            failure_report_path=failure_report_path,
+        )
+    )
+
+    assert stats["downloaded"] == 0
+    assert stats["failed"] == 1
+    assert not list(output_dir.rglob("SKILL.md"))
+    failure_report = json.loads(failure_report_path.read_text())
+    assert failure_report["failure_reasons"]["bundled_listing_failed"] == 1
+    assert "non-portable bundled path" in failure_report["failures"]["bundled_listing_failed"][0]
+
+
 def test_bundled_listing_failure_degrades_when_skill_has_no_support_refs(
     tmp_path,
     monkeypatch,


### PR DESCRIPTION
## Summary

Implements Phase 1 inventory groundwork for #259 without introducing a parallel curated archive:

- add a current-state report based on actual archived support files
- emit deterministic backfill target JSONL only for exact owner/repo + SKILL.md identities
- fail closed on duplicate stable keys, malformed metadata, invalid stars, traversal/absolute paths, and symbolic links
- exclude declared nested support SKILL.md files from top-level skill counts
- distinguish actual archive mode from stale or incorrect metadata
- retain the existing census and targets commands

## Routing

- [x] This PR belongs in claude-skill-registry-core.
- [x] Generated main-repo artifacts were not edited directly.
- [x] Data-repo-only skill body changes were not made here.

## Verification

- PATH=/Users/apple/Desktop/code/AI/tool/claude-skill-registry-core/.venv/bin:$PATH pytest -q --cov-report=xml:coverage.xml --cov-report=json:coverage.json
  - 758 passed
- python scripts/check_coverage_ratchet.py --coverage coverage.json --baseline coverage-baseline.json --compare-ref origin/main
  - passed
- diff-cover coverage.xml --compare-branch=origin/main --fail-under=80
  - 96% changed-line coverage
- python scripts/check_taxonomy_governance.py
  - 0 errors, 0 warnings
- ruff check scripts/audit_skill_assets.py tests/test_skill_asset_pipeline.py
  - passed
- git diff --check
  - passed

Codex CLI reviewed the Phase 1 diff. Its path validation, nested-SKILL, malformed-metadata, symlink, actual-mode, and double-scan findings were addressed before this PR.

## Linked Issues

Part of #259. This PR does not close the epic.
