### PR TITLE
fix(pages): establish main as canonical Registry site

### DIFF
--- a/.github/workflows/build-index.yml
+++ b/.github/workflows/build-index.yml
@@ -28,8 +28,7 @@ on:
       - '.github/workflows/build-index.yml'
 
 permissions:
-  pages: write
-  id-token: write
+  contents: read
   actions: read
 
 jobs:
@@ -352,25 +351,3 @@ jobs:
 
       - name: Validate static artifact API v1
         run: python scripts/check_artifact_api.py --root . --docs-dir docs
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v6
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: 'docs'
-
-  deploy-pages:
-    if: github.ref == 'refs/heads/main'
-    needs: build-index
-    runs-on: ubuntu-latest
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Claude Skills Registry - Search Skills</title>
     <meta name="description" content="Search and discover Claude Code skills for Claude Code, Codex CLI, and ChatGPT.">
+    <link rel="canonical" href="https://majiayu000.github.io/claude-skill-registry/">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Claude Skills Registry">
+    <meta property="og:description" content="Search and discover Claude Code skills for Claude Code, Codex CLI, and ChatGPT.">
+    <meta property="og:url" content="https://majiayu000.github.io/claude-skill-registry/">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Claude Skills Registry">
+    <meta name="twitter:description" content="Search and discover Claude Code skills for Claude Code, Codex CLI, and ChatGPT.">
     <link rel="stylesheet" href="css/style.css">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🎯</text></svg>">
 </head>

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://majiayu000.github.io/claude-skill-registry/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://majiayu000.github.io/claude-skill-registry/</loc>
+  </url>
+</urlset>

--- a/tests/test_pages_canonical_site.py
+++ b/tests/test_pages_canonical_site.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+from xml.etree import ElementTree
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PUBLIC_SITE = "https://majiayu000.github.io/claude-skill-registry/"
+
+
+def read_repo_file(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_homepage_declares_main_registry_as_its_public_identity():
+    homepage = read_repo_file("docs/index.html")
+
+    assert f'<link rel="canonical" href="{PUBLIC_SITE}">' in homepage
+    assert '<meta property="og:type" content="website">' in homepage
+    assert '<meta property="og:title" content="Claude Skills Registry">' in homepage
+    assert f'<meta property="og:url" content="{PUBLIC_SITE}">' in homepage
+    assert '<meta name="twitter:card" content="summary">' in homepage
+    assert '<meta name="twitter:title" content="Claude Skills Registry">' in homepage
+
+
+def test_robots_and_sitemap_publish_only_the_main_registry_url():
+    robots = read_repo_file("docs/robots.txt")
+    sitemap = ElementTree.fromstring(read_repo_file("docs/sitemap.xml"))
+    namespace = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    locations = [node.text for node in sitemap.findall("sm:url/sm:loc", namespace)]
+
+    assert robots == (
+        "User-agent: *\n"
+        "Allow: /\n"
+        f"Sitemap: {PUBLIC_SITE}sitemap.xml\n"
+    )
+    assert locations == [PUBLIC_SITE]
+
+
+def test_core_build_generates_artifacts_without_deploying_duplicate_pages():
+    workflow_text = read_repo_file(".github/workflows/build-index.yml")
+    workflow = yaml.safe_load(workflow_text)
+    permissions = workflow["permissions"]
+    step_uses = [
+        step.get("uses", "")
+        for job in workflow["jobs"].values()
+        for step in job.get("steps", [])
+    ]
+
+    assert permissions["contents"] == "read"
+    assert permissions["actions"] == "read"
+    assert "pages" not in permissions
+    assert "id-token" not in permissions
+    assert "deploy-pages" not in workflow["jobs"]
+    assert not any("configure-pages" in use for use in step_uses)
+    assert not any("upload-pages-artifact" in use for use in step_uses)
+    assert not any("deploy-pages" in use for use in step_uses)

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -579,7 +579,7 @@ def test_uploaded_security_evidence_excludes_raw_secret_markers(tmp_path):
     assert "/private/" not in evidence_text
 
 
-def test_build_index_runs_generated_size_guard_before_pages_upload():
+def test_build_index_runs_generated_guards_without_deploying_pages():
     workflow_text = read_repo_file(".github/workflows/build-index.yml")
     workflow = yaml.safe_load(workflow_text)
     steps = workflow["jobs"]["build-index"]["steps"]
@@ -591,10 +591,7 @@ def test_build_index_runs_generated_size_guard_before_pages_upload():
     artifact_api_pos = names.index("Validate static artifact API v1")
     rebuild_pos = names.index("Rebuild root registry artifacts")
     search_pos = names.index("Build search index")
-    setup_pos = names.index("Setup Pages")
-    upload_pos = names.index("Upload Pages artifact")
-
-    assert rebuild_pos < search_pos < guard_pos < category_guard_pos < canonical_pos < artifact_api_pos < setup_pos < upload_pos
+    assert rebuild_pos < search_pos < guard_pos < category_guard_pos < canonical_pos < artifact_api_pos
     validator_step = steps[artifact_api_pos]
     assert validator_step["run"] == "python scripts/check_artifact_api.py --root . --docs-dir docs"
     assert "continue-on-error" not in validator_step
@@ -602,6 +599,9 @@ def test_build_index_runs_generated_size_guard_before_pages_upload():
     assert "scripts/check_registry_shard_placement.py" in workflow_text
     assert "--include docs" in workflow_text
     assert "--docs-dir docs" in workflow_text
+    assert "actions/configure-pages" not in workflow_text
+    assert "actions/upload-pages-artifact" not in workflow_text
+    assert "actions/deploy-pages" not in workflow_text
 
 
 def test_build_index_root_rebuild_commands_are_executable(tmp_path):


### PR DESCRIPTION
## Summary

- declare the generated main Registry URL as the canonical public identity
- add Open Graph and Twitter metadata plus robots.txt and sitemap.xml
- retire the duplicate Core GitHub Pages deployment while keeping artifact generation and validation in Core
- protect the contract with focused workflow and metadata tests

## Architecture

Core remains the source of truth for generated docs and indexes. Main remains the merged public artifact and already owns deploy-pages.yml. This PR removes only the duplicate Core deployment path.

## Verification

- RED: 4 focused assertions failed before implementation
- GREEN: 4 focused assertions passed after implementation
- Full suite: 1001 passed, 6 skipped
- git diff --check passed
- workflow YAML and sitemap XML parsed successfully
- patch-guard observed only the six files in this PR with no boundary violations

## External metadata

The Core repository homepage now points to:
https://majiayu000.github.io/claude-skill-registry/

## Dependency and rollout

Issue #267 currently blocks new generated publication because the strict security scan reports failed decisions. The existing main Pages site remains live. After #267 is resolved and this PR merges, verify the next main publish and audit canonical, robots, and sitemap over HTTP.

Closes #296