### PR TITLE
fix(sync): allow standalone skills without support files

### DIFF
--- a/scripts/sync_download.py
+++ b/scripts/sync_download.py
@@ -477,9 +477,12 @@ async def download_skills(
                                     and len(content) > 50
                                     and ("---" in content[:50] or "#" in content[:100])
                                 ):
-                                    require_complete_archive = requires_complete_bundled_archive(
-                                        content
-                                    ) or (exact_paths_only and pin_commit_sha)
+                                    content_requires_complete_archive = (
+                                        requires_complete_bundled_archive(content)
+                                    )
+                                    require_complete_archive = content_requires_complete_archive or (
+                                        exact_paths_only and pin_commit_sha
+                                    )
                                     redistribution_approved = asset_redistribution_approved(skill)
                                     if require_complete_archive and not redistribution_approved:
                                         failure_reason = "asset_redistribution_not_approved"
@@ -509,6 +512,11 @@ async def download_skills(
                                             relative_path,
                                             skill_dir,
                                             require_complete_archive,
+                                            allow_empty_complete_archive=(
+                                                exact_paths_only
+                                                and pin_commit_sha
+                                                and not content_requires_complete_archive
+                                            ),
                                             pin_commit_sha=pin_commit_sha,
                                             timeout=request_timeout,
                                             tree_cache=tree_cache,

--- a/scripts/sync_download.py
+++ b/scripts/sync_download.py
@@ -478,7 +478,8 @@ async def download_skills(
                                     and ("---" in content[:50] or "#" in content[:100])
                                 ):
                                     content_requires_complete_archive = (
-                                        requires_complete_bundled_archive(content)
+                                        requires_complete_bundled_archive(source_text)
+                                        or requires_complete_bundled_archive(content)
                                     )
                                     require_complete_archive = content_requires_complete_archive or (
                                         exact_paths_only and pin_commit_sha

--- a/scripts/sync_download_support.py
+++ b/scripts/sync_download_support.py
@@ -334,6 +334,7 @@ async def download_bundled_files_to_directory(
     skill_dir: Path,
     require_complete_archive: bool,
     *,
+    allow_empty_complete_archive: bool = False,
     pin_commit_sha: bool,
     timeout: Any,
     tree_cache: dict[tuple[str, str], list[dict]],
@@ -370,9 +371,13 @@ async def download_bundled_files_to_directory(
         message = "eligible bundled files exceed per-skill count or byte limits"
         return archived, [message], "bundled_limits_exceeded", blob_ids
     if not entries:
-        # A complete empty listing is valid for standalone SKILL.md sources with no
-        # eligible support files. Listing failures and omissions are already
-        # represented by BundledListingError or the truncated/incomplete flag.
+        if require_complete_archive and not allow_empty_complete_archive:
+            return (
+                archived,
+                ["required bundled archive contains no eligible support files"],
+                "bundled_listing_incomplete",
+                blob_ids,
+            )
         return archived, failed, "", blob_ids
 
     skill_root = skill_dir.resolve()

--- a/scripts/sync_download_support.py
+++ b/scripts/sync_download_support.py
@@ -370,13 +370,9 @@ async def download_bundled_files_to_directory(
         message = "eligible bundled files exceed per-skill count or byte limits"
         return archived, [message], "bundled_limits_exceeded", blob_ids
     if not entries:
-        if require_complete_archive:
-            return (
-                archived,
-                ["required bundled archive contains no eligible support files"],
-                "bundled_listing_incomplete",
-                blob_ids,
-            )
+        # A complete empty listing is valid for standalone SKILL.md sources with no
+        # eligible support files. Listing failures and omissions are already
+        # represented by BundledListingError or the truncated/incomplete flag.
         return archived, failed, "", blob_ids
 
     skill_root = skill_dir.resolve()

--- a/tests/test_skill_asset_pipeline.py
+++ b/tests/test_skill_asset_pipeline.py
@@ -728,7 +728,7 @@ class TestBackfillTargets:
         assert entries == []
         assert incomplete is True
 
-    def test_required_ordinary_bundle_allows_complete_empty_listing(self, tmp_path):
+    def test_required_ordinary_bundle_rejects_empty_listing(self, tmp_path):
         async def empty_collector(*_args):
             return [], False
 
@@ -744,6 +744,31 @@ class TestBackfillTargets:
                 timeout=None,
                 tree_cache={},
                 contents_collector=empty_collector,
+            )
+        )
+
+        assert result[1] == ["required bundled archive contains no eligible support files"]
+        assert result[2] == "bundled_listing_incomplete"
+
+    def test_exact_pinned_standalone_bundle_allows_complete_empty_listing(self, tmp_path):
+        result = asyncio.run(
+            sync_download_support.download_bundled_files_to_directory(
+                object(),
+                "acme/tools",
+                "deadbeef" * 5,
+                "SKILL.md",
+                tmp_path,
+                True,
+                allow_empty_complete_archive=True,
+                pin_commit_sha=True,
+                timeout=None,
+                tree_cache={},
+                contents_collector=None,
+                pinned_tree_result=(
+                    [],
+                    False,
+                    {"repo_path": "SKILL.md", "relative_path": "SKILL.md", "size": 1, "sha": "x"},
+                ),
             )
         )
 

--- a/tests/test_skill_asset_pipeline.py
+++ b/tests/test_skill_asset_pipeline.py
@@ -728,7 +728,7 @@ class TestBackfillTargets:
         assert entries == []
         assert incomplete is True
 
-    def test_required_ordinary_bundle_rejects_empty_listing(self, tmp_path):
+    def test_required_ordinary_bundle_allows_complete_empty_listing(self, tmp_path):
         async def empty_collector(*_args):
             return [], False
 
@@ -747,8 +747,7 @@ class TestBackfillTargets:
             )
         )
 
-        assert result[1] == ["required bundled archive contains no eligible support files"]
-        assert result[2] == "bundled_listing_incomplete"
+        assert result == ([], [], "", {})
 
     @pytest.mark.parametrize(
         "paths",

--- a/tests/test_sync_and_download.py
+++ b/tests/test_sync_and_download.py
@@ -588,6 +588,141 @@ def test_exact_download_pins_skill_and_bundled_files_to_commit_sha(
     assert metadata["bundled_file_blobs"] == {"scripts/setup.py": git_blob_sha(script_body)}
 
 
+def test_exact_download_allows_standalone_skill_with_empty_support_listing(
+    tmp_path, monkeypatch
+):
+    module = load_module()
+    registry_path = tmp_path / "registry.json"
+    output_dir = tmp_path / "skills"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "skills": [
+                    {
+                        "name": "standalone",
+                        "repo": "acme/standalone",
+                        "path": "skills/standalone/SKILL.md",
+                        "category": "development",
+                        "github_branch": "main",
+                        "license": "MIT",
+                        "distribution": "compatible",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    sha = "a" * 40
+    skill_body = (
+        b"---\nname: standalone\ndescription: A complete standalone skill.\n---\n"
+        b"# Standalone\nFollow these self-contained instructions.\n"
+    )
+    install_fake_aiohttp(
+        monkeypatch,
+        {
+            **exact_repo_routes(
+                "acme/standalone",
+                "main",
+                sha,
+                [git_blob_entry("skills/standalone/SKILL.md", skill_body)],
+            ),
+            f"https://raw.githubusercontent.com/acme/standalone/{sha}/skills/standalone/SKILL.md": (  # noqa: E501
+                FakeResponse(200, body=skill_body)
+            ),
+        },
+    )
+
+    stats = asyncio.run(
+        module.download_skills(
+            registry_path,
+            output_dir,
+            manifest_path=None,
+            cleanup_ci_untracked=False,
+            exact_paths_only=True,
+            pin_commit_sha=True,
+        )
+    )
+
+    assert stats["downloaded"] == 1
+    assert stats["failed"] == 0
+    skill_dir = next(output_dir.glob("development/*"))
+    metadata = json.loads((skill_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert metadata["bundled_files"] == []
+    assert "bundled_file_blobs" not in metadata
+
+
+@pytest.mark.parametrize(
+    ("upstream_description", "curated_description"),
+    [
+        ("x" * 501 + " See references/guide.md.", "A curated replacement description."),
+        ("x" * 501, "Read references/guide.md before use."),
+    ],
+    ids=["raw-reference", "normalized-reference"],
+)
+def test_exact_download_checks_dependencies_before_and_after_frontmatter_repair(
+    tmp_path, monkeypatch, upstream_description, curated_description
+):
+    module = load_module()
+    registry_path = tmp_path / "registry.json"
+    failure_report_path = tmp_path / "failures.json"
+    output_dir = tmp_path / "skills"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "skills": [
+                    {
+                        "name": "demo",
+                        "description": curated_description,
+                        "repo": "acme/demo",
+                        "path": "skills/demo/SKILL.md",
+                        "category": "development",
+                        "github_branch": "main",
+                        "license": "MIT",
+                        "distribution": "compatible",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    sha = "a" * 40
+    skill_body = (
+        f"---\nname: demo\ndescription: {upstream_description}\n---\n# Demo\n"
+    ).encode()
+    install_fake_aiohttp(
+        monkeypatch,
+        {
+            **exact_repo_routes(
+                "acme/demo",
+                "main",
+                sha,
+                [git_blob_entry("skills/demo/SKILL.md", skill_body)],
+            ),
+            f"https://raw.githubusercontent.com/acme/demo/{sha}/skills/demo/SKILL.md": (
+                FakeResponse(200, body=skill_body)
+            ),
+        },
+    )
+
+    stats = asyncio.run(
+        module.download_skills(
+            registry_path,
+            output_dir,
+            failure_report_path=failure_report_path,
+            manifest_path=None,
+            cleanup_ci_untracked=False,
+            exact_paths_only=True,
+            pin_commit_sha=True,
+        )
+    )
+
+    assert stats["downloaded"] == 0
+    assert stats["failed"] == 1
+    report = json.loads(failure_report_path.read_text(encoding="utf-8"))
+    assert report["failure_reasons"]["bundled_listing_incomplete"] == 1
+    assert not list(output_dir.rglob("SKILL.md"))
+
+
 @pytest.mark.parametrize(
     ("commit_response", "error"),
     [


### PR DESCRIPTION
## Summary

Treat a complete, empty support-file listing as valid when a skill consists only of `SKILL.md`.

The current complete-archive path returns `bundled_listing_incomplete` whenever `entries == []`, even when collection completed without truncation or a listing error. That blocks valid single-file skills such as the already accepted HOL Guard source in #285.

This change:
- keeps listing failures fail-closed through `BundledListingError`;
- keeps truncated/incomplete support scopes fail-closed through the existing `truncated` check;
- allows the distinct valid case where collection completed and there are simply no eligible support files;
- updates the existing regression test to pin that behavior.

No source-skill validation is relaxed. The source `SKILL.md` is still resolved/validated separately, and pinned-tree collection still requires it to be a regular blob with a valid size/object ID.

Related: #285

AI-assisted tooling was used to prepare this small fix. I maintain the HOL Guard source affected by #285.